### PR TITLE
Update conf file to work with modern SQL servers

### DIFF
--- a/src/mangosd/mangosd.conf.dist.in
+++ b/src/mangosd/mangosd.conf.dist.in
@@ -69,7 +69,7 @@ CharacterDatabaseInfo        = "127.0.0.1;3306;mangos;mangos;characters"
 LoginDatabaseConnections     = 1
 WorldDatabaseConnections     = 1
 CharacterDatabaseConnections = 1
-MaxPingTime                  = 30
+MaxPingTime                  = 5
 WorldServerPort              = 8085
 BindIP                       = "0.0.0.0"
 


### PR DESCRIPTION
Modified the default configuration to ping the DB server at five minute intervals since both MySQL and MariaDB now have a maximum ten minute timeout before dropping a connection. This fixes issues with connections being dropped, characters not being saved, things not being loaded, etc.