### PR TITLE
Fix wrong error display - Bloodthirst triggers

### DIFF
--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -1070,7 +1070,9 @@ void Spell::DoAllEffectOnTarget(TargetInfo* target)
         caster->DealSpellDamage(&damageInfo, true);
 
         // Bloodthirst
-        if (m_spellInfo->SpellFamilyName == SPELLFAMILY_WARRIOR && m_spellInfo->SpellFamilyFlags & UI64LIT(0x0000000002000000))
+        if (m_spellInfo->SpellFamilyName == SPELLFAMILY_WARRIOR &&
+            m_spellInfo->SpellFamilyFlags & UI64LIT(0x0000000002000000) &&
+            m_spellInfo->SpellIconID == 38)
         {
             uint32 BTAura = 0;
             switch (m_spellInfo->Id)


### PR DESCRIPTION
    - Bloodthirst and Mortal Strike have same SpellFamilyFlags
    - supress displaying "Spell::EffectSchoolDMG: Spell #id not handled in BTAura"
    - this fix applies to ZERO only!