### PR TITLE
[Warden] DB log: correct check ID

### DIFF
--- a/src/game/Warden/Warden.cpp
+++ b/src/game/Warden/Warden.cpp
@@ -299,7 +299,7 @@ void Warden::LogPositiveToDB(WardenCheck* check)
 
     SqlStatement stmt = LoginDatabase.CreateStatement(insWardenPositive, "INSERT INTO warden_log (`check`, `action`, `account`, `guid`, `map`, `position_x`, `position_y`, `position_z`) VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
 
-    stmt.addUInt8(check->CheckId);
+    stmt.addUInt16(check->CheckId);
     stmt.addInt8(check->Action);
     stmt.addUInt32(_session->GetAccountId());
     if (Player* pl = _session->GetPlayer())

--- a/src/game/Warden/WardenWin.cpp
+++ b/src/game/Warden/WardenWin.cpp
@@ -103,10 +103,10 @@ void WardenWin::InitializeModule()
     Request.Unk2 = 0;
     Request.Type = 1;
     Request.String_library1 = 0;
-    Request.Function1[0] = 0x00024F80;                      // 0x00400000 + 0x00024F80 SFileOpenFile
-    Request.Function1[1] = 0x000218C0;                      // 0x00400000 + 0x000218C0 SFileGetFileSize
-    Request.Function1[2] = 0x00022530;                      // 0x00400000 + 0x00022530 SFileReadFile
-    Request.Function1[3] = 0x00022910;                      // 0x00400000 + 0x00022910 SFileCloseFile
+    Request.Function1[0] = 0x002485F0;                      // 0x00400000 + 0x002485F0 SFileOpenFile
+    Request.Function1[1] = 0x002487F0;                      // 0x00400000 + 0x002487F0 SFileGetFileSize
+    Request.Function1[2] = 0x00248460;                      // 0x00400000 + 0x00248460 SFileReadFile
+    Request.Function1[3] = 0x00248730;                      // 0x00400000 + 0x00248730 SFileCloseFile
 
     Request.Command2 = WARDEN_SMSG_MODULE_INITIALIZE;
     Request.Size2 = 8;

--- a/src/shared/revision.h
+++ b/src/shared/revision.h
@@ -27,5 +27,5 @@
 #define REVISION_NR "21000"
 #define REVISION_DB_CHARACTERS "required_21000_01_warden_action"
 #define REVISION_DB_MANGOS "required_21000_08_warden_checks"
-#define REVISION_DB_REALMD "required_20150412_auth_realmlist"
+#define REVISION_DB_REALMD "required_20150420_warden_db_log"
 #endif // __REVISION_H__


### PR DESCRIPTION
1. Old version wrote (checkID mod 256) due to incorrect column type TINYINT.
See also RealmDB modification.
2. Guessed offsets for 5875 client (in comparison with 12340). Note that I did not succeed in finding two other equivalent functions, which may mean missing such functionality in Zero warden. Note also that all these functions are never used (due to unknown warden opcodes).