### PR TITLE
[914] SD2: correct handling OnGossipSelect

### DIFF
--- a/src/game/Object/GameObject.cpp
+++ b/src/game/Object/GameObject.cpp
@@ -204,6 +204,8 @@ bool GameObject::Create(uint32 guidlow, uint32 name_id, Map* map, float x, float
         case GAMEOBJECT_TYPE_CHEST:
             RollIfMineralVein();
             break;
+        default:
+            break;
     }
 
     // Used by Eluna

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -1940,6 +1940,7 @@ void Player::Regenerate(Powers power)
         case POWER_FOCUS:
         case POWER_HAPPINESS:
         case POWER_HEALTH:
+        default:
             break;
     }
 
@@ -3055,9 +3056,9 @@ bool Player::addSpell(uint32 spell_id, bool active, bool learning, bool dependen
 
             if (skillAbility->learnOnGetSkill == ABILITY_LEARNED_ON_GET_RACE_OR_CLASS_SKILL ||
                 // poison special case, not have ABILITY_LEARNED_ON_GET_RACE_OR_CLASS_SKILL
-                    pSkill->id == SKILL_POISONS && skillAbility->max_value == 0 ||
+                    (pSkill->id == SKILL_POISONS && skillAbility->max_value == 0) ||
                 // lockpicking special case, not have ABILITY_LEARNED_ON_GET_RACE_OR_CLASS_SKILL
-                    pSkill->id == SKILL_LOCKPICKING && skillAbility->max_value == 0)
+                    (pSkill->id == SKILL_LOCKPICKING && skillAbility->max_value == 0))
             {
                 switch (GetSkillRangeType(pSkill, skillAbility->racemask != 0))
                 {

--- a/src/game/Object/SpellMgr.cpp
+++ b/src/game/Object/SpellMgr.cpp
@@ -4407,9 +4407,21 @@ DiminishingReturnsType GetDiminishingReturnsGroupType(DiminishingGroup group)
 
 bool SpellArea::IsFitToRequirements(Player const* player, uint32 newZone, uint32 newArea) const
 {
+    if (areaId)
+    {
+        // not in expected zone
+        if (newZone != areaId && newArea != areaId)
+        {
+            return false;
+        }
+    }
+
+    if (!player)    //all following checks require valid player
+        return false;
+
     if (conditionId)
     {
-        if (!player || !sObjectMgr.IsPlayerMeetToCondition(conditionId, player, player->GetMap(), NULL, CONDITION_FROM_SPELL_AREA))
+        if (!sObjectMgr.IsPlayerMeetToCondition(conditionId, player, player->GetMap(), NULL, CONDITION_FROM_SPELL_AREA))
             { return false; }
     }
     else                                                    // This block will be removed
@@ -4417,44 +4429,35 @@ bool SpellArea::IsFitToRequirements(Player const* player, uint32 newZone, uint32
         if (gender != GENDER_NONE)
         {
             // not in expected gender
-            if (!player || gender != player->getGender())
+            if (gender != player->getGender())
                 { return false; }
         }
 
         if (raceMask)
         {
             // not in expected race
-            if (!player || !(raceMask & player->getRaceMask()))
+            if (!(raceMask & player->getRaceMask()))
                 { return false; }
         }
 
         if (questStart)
         {
             // not in expected required quest state
-            if (!player || (!questStartCanActive || !player->IsActiveQuest(questStart)) && !player->GetQuestRewardStatus(questStart))
+            if ((!questStartCanActive || !player->IsActiveQuest(questStart)) || player->GetQuestRewardStatus(questStart))
                 { return false; }
         }
 
         if (questEnd)
         {
             // not in expected forbidden quest state
-            if (!player || player->GetQuestRewardStatus(questEnd))
+            if (player->GetQuestRewardStatus(questEnd))
                 { return false; }
         }
-    }
-
-    if (areaId)
-    {
-        // not in expected zone
-        if (newZone != areaId && newArea != areaId)
-            { return false; }
     }
 
     if (auraSpell)
     {
         // not have expected aura
-        if (!player)
-            { return false; }
         if (auraSpell > 0)
             // have expected aura
             { return player->HasAura(auraSpell); }

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -7269,7 +7269,7 @@ bool Unit::IsSecondChoiceTarget(Unit* pTarget, bool checkThreatArea)
     return
         pTarget->IsImmunedToDamage(GetMeleeDamageSchoolMask()) ||
         pTarget->hasNegativeAuraWithInterruptFlag(AURA_INTERRUPT_FLAG_DAMAGE) ||
-        checkThreatArea && ((Creature*)this)->IsOutOfThreatArea(pTarget);
+        (checkThreatArea && ((Creature*)this)->IsOutOfThreatArea(pTarget));
 }
 
 //======================================================================
@@ -7969,6 +7969,7 @@ uint32 Unit::GetCreatePowers(Powers power) const
         case POWER_FOCUS:       return (GetTypeId() == TYPEID_PLAYER || !((Creature const*)this)->IsPet() || ((Pet const*)this)->getPetType() != HUNTER_PET ? 0 : POWER_FOCUS_DEFAULT);
         case POWER_ENERGY:      return POWER_ENERGY_DEFAULT;
         case POWER_HAPPINESS:   return (GetTypeId() == TYPEID_PLAYER || !((Creature const*)this)->IsPet() || ((Pet const*)this)->getPetType() != HUNTER_PET ? 0 : POWER_HAPPINESS_DEFAULT);
+        default: break; //MAX_POWERS and POWERS_ALL probably should not belong to the enum Powers to do not require the default: case
     }
 
     return 0;

--- a/src/game/WorldHandlers/AddonHandler.cpp
+++ b/src/game/WorldHandlers/AddonHandler.cpp
@@ -88,7 +88,7 @@ bool AddonHandler::BuildAddonPacket(WorldPacket* Source, WorldPacket* Target)
 
     AddOnPacked.resize(AddonRealSize);                      // resize target for zlib action
 
-    if (!uncompress(const_cast<uint8*>(AddOnPacked.contents()), &AddonRealSize, const_cast<uint8*>((*Source).contents() + CurrentPosition), (*Source).size() - CurrentPosition) != Z_OK)
+    if (uncompress(const_cast<uint8*>(AddOnPacked.contents()), &AddonRealSize, const_cast<uint8*>((*Source).contents() + CurrentPosition), (*Source).size() - CurrentPosition) == Z_OK)
     {
         Target->Initialize(SMSG_ADDON_INFO);
 

--- a/src/game/WorldHandlers/Group.cpp
+++ b/src/game/WorldHandlers/Group.cpp
@@ -643,6 +643,8 @@ void Group::FillPremadeLFG(ObjectGuid plrGuid, ClassRoles requiredRole, uint32& 
                 }
                 break;
             }
+            default:
+                break;
         }
         playersProcessed.push_back(plrGuid);
     }
