### PR TITLE
Player::TeleportTo() signature change to request undelayed teleport

### DIFF
--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -908,7 +908,7 @@ class Player : public Unit
         void AddToWorld() override;
         void RemoveFromWorld() override;
 
-        bool TeleportTo(uint32 mapid, float x, float y, float z, float orientation, uint32 options = 0, AreaTrigger const* at = NULL);
+        bool TeleportTo(uint32 mapid, float x, float y, float z, float orientation, uint32 options = 0, bool allowNoDelay = false);
 
         bool TeleportTo(WorldLocation const& loc, uint32 options = 0)
         {

--- a/src/game/WorldHandlers/MiscHandler.cpp
+++ b/src/game/WorldHandlers/MiscHandler.cpp
@@ -811,8 +811,16 @@ void WorldSession::HandleAreaTriggerOpcode(WorldPacket& recv_data)
         player->SpawnCorpseBones();
     }
 
-    // teleport player (trigger requirement will be checked on TeleportTo)
-    player->TeleportTo(at->target_mapId, at->target_X, at->target_Y, at->target_Z, at->target_Orientation, TELE_TO_NOT_LEAVE_TRANSPORT, at);
+    uint32 miscRequirement = 0;
+    AreaLockStatus lockStatus = player->GetAreaTriggerLockStatus(at, miscRequirement);
+    if (lockStatus != AREA_LOCKSTATUS_OK)
+    {
+        player->SendTransferAbortedByLockStatus(targetMapEntry, lockStatus, miscRequirement);
+        return;
+    }
+
+    // teleport player
+    player->TeleportTo(at->target_mapId, at->target_X, at->target_Y, at->target_Z, at->target_Orientation, TELE_TO_NOT_LEAVE_TRANSPORT, true);
 }
 
 void WorldSession::HandleUpdateAccountData(WorldPacket& recv_data)


### PR DESCRIPTION
Improved TeleportTo() signature as discussed [here](https://github.com/mangoszero/server/pull/77). Areatrigger requirement check is moved to the handler, like the TC.
TODO: identify, what other TeleportTo() calls may be completed without delay, and add the flag to the calls.