### PR TITLE
[SD2][915] Call Reset() after AI ctor; AT 522 script fix

### DIFF
--- a/src/game/Object/CreatureAI.h
+++ b/src/game/Object/CreatureAI.h
@@ -342,6 +342,9 @@ class CreatureAI
          */
         virtual void ReceiveAIEvent(AIEventType /*eventType*/, Creature* /*pSender*/, Unit* /*pInvoker*/, uint32 /*miscValue*/) {}
 
+        // Reset should be defined here, as it is called from out the AI ctor now
+        virtual void Reset() {}
+
     protected:
         void HandleMovementOnAttackStart(Unit* victim);
 

--- a/src/modules/SD2/include/sc_creature.h
+++ b/src/modules/SD2/include/sc_creature.h
@@ -176,7 +176,7 @@ struct ScriptedAI : public CreatureAI
          * Called by default on creature evade and respawn
          * In most scripts also called in the constructor of the AI
          */
-        virtual void Reset() = 0;
+        //virtual void Reset() = 0; // is defined in CreatureAI
 
         /// Called at creature EnterCombat with an enemy
         /**

--- a/src/modules/SD2/scripts/kalimdor/the_barrens.cpp
+++ b/src/modules/SD2/scripts/kalimdor/the_barrens.cpp
@@ -546,16 +546,12 @@ struct at_twiggy_flathead : public AreaTriggerScript
                 return true;
             }
 
-            if (CreatureAI* pTwiggyAI = pCreature->AI())    //TODO how the data transfer unit->object (GO, AT) may be implemented? CreatureAI::GetData()? or &miscValue in SendAIEvent?
+            if (CreatureAI* pTwiggyAI = pCreature->AI())
             {
-                pTwiggyAI->SendAIEvent(AI_EVENT_CUSTOM_A, pPlayer, pCreature);  //TODO check the state here and return true/false (other possible AT uses are blocked now!)
-                //if (pTwiggyAI->CanStartEvent(pPlayer))
-                //{
-                //    return false;    // ok to let mangos process further
-                //}
+                pTwiggyAI->SendAIEvent(AI_EVENT_CUSTOM_A, pPlayer, pCreature);
             }
 
-            return true;
+            return false;   //this will let the trigger pop up several times until the quest is complete, but who cares
         }
         return true;
     }

--- a/src/modules/SD2/system/ScriptDevMgr.cpp
+++ b/src/modules/SD2/system/ScriptDevMgr.cpp
@@ -514,7 +514,11 @@ CreatureAI* SD2::GetCreatureAI(Creature* pCreature)
         return NULL;
     }
 
-    return pTempScript->ToCreatureScript()->GetAI(pCreature);
+    CreatureAI* ai = pTempScript->ToCreatureScript()->GetAI(pCreature);
+    if (ai)
+        ai->Reset();
+
+    return ai;
 }
 
 bool SD2::ItemUse(Player* pPlayer, Item* pItem, SpellCastTargets const& targets)


### PR DESCRIPTION
1. Fixed the substantial mechanic: CreatureAI::Reset() should be called after AI init (i.e. ctor) from outside the ctor.
2. Minor areatrigger script fix for quest 1719 "The Affray" (class warrior).