@@ -691,6 +693,8 @@ void Group::FillPremadeLFG(ObjectGuid plrGuid, ClassRoles requiredRole, uint32& 
                     }
                     break;
                 }
+                default:
+                    break;
             }
 
             playersProcessed.push_back(plrGuid);

--- a/src/game/WorldHandlers/ScriptMgr.cpp
+++ b/src/game/WorldHandlers/ScriptMgr.cpp
@@ -2027,7 +2027,7 @@ void ScriptMgr::LoadScriptBinding()
     {
         if (m_scriptBind[i].size()) //ignore missing script types to shorten the log
         {
-            sLog.outString(".. type %u: %u binds", i, m_scriptBind[i].size());
+            sLog.outString(".. type %u: %u binds", i, uint32(m_scriptBind[i].size()));
             count -= m_scriptBind[i].size();
         }
     }

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -6437,14 +6437,14 @@ void Spell::FillRaidOrPartyTargets(UnitList& targetUnitMap, Unit* member, float 
             if (Target && (raid || subgroup == Target->GetSubGroup())
                 && !m_caster->IsHostileTo(Target))
             {
-                if (Target == m_caster && withcaster ||
-                    Target != m_caster && m_caster->IsWithinDistInMap(Target, radius))
+                if ((Target == m_caster && withcaster) ||
+                    (Target != m_caster && m_caster->IsWithinDistInMap(Target, radius)))
                     { targetUnitMap.push_back(Target); }
 
                 if (withPets)
                     if (Pet* pet = Target->GetPet())
-                        if (pet == m_caster && withcaster ||
-                            pet != m_caster && m_caster->IsWithinDistInMap(pet, radius))
+                        if ((pet == m_caster && withcaster) ||
+                            (pet != m_caster && m_caster->IsWithinDistInMap(pet, radius)))
                             { targetUnitMap.push_back(pet); }
             }
         }
