### PR TITLE
Don't interrupt certain channeled spells

### DIFF
--- a/src/game/Server/SharedDefines.h
+++ b/src/game/Server/SharedDefines.h
@@ -413,7 +413,7 @@ enum SpellAttributesEx3
     SPELL_ATTR_EX3_UNK25                        = 0x02000000,            // 25 no cause spell pushback ?
     SPELL_ATTR_EX3_UNK26                        = 0x04000000,            // 26
     SPELL_ATTR_EX3_UNK27                        = 0x08000000,            // 27
-    SPELL_ATTR_EX3_UNK28                        = 0x10000000,            // 28
+    SPELL_ATTR_EX3_UNK28                        = 0x10000000,            // 28 always cast ok ? (requires more research)
     SPELL_ATTR_EX3_UNK29                        = 0x20000000,            // 29
     SPELL_ATTR_EX3_UNK30                        = 0x40000000,            // 30
     SPELL_ATTR_EX3_UNK31                        = 0x80000000             // 31

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -3036,7 +3036,11 @@ void Spell::update(uint32 difftime)
 
                     // check for incapacitating player states
                     if (m_caster->hasUnitState(UNIT_STAT_CAN_NOT_REACT))
-                        { cancel(); }
+                    {
+                        // certain channel spells are not interrupted
+                        if (!m_spellInfo->HasAttribute(SPELL_ATTR_EX_CHANNELED_1) && !m_spellInfo->HasAttribute(SPELL_ATTR_EX3_UNK28))
+                            cancel();
+                    }
 
                     // check if player has turned if flag is set
                     if (m_spellInfo->ChannelInterruptFlags & CHANNEL_FLAG_TURNING && m_castOrientation != m_caster->GetOrientation())


### PR DESCRIPTION
This will check for the combination of SPELL_ATTR_EX_CHANNELED_1 and SPELL_ATTR_EX3_UNK28 (possible SPELL_ATTR_EX3_ALWAYS_CAST_OK) and ignore UNIT_STAT_CAN_NOT_REACT

Thanks to @vovk

Close scriptdev2/scriptdev2#145

(based on https://github.com/cmangos/mangos-wotlk/commit/7ced9cf483bc1e8afdc403b4a60a8ff4ff3c7912)

Signed-off-by: Cala <calaftp@free.fr>

(based on https://github.com/cmangos/mangos-tbc/commit/fbf73342c785a795affcd5c5d8242dd7f7720454)

Signed-off-by: Cala <calaftp@free.fr>