### PR TITLE
More minor fixes for worldserver startup/shutdown on *nix

### DIFF
--- a/src/mangosd/CMakeLists.txt
+++ b/src/mangosd/CMakeLists.txt
@@ -140,9 +140,9 @@ set(EXECUTABLE_LINK_FLAGS "")
 
 if(UNIX)
     if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
-        set(EXECUTABLE_LINK_FLAGS "-Wl,--no-as-needed -pthread -lrt ${EXECUTABLE_LINK_FLAGS} -rdynamic")
+        set(EXECUTABLE_LINK_FLAGS "-Wl,--no-as-needed -pthread -lrt ${EXECUTABLE_LINK_FLAGS}")
     elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
-        set(EXECUTABLE_LINK_FLAGS "-Wl,--no-as-needed -ldl -pthread -lrt ${EXECUTABLE_LINK_FLAGS} -rdynamic")
+        set(EXECUTABLE_LINK_FLAGS "-Wl,--no-as-needed -ldl -pthread -lrt ${EXECUTABLE_LINK_FLAGS}")
     endif()
 endif()
 

--- a/src/mangosd/Comm/CliRunnable.cpp
+++ b/src/mangosd/Comm/CliRunnable.cpp
@@ -576,7 +576,7 @@ bool ChatHandler::HandleServerLogLevelCommand(char* args)
 
 /// @}
 
-#ifdef linux
+#if (PLATFORM == PLATFORM_APPLE) || (PLATFORM == PLATFORM_UNIX)
 // Non-blocking keypress detector, when return pressed, return 1, else always return 0
 int kb_hit_return()
 {
@@ -613,7 +613,7 @@ void CliRunnable::run()
     while (!World::IsStopped())
     {
         fflush(stdout);
-#ifdef linux
+#if (PLATFORM == PLATFORM_APPLE) || (PLATFORM == PLATFORM_UNIX)
         while (!kb_hit_return() && !World::IsStopped())
             // With this, we limit CLI to 10commands/second
             { usleep(100); }


### PR DESCRIPTION
  - Fixed rpath of ACE_LITE on startup
  - Fixed freeze on shutdown for non-Linux OS