@@ -6452,14 +6452,14 @@ void Spell::FillRaidOrPartyTargets(UnitList& targetUnitMap, Unit* member, float 
     else
     {
         Unit* ownerOrSelf = pMember ? pMember : member->GetCharmerOrOwnerOrSelf();
-        if (ownerOrSelf == m_caster && withcaster ||
-            ownerOrSelf != m_caster && m_caster->IsWithinDistInMap(ownerOrSelf, radius))
+        if ((ownerOrSelf == m_caster && withcaster) ||
+            (ownerOrSelf != m_caster && m_caster->IsWithinDistInMap(ownerOrSelf, radius)))
             { targetUnitMap.push_back(ownerOrSelf); }
 
         if (withPets)
             if (Pet* pet = ownerOrSelf->GetPet())
-                if (pet == m_caster && withcaster ||
-                    pet != m_caster && m_caster->IsWithinDistInMap(pet, radius))
+                if ((pet == m_caster && withcaster) ||
+                    (pet != m_caster && m_caster->IsWithinDistInMap(pet, radius)))
                     { targetUnitMap.push_back(pet); }
     }
 }

--- a/src/modules/SD2/scripts/battlegrounds/battleground.cpp
+++ b/src/modules/SD2/scripts/battlegrounds/battleground.cpp
@@ -62,6 +62,7 @@ struct npc_spirit_guide : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* /*pCreature*/) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         pPlayer->CastSpell(pPlayer, SPELL_WAITING_TO_RESURRECT, true);
         return true;
     }
@@ -71,7 +72,6 @@ struct npc_spirit_guide : public CreatureScript
         npc_spirit_guideAI(Creature* pCreature) : ScriptedAI(pCreature)
         {
             pCreature->SetActiveObjectState(true);
-            Reset();
         }
 
         void Reset() override {}

