### PR TITLE
[SD2]Fix typing error for High Priestess Jeklik (tnx: Cab)

### DIFF
--- a/src/modules/SD2/scripts/eastern_kingdoms/zulgurub/boss_jeklik.cpp
+++ b/src/modules/SD2/scripts/eastern_kingdoms/zulgurub/boss_jeklik.cpp
@@ -363,7 +363,7 @@ struct boss_jeklik : public CreatureScript
         }
     };
 
-    CreatureAI* GetAI_boss_jeklik(Creature* pCreature)
+    CreatureAI* GetAI(Creature* pCreature) override
     {
         return new boss_jeklikAI(pCreature);
     }


### PR DESCRIPTION
The boss AI was disabled due to missing change.