### PR TITLE
Cleanup: no more used after SD2 reactoring WorldTemplate stuff

### DIFF
--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -2974,7 +2974,6 @@ CreatureDataAddon const* ObjectMgr::GetCreatureAddon(uint32 lowguid) { return sC
 CreatureDataAddon const* ObjectMgr::GetCreatureTemplateAddon(uint32 entry) { return sCreatureInfoAddonStorage.LookupEntry<CreatureDataAddon>(entry); }
 ItemPrototype const* ObjectMgr::GetItemPrototype(uint32 id) { return sItemStorage.LookupEntry<ItemPrototype>(id); }
 InstanceTemplate const* ObjectMgr::GetInstanceTemplate(uint32 map) { return sInstanceTemplate.LookupEntry<InstanceTemplate>(map); }
-WorldTemplate const* ObjectMgr::GetWorldTemplate(uint32 map) { return sWorldTemplate.LookupEntry<WorldTemplate>(map); }
 
 /* ********************************************************************************************* */
 /* *                                Loading Functions                                            */
@@ -4302,37 +4301,6 @@ struct SQLWorldLoader : public SQLStorageLoaderBase<SQLWorldLoader, SQLStorage>
         dst = D(sScriptMgr.GetScriptId(src));
     }
 };
-
-void ObjectMgr::LoadWorldTemplate()
-{
-    SQLWorldLoader loader;
-    loader.Load(sWorldTemplate, false);
-
-    for (uint32 i = 0; i < sWorldTemplate.GetMaxEntry(); ++i)
-    {
-        WorldTemplate const* temp = GetWorldTemplate(i);
-        if (!temp)
-            { continue; }
-
-        MapEntry const* mapEntry = sMapStore.LookupEntry(temp->map);
-        if (!mapEntry)
-        {
-            sLog.outErrorDb("ObjectMgr::LoadWorldTemplate: bad mapid %d for template!", temp->map);
-            sWorldTemplate.EraseEntry(i);
-            continue;
-        }
-
-        if (mapEntry->Instanceable())
-        {
-            sLog.outErrorDb("ObjectMgr::LoadWorldTemplate: instanceable mapid %d for template!", temp->map);
-            sWorldTemplate.EraseEntry(i);
-            continue;
-        }
-    }
-
-    sLog.outString(">> Loaded %u World Template definitions", sWorldTemplate.GetRecordCount());
-    sLog.outString();
-}
 
 void ObjectMgr::LoadConditions()
 {

--- a/src/game/Object/ObjectMgr.h
+++ b/src/game/Object/ObjectMgr.h
@@ -628,7 +628,6 @@ class ObjectMgr
         static CreatureDataAddon const* GetCreatureTemplateAddon(uint32 entry);     ///< Wrapper for sCreatureInfoAddonStorage.LookupEntry
         static ItemPrototype const* GetItemPrototype(uint32 id);                    ///< Wrapper for sItemStorage.LookupEntry
         static InstanceTemplate const* GetInstanceTemplate(uint32 map);             ///< Wrapper for sInstanceTemplate.LookupEntry
-        static WorldTemplate const* GetWorldTemplate(uint32 map);                   ///< Wrapper for sWorldTemplate.LookupEntry
 
         void LoadGroups();
         void LoadQuests();
@@ -669,7 +668,6 @@ class ObjectMgr
         void LoadGossipMenuItemsLocales();
         void LoadPointOfInterestLocales();
         void LoadInstanceTemplate();
-        void LoadWorldTemplate();
         void LoadConditions();
 
         void LoadGossipText();

--- a/src/game/Server/SQLStorages.cpp
+++ b/src/game/Server/SQLStorages.cpp
@@ -39,8 +39,6 @@ const char ItemPrototypedstfmt[] = "iiisiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii
 const char PageTextfmt[] = "isi";
 const char InstanceTemplatesrcfmt[] = "iiiiiiiff";
 const char InstanceTemplatedstfmt[] = "iiiiiiiff";
-const char WorldTemplatesrcfmt[] = "is";
-const char WorldTemplatedstfmt[] = "ii";
 const char ConditionsSrcFmt[] = "iiii";
 const char ConditionsDstFmt[] = "iiii";
 const char CreatureTemplateSpellsFmt[] = "iiiii";
@@ -56,7 +54,6 @@ SQLStorage sEquipmentStorageRaw(EquipmentInfoRawfmt, "entry", "creature_equip_te
 SQLStorage sItemStorage(ItemPrototypesrcfmt, ItemPrototypedstfmt, "entry", "item_template");
 SQLStorage sPageTextStore(PageTextfmt, "entry", "page_text");
 SQLStorage sInstanceTemplate(InstanceTemplatesrcfmt, InstanceTemplatedstfmt, "map", "instance_template");
-SQLStorage sWorldTemplate(WorldTemplatesrcfmt, WorldTemplatedstfmt, "map", "world_template");
 SQLStorage sConditionStorage(ConditionsSrcFmt, ConditionsDstFmt, "condition_entry", "conditions");
 
 SQLHashStorage sGOStorage(GameObjectInfosrcfmt, GameObjectInfodstfmt, "entry", "gameobject_template");

--- a/src/game/Server/SQLStorages.h
+++ b/src/game/Server/SQLStorages.h
@@ -38,7 +38,6 @@ extern SQLStorage sEquipmentStorageRaw;
 extern SQLStorage sPageTextStore;
 extern SQLStorage sItemStorage;
 extern SQLStorage sInstanceTemplate;
-extern SQLStorage sWorldTemplate;
 extern SQLStorage sConditionStorage;
 
 extern SQLHashStorage sGOStorage;

--- a/src/game/WorldHandlers/Map.h
+++ b/src/game/WorldHandlers/Map.h
@@ -86,12 +86,6 @@ struct InstanceTemplate
     uint32 script_id;
 };
 
-struct WorldTemplate
-{
-    uint32 map;                                             // non-instance map
-    uint32 script_id;
-};
-
 #if defined( __GNUC__ )
 #pragma pack()
 #else


### PR DESCRIPTION
WorldTemplate ScriptID is now get as for Map object with general enough (virtual) method.