### PR TITLE
[Spells] Heartbeat resist; [Core] UpdateMask refactoring

### DIFF
--- a/src/game/WorldHandlers/SpellAuras.h
+++ b/src/game/WorldHandlers/SpellAuras.h
@@ -213,6 +213,7 @@ class SpellAuraHolder
         ~SpellAuraHolder();
     private:
         void UpdateAuraApplication();                       // called at charges or stack changes
+        bool HeartbeatResist(uint32 diff);
 
         SpellEntry const* m_spellProto;
 
@@ -237,6 +238,7 @@ class SpellAuraHolder
         bool m_isPassive: 1;
         bool m_isDeathPersist: 1;
         bool m_isRemovedOnShapeLost: 1;
+        bool m_isHeartbeatSubject: 1;
         bool m_deleted: 1;
 
         uint32 m_in_use;                                    // > 0 while in SpellAuraHolder::ApplyModifiers call/SpellAuraHolder::Update/etc


### PR DESCRIPTION
1. https://www.getmangos.eu/developer-area-private-no-public-access-/10313-heartbeat-resist-informational-topic-post74536.html#post74536
Here, each aura drop by the heartbeat resist is logged as "ERROR", being actually not a one.

TODO: formula including victim resist and maybe caster spellpower.
Feel free to experiment with the method SpellAuraHolder::HeartbeatResist(uint32 diff).

2. https://www.getmangos.eu/developer-area-private-no-public-access-/10270-updatemask-class-refactoring.html
The new scheme of building value updates is implemented.
TODO: remove debugging code part before next release.