--- a/src/modules/SD2/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/blackrock_mountain/blackrock_depths/blackrock_depths.cpp
@@ -542,6 +542,7 @@ struct npc_kharan_mighthammer : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature)
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pCreature->IsQuestGiver())
         {
             pPlayer->PrepareQuestMenu(pCreature->GetObjectGuid());
@@ -571,6 +572,7 @@ struct npc_kharan_mighthammer : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction)
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         switch (uiAction)
         {
         case GOSSIP_ACTION_INFO_DEF + 1:
@@ -1108,6 +1110,7 @@ struct npc_dughal_stormwing : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pPlayer->GetQuestStatus(QUEST_JAIL_BREAK) == QUEST_STATUS_INCOMPLETE)
         {
             pPlayer->ADD_GOSSIP_ITEM_ID(GOSSIP_ICON_CHAT, GOSSIP_ID_DUGHAL, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
@@ -1119,6 +1122,7 @@ struct npc_dughal_stormwing : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (uiAction == GOSSIP_ACTION_INFO_DEF + 1)
         {
             // Set instance data in order to allow the quest to continue
@@ -1150,6 +1154,7 @@ struct npc_tobias_seecher : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pPlayer->GetQuestStatus(QUEST_JAIL_BREAK) == QUEST_STATUS_INCOMPLETE)
         {
             pPlayer->ADD_GOSSIP_ITEM_ID(GOSSIP_ICON_CHAT, GOSSIP_ID_TOBIAS, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
@@ -1162,6 +1167,7 @@ struct npc_tobias_seecher : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (uiAction == GOSSIP_ACTION_INFO_DEF + 1)
         {
             // Set instance data in order to allow the quest to continue
@@ -1200,6 +1206,7 @@ struct boss_doomrel : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (ScriptedInstance* pInstance = (ScriptedInstance*)pCreature->GetInstanceData())
         {
             if (pInstance->GetData(TYPE_TOMB_OF_SEVEN) == NOT_STARTED || pInstance->GetData(TYPE_TOMB_OF_SEVEN) == FAIL)
@@ -1214,6 +1221,7 @@ struct boss_doomrel : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         switch (uiAction)
         {
         case GOSSIP_ACTION_INFO_DEF + 1:

--- a/src/modules/SD2/scripts/eastern_kingdoms/blackrock_mountain/blackwing_lair/boss_vaelastrasz.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/blackrock_mountain/blackwing_lair/boss_vaelastrasz.cpp
@@ -378,6 +378,7 @@ struct boss_vaelastrasz : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         switch (uiAction)
         {
         case GOSSIP_ACTION_INFO_DEF + 1:
@@ -398,6 +399,7 @@ struct boss_vaelastrasz : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pCreature->IsQuestGiver())
         {
             pPlayer->PrepareQuestMenu(pCreature->GetObjectGuid());

--- a/src/modules/SD2/scripts/eastern_kingdoms/blackrock_mountain/blackwing_lair/boss_victor_nefarius.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/blackrock_mountain/blackwing_lair/boss_victor_nefarius.cpp
@@ -412,6 +412,7 @@ struct boss_victor_nefarius : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pCreature->GetMapId() != MAP_ID_BWL)
         {
             return true;
@@ -424,6 +425,7 @@ struct boss_victor_nefarius : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (pCreature->GetMapId() != MAP_ID_BWL)
         {
             return true;

--- a/src/modules/SD2/scripts/eastern_kingdoms/blackrock_mountain/molten_core/boss_majordomo_executus.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/blackrock_mountain/molten_core/boss_majordomo_executus.cpp
@@ -486,6 +486,7 @@ struct boss_majordomo : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (InstanceData* pInstance = pCreature->GetInstanceData())
         {
             if (pInstance->GetData(TYPE_RAGNAROS) == NOT_STARTED || pInstance->GetData(TYPE_RAGNAROS) == FAIL)
@@ -499,6 +500,7 @@ struct boss_majordomo : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*sender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         switch (uiAction)
         {
         case GOSSIP_ACTION_INFO_DEF + 1:

--- a/src/modules/SD2/scripts/eastern_kingdoms/blasted_lands.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/blasted_lands.cpp
@@ -58,6 +58,7 @@ struct npc_fallen_hero_of_horde : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pCreature->IsQuestGiver())
         {
             pPlayer->PrepareQuestMenu(pCreature->GetObjectGuid());
@@ -85,6 +86,7 @@ struct npc_fallen_hero_of_horde : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         switch (uiAction)
         {
         case GOSSIP_ACTION_INFO_DEF + 1:

--- a/src/modules/SD2/scripts/eastern_kingdoms/burning_steppes.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/burning_steppes.cpp
@@ -91,6 +91,7 @@ struct npc_ragged_john : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override   //TODO localisation setup
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pCreature->IsQuestGiver())
         {
             pPlayer->PrepareQuestMenu(pCreature->GetObjectGuid());
@@ -107,6 +108,7 @@ struct npc_ragged_john : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         switch (uiAction)
         {
         case GOSSIP_ACTION_INFO_DEF:

--- a/src/modules/SD2/scripts/eastern_kingdoms/gnomeregan/gnomeregan.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/gnomeregan/gnomeregan.cpp
@@ -666,6 +666,7 @@ struct npc_blastmaster_emi_shortfuse : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (InstanceData* pInstance = pCreature->GetInstanceData())
         {
             if (pInstance->GetData(TYPE_GRUBBIS) == NOT_STARTED || pInstance->GetData(TYPE_GRUBBIS) == FAIL)
@@ -679,6 +680,7 @@ struct npc_blastmaster_emi_shortfuse : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (uiAction == GOSSIP_ACTION_INFO_DEF + 1)
         {
             if (InstanceData* pInstance = pCreature->GetInstanceData())

--- a/src/modules/SD2/scripts/eastern_kingdoms/loch_modan.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/loch_modan.cpp
@@ -52,6 +52,7 @@ struct npc_mountaineer_pebblebitty : public CreatureScript  //TODO localisation
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pCreature->IsQuestGiver())
         {
             pPlayer->PrepareQuestMenu(pCreature->GetObjectGuid());
@@ -69,6 +70,7 @@ struct npc_mountaineer_pebblebitty : public CreatureScript  //TODO localisation
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         switch (uiAction)
         {
         case GOSSIP_ACTION_INFO_DEF + 1:

--- a/src/modules/SD2/scripts/eastern_kingdoms/shadowfang_keep/shadowfang_keep.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/shadowfang_keep/shadowfang_keep.cpp
@@ -183,6 +183,7 @@ struct npc_shadowfang_prisoner : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         ScriptedInstance* pInstance = (ScriptedInstance*)pCreature->GetInstanceData();
 
         if (pInstance && pInstance->GetData(TYPE_FREE_NPC) != DONE && pInstance->GetData(TYPE_RETHILGORE) == DONE)
@@ -196,6 +197,7 @@ struct npc_shadowfang_prisoner : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (uiAction == GOSSIP_ACTION_INFO_DEF + 1)
         {
             pPlayer->CLOSE_GOSSIP_MENU();

--- a/src/modules/SD2/scripts/eastern_kingdoms/stormwind_city.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/stormwind_city.cpp
@@ -228,6 +228,7 @@ struct npc_lady_katrana_prestor : public CreatureScript //TODO localisation
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pCreature->IsQuestGiver())
         {
             pPlayer->PrepareQuestMenu(pCreature->GetObjectGuid());
@@ -245,6 +246,7 @@ struct npc_lady_katrana_prestor : public CreatureScript //TODO localisation
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         switch (uiAction)
         {
         case GOSSIP_ACTION_INFO_DEF:
@@ -451,6 +453,7 @@ struct npc_squire_rowe : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         // Allow gossip if quest 6402 is completed but not yet rewarded or 6402 is rewarded but 6403 isn't yet completed
         if ((pPlayer->GetQuestStatus(QUEST_STORMWIND_RENDEZVOUS) == QUEST_STATUS_COMPLETE && !pPlayer->GetQuestRewardStatus(QUEST_STORMWIND_RENDEZVOUS)) ||
             (pPlayer->GetQuestRewardStatus(QUEST_STORMWIND_RENDEZVOUS) && pPlayer->GetQuestStatus(QUEST_THE_GREAT_MASQUERADE) != QUEST_STATUS_COMPLETE))
@@ -484,6 +487,7 @@ struct npc_squire_rowe : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (uiAction == GOSSIP_ACTION_INFO_DEF + 1)
         {
             if (npc_squire_roweAI* pRoweAI = dynamic_cast<npc_squire_roweAI*>(pCreature->AI()))
@@ -1135,6 +1139,7 @@ struct npc_reginald_windsor : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         bool bIsEventReady = false;
 
         if (npc_reginald_windsorAI* pReginaldAI = dynamic_cast<npc_reginald_windsorAI*>(pCreature->AI()))
@@ -1163,6 +1168,7 @@ struct npc_reginald_windsor : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (uiAction == GOSSIP_ACTION_INFO_DEF + 1)
         {
             if (npc_reginald_windsorAI* pReginaldAI = dynamic_cast<npc_reginald_windsorAI*>(pCreature->AI()))

--- a/src/modules/SD2/scripts/kalimdor/azshara.cpp
+++ b/src/modules/SD2/scripts/kalimdor/azshara.cpp
@@ -229,6 +229,7 @@ struct npc_loramus_thalipedes : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pCreature->IsQuestGiver())
         {
             pPlayer->PrepareQuestMenu(pCreature->GetObjectGuid());
@@ -251,6 +252,7 @@ struct npc_loramus_thalipedes : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override    //TODO localisation
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         switch (uiAction)
         {
         case GOSSIP_ACTION_INFO_DEF + 1:

--- a/src/modules/SD2/scripts/kalimdor/darkshore.cpp
+++ b/src/modules/SD2/scripts/kalimdor/darkshore.cpp
@@ -417,6 +417,7 @@ struct npc_threshwackonator : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pPlayer->GetQuestStatus(QUEST_GYROMAST_REV) == QUEST_STATUS_INCOMPLETE)
         {
             pPlayer->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, GOSSIP_ITEM_INSERT_KEY, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF + 1);
@@ -428,6 +429,7 @@ struct npc_threshwackonator : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (uiAction == GOSSIP_ACTION_INFO_DEF + 1)
         {
             pPlayer->CLOSE_GOSSIP_MENU();

--- a/src/modules/SD2/scripts/kalimdor/desolace.cpp
+++ b/src/modules/SD2/scripts/kalimdor/desolace.cpp
@@ -152,6 +152,7 @@ struct npc_aged_dying_ancient_kodo : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pPlayer->HasAura(SPELL_KODO_KOMBO_PLAYER_BUFF) && pCreature->HasAura(SPELL_KODO_KOMBO_DESPAWN_BUFF))
         {
             // the expected quest objective

--- a/src/modules/SD2/scripts/kalimdor/felwood.cpp
+++ b/src/modules/SD2/scripts/kalimdor/felwood.cpp
@@ -170,6 +170,7 @@ struct npc_corrupt_saber : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pPlayer->GetQuestStatus(QUEST_CORRUPT_SABER) == QUEST_STATUS_INCOMPLETE)
         {
             if (GetClosestCreatureWithEntry(pCreature, NPC_WINNA, INTERACTION_DISTANCE))
@@ -184,6 +185,7 @@ struct npc_corrupt_saber : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (uiAction == GOSSIP_ACTION_INFO_DEF + 1)
         {
             pPlayer->CLOSE_GOSSIP_MENU();

--- a/src/modules/SD2/scripts/kalimdor/orgrimmar.cpp
+++ b/src/modules/SD2/scripts/kalimdor/orgrimmar.cpp
@@ -167,6 +167,7 @@ struct npc_thrall_warchief : public CreatureScript  //TODO localise
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pCreature->IsQuestGiver())
         {
             pPlayer->PrepareQuestMenu(pCreature->GetObjectGuid());
@@ -183,6 +184,7 @@ struct npc_thrall_warchief : public CreatureScript  //TODO localise
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         switch (uiAction)
         {
         case GOSSIP_ACTION_INFO_DEF + 1:

--- a/src/modules/SD2/scripts/kalimdor/ruins_of_ahnqiraj/boss_rajaxx.cpp
+++ b/src/modules/SD2/scripts/kalimdor/ruins_of_ahnqiraj/boss_rajaxx.cpp
@@ -302,6 +302,7 @@ struct npc_general_andorov : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (ScriptedInstance* pInstance = (ScriptedInstance*)pCreature->GetInstanceData())
         {
             if (pInstance->GetData(TYPE_RAJAXX) == IN_PROGRESS)
@@ -323,6 +324,7 @@ struct npc_general_andorov : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (uiAction == GOSSIP_ACTION_INFO_DEF + 1)
         {
             if (npc_general_andorovAI* pAndorovAI = dynamic_cast<npc_general_andorovAI*>(pCreature->AI()))

--- a/src/modules/SD2/scripts/kalimdor/tanaris.cpp
+++ b/src/modules/SD2/scripts/kalimdor/tanaris.cpp
@@ -299,6 +299,7 @@ struct npc_stone_watcher_of_norgannon : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pCreature->IsQuestGiver())
         {
             pPlayer->PrepareQuestMenu(pCreature->GetObjectGuid());
@@ -316,6 +317,7 @@ struct npc_stone_watcher_of_norgannon : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         switch (uiAction)
         {
         case GOSSIP_ACTION_INFO_DEF:

--- a/src/modules/SD2/scripts/kalimdor/the_barrens.cpp
+++ b/src/modules/SD2/scripts/kalimdor/the_barrens.cpp
@@ -63,6 +63,7 @@ struct npc_beaten_corpse : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pPlayer->GetQuestStatus(QUEST_LOST_IN_BATTLE) == QUEST_STATUS_INCOMPLETE ||
             pPlayer->GetQuestStatus(QUEST_LOST_IN_BATTLE) == QUEST_STATUS_COMPLETE)
         {
@@ -75,6 +76,7 @@ struct npc_beaten_corpse : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (uiAction == GOSSIP_ACTION_INFO_DEF + 1)
         {
             pPlayer->SEND_GOSSIP_MENU(3558, pCreature->GetObjectGuid());
@@ -1152,6 +1154,7 @@ struct npc_regthar_deathgate : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pCreature->IsQuestGiver())
             pPlayer->PrepareQuestMenu(pCreature->GetObjectGuid());
 
@@ -1168,6 +1171,7 @@ struct npc_regthar_deathgate : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (uiAction == GOSSIP_ACTION_INFO_DEF + 1)
         {
             DoScriptText(SAY_START_REGTHAR, pCreature, pPlayer);

--- a/src/modules/SD2/scripts/kalimdor/thousand_needles.cpp
+++ b/src/modules/SD2/scripts/kalimdor/thousand_needles.cpp
@@ -400,6 +400,7 @@ struct npc_plucky_johnson : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pPlayer->GetQuestStatus(QUEST_SCOOP) == QUEST_STATUS_INCOMPLETE)
         {
             pPlayer->ADD_GOSSIP_ITEM(GOSSIP_ICON_CHAT, GOSSIP_ITEM_QUEST, GOSSIP_SENDER_MAIN, GOSSIP_ACTION_INFO_DEF);
@@ -411,6 +412,7 @@ struct npc_plucky_johnson : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         if (uiAction == GOSSIP_ACTION_INFO_DEF)
         {
             pPlayer->SEND_GOSSIP_MENU(738, pCreature->GetObjectGuid());

--- a/src/modules/SD2/scripts/kalimdor/wailing_caverns/wailing_caverns.cpp
+++ b/src/modules/SD2/scripts/kalimdor/wailing_caverns/wailing_caverns.cpp
@@ -500,6 +500,7 @@ struct npc_disciple_of_naralex : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         ScriptedInstance* m_pInstance = (ScriptedInstance*)pCreature->GetInstanceData();
 
         if (pCreature->IsQuestGiver())
@@ -525,6 +526,7 @@ struct npc_disciple_of_naralex : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         ScriptedInstance* m_pInstance = (ScriptedInstance*)pCreature->GetInstanceData();
 
         if (!m_pInstance)

--- a/src/modules/SD2/scripts/world/go_scripts.cpp
+++ b/src/modules/SD2/scripts/world/go_scripts.cpp
@@ -128,6 +128,7 @@ struct go_table_theka : public GameObjectScript
 
     bool OnGossipHello(Player* pPlayer, GameObject* pGo) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         if (pPlayer->GetQuestStatus(QUEST_SPIDER_GOD) == QUEST_STATUS_INCOMPLETE)
             pPlayer->AreaExploredOrEventHappens(QUEST_SPIDER_GOD);
 

--- a/src/modules/SD2/scripts/world/npcs_special.cpp
+++ b/src/modules/SD2/scripts/world/npcs_special.cpp
@@ -919,6 +919,7 @@ struct npc_innkeeper : public CreatureScript
 
     bool OnGossipHello(Player* pPlayer, Creature* pCreature) override
     {
+        //pPlayer->PlayerTalkClass->ClearMenus();
         pPlayer->PrepareGossipMenu(pCreature, pPlayer->GetDefaultGossipMenuForSource(pCreature));
 
         if (IsHolidayActive(HOLIDAY_HALLOWS_END) && !pPlayer->HasAura(SPELL_TRICK_OR_TREATED, EFFECT_INDEX_0))
@@ -941,6 +942,7 @@ struct npc_innkeeper : public CreatureScript
 
     bool OnGossipSelect(Player* pPlayer, Creature* pCreature, uint32 /*uiSender*/, uint32 uiAction) override
     {
+        pPlayer->PlayerTalkClass->ClearMenus();
         switch (uiAction)
         {
         case GOSSIP_ACTION_INFO_DEF + 1:

--- a/src/modules/SD2/system/ScriptDevMgr.cpp
+++ b/src/modules/SD2/system/ScriptDevMgr.cpp
@@ -290,7 +290,7 @@ bool SD2::GossipHello(Player* pPlayer, Creature* pCreature)
         return false;
     }
 
-    pPlayer->PlayerTalkClass->ClearMenus();
+    //pPlayer->PlayerTalkClass->ClearMenus();
 
     return pTempScript->ToCreatureScript()->OnGossipHello(pPlayer, pCreature);
 }
@@ -304,7 +304,7 @@ bool SD2::GOGossipHello(Player* pPlayer, GameObject* pGo)
         return false;
     }
 
-    pPlayer->PlayerTalkClass->ClearMenus();
+    //pPlayer->PlayerTalkClass->ClearMenus();
 
     return pTempScript->ToGameObjectScript()->OnGossipHello(pPlayer, pGo);
 }
@@ -320,8 +320,6 @@ bool SD2::GossipSelect(Player* pPlayer, Creature* pCreature, uint32 uiSender, ui
         return false;
     }
 
-    pPlayer->PlayerTalkClass->ClearMenus();
-
     return pTempScript->ToCreatureScript()->OnGossipSelect(pPlayer, pCreature, uiSender, uiAction);
 }
 
@@ -335,8 +333,6 @@ bool SD2::GOGossipSelect(Player* pPlayer, GameObject* pGo, uint32 uiSender, uint
     {
         return false;
     }
-
-    pPlayer->PlayerTalkClass->ClearMenus();
 
     return pTempScript->ToGameObjectScript()->OnGossipSelect(pPlayer, pGo, uiSender, uiAction);
 }
@@ -352,7 +348,7 @@ bool SD2::GossipSelectWithCode(Player* pPlayer, Creature* pCreature, uint32 uiSe
         return false;
     }
 
-    pPlayer->PlayerTalkClass->ClearMenus();
+    //pPlayer->PlayerTalkClass->ClearMenus();
 
     return pTempScript->ToCreatureScript()->OnGossipSelectWithCode(pPlayer, pCreature, uiSender, uiAction, sCode);
 }
@@ -368,7 +364,7 @@ bool SD2::GOGossipSelectWithCode(Player* pPlayer, GameObject* pGo, uint32 uiSend
         return false;
     }
 
-    pPlayer->PlayerTalkClass->ClearMenus();
+    //pPlayer->PlayerTalkClass->ClearMenus();
 
     return pTempScript->ToGameObjectScript()->OnGossipSelectWithCode(pPlayer, pGo, uiSender, uiAction, sCode);
 }
@@ -382,7 +378,7 @@ bool SD2::QuestAccept(Player* pPlayer, Creature* pCreature, const Quest* pQuest)
         return false;
     }
 
-    pPlayer->PlayerTalkClass->ClearMenus();
+    //pPlayer->PlayerTalkClass->ClearMenus();
 
     return pTempScript->ToCreatureScript()->OnQuestAccept(pPlayer, pCreature, pQuest);
 }
@@ -396,7 +392,7 @@ bool SD2::QuestRewarded(Player* pPlayer, Creature* pCreature, Quest const* pQues
         return false;
     }
 
-    pPlayer->PlayerTalkClass->ClearMenus();
+    //pPlayer->PlayerTalkClass->ClearMenus();
 
     return pTempScript->ToCreatureScript()->OnQuestRewarded(pPlayer, pCreature, pQuest);
 }
@@ -410,7 +406,7 @@ uint32 SD2::GetNPCDialogStatus(Player* pPlayer, Creature* pCreature)
         return DIALOG_STATUS_UNDEFINED;
     }
 
-    pPlayer->PlayerTalkClass->ClearMenus();
+    //pPlayer->PlayerTalkClass->ClearMenus();
 
     return pTempScript->ToCreatureScript()->OnDialogEnd(pPlayer, pCreature);
 }
@@ -424,7 +420,7 @@ uint32 SD2::GetGODialogStatus(Player* pPlayer, GameObject* pGo)
         return DIALOG_STATUS_UNDEFINED;
     }
 
-    pPlayer->PlayerTalkClass->ClearMenus();
+    //pPlayer->PlayerTalkClass->ClearMenus();
 
     return pTempScript->ToGameObjectScript()->OnDialogEnd(pPlayer, pGo);
 }
@@ -438,7 +434,7 @@ bool SD2::ItemQuestAccept(Player* pPlayer, Item* pItem, Quest const* pQuest)
         return false;
     }
 
-    pPlayer->PlayerTalkClass->ClearMenus();
+    //pPlayer->PlayerTalkClass->ClearMenus();
 
     return pTempScript->ToItemScript()->OnQuestAccept(pPlayer, pItem, pQuest);
 }
@@ -464,7 +460,7 @@ bool SD2::GOQuestAccept(Player* pPlayer, GameObject* pGo, const Quest* pQuest)
         return false;
     }
 
-    pPlayer->PlayerTalkClass->ClearMenus();
+    //pPlayer->PlayerTalkClass->ClearMenus();
 
     return pTempScript->ToGameObjectScript()->OnQuestAccept(pPlayer, pGo, pQuest);
 }
@@ -478,7 +474,7 @@ bool SD2::GOQuestRewarded(Player* pPlayer, GameObject* pGo, Quest const* pQuest)
         return false;
     }
 
-    pPlayer->PlayerTalkClass->ClearMenus();
+    //pPlayer->PlayerTalkClass->ClearMenus();
 
     return pTempScript->ToGameObjectScript()->OnQuestRewarded(pPlayer, pGo, pQuest);
 }


### PR DESCRIPTION
1. Fixing the error intoduced by SD2 refactoring.
2. Get rid of few gcc build warnings (evident cases).