### PR TITLE
Fix displaying the right ranks of spells in spellbook

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -2983,8 +2983,10 @@ bool Player::addSpell(uint32 spell_id, bool active, bool learning, bool dependen
 
         m_spells[spell_id] = newspell;
 
-        // return false if spell disabled
-        if (newspell.disabled)
+        // return false if spell disabled or spell is non-stackable with lower-ranks
+        if (newspell.disabled ||
+            (sSpellMgr.IsRankedSpellNonStackableInSpellBook(spellInfo) &&
+            (sSpellMgr.GetFirstSpellInChain(spell_id) != spell_id)))
             { return false; }
     }
 

--- a/src/game/Object/SpellMgr.cpp
+++ b/src/game/Object/SpellMgr.cpp
@@ -1964,6 +1964,9 @@ bool SpellMgr::canStackSpellRanksInSpellBook(SpellEntry const* spellInfo) const
         switch (spellInfo->SpellFamilyName)
         {
             case SPELLFAMILY_PALADIN:
+                // Paladin SoR spell, Judgement version
+                if (spellInfo->Id == 21084 || spellInfo->Id == 20154)
+                    { return false; }
                 // Paladin aura Spell
                 if (spellInfo->Effect[i] == SPELL_EFFECT_APPLY_AREA_AURA_PARTY)
                     { return false; }

--- a/src/game/Object/SpellMgr.cpp
+++ b/src/game/Object/SpellMgr.cpp
@@ -1958,33 +1958,15 @@ bool SpellMgr::canStackSpellRanksInSpellBook(SpellEntry const* spellInfo) const
     if (IsSkillBonusSpell(spellInfo->Id))
         { return false; }
 
-    // All stance spells. if any better way, change it.
-    for (int i = 0; i < MAX_EFFECT_INDEX; ++i)
+    // Any spell which has skill forward spell
+    // Include party auras from paladins, stealth from rogues, shapeshift spells for druids...and more :)
+    SkillLineAbilityMap::const_iterator itr = mSkillLineAbilityMap.find(spellInfo->Id);
+    if (itr != mSkillLineAbilityMap.end())
     {
-        switch (spellInfo->SpellFamilyName)
-        {
-            case SPELLFAMILY_PALADIN:
-                // Paladin SoR spell, Judgement version
-                if (spellInfo->Id == 21084 || spellInfo->Id == 20154)
-                    { return false; }
-                // Paladin aura Spell
-                if (spellInfo->Effect[i] == SPELL_EFFECT_APPLY_AREA_AURA_PARTY)
-                    { return false; }
-                break;
-            case SPELLFAMILY_DRUID:
-                // Druid form Spell
-                if (spellInfo->Effect[i] == SPELL_EFFECT_APPLY_AURA &&
-                    spellInfo->EffectApplyAuraName[i] == SPELL_AURA_MOD_SHAPESHIFT)
-                    { return false; }
-                break;
-            case SPELLFAMILY_ROGUE:
-                // Rogue Stealth
-                if (spellInfo->Effect[i] == SPELL_EFFECT_APPLY_AURA &&
-                    spellInfo->EffectApplyAuraName[i] == SPELL_AURA_MOD_SHAPESHIFT)
-                    { return false; }
-                break;
-        }
+        if (itr->second->forward_spellid != 0)
+            { return false; }
     }
+
     return true;
 }
 

--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -2276,6 +2276,11 @@ void Spell::EffectLearnSpell(SpellEffectIndex eff_idx)
     Player* player = (Player*)unitTarget;
 
     uint32 spellToLearn = m_spellInfo->EffectTriggerSpell[eff_idx];
+
+    // special case for paladin SoR 20154 (non-judgement version)
+    if (m_spellInfo->Id == 10321)
+        { player->removeSpell(20154, true, false); }
+
     player->learnSpell(spellToLearn, false);
 
     if (WorldObject const* caster = GetCastingObject())

--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -2274,12 +2274,7 @@ void Spell::EffectLearnSpell(SpellEffectIndex eff_idx)
     }
 
     Player* player = (Player*)unitTarget;
-
     uint32 spellToLearn = m_spellInfo->EffectTriggerSpell[eff_idx];
-
-    // special case for paladin SoR 20154 (non-judgement version)
-    if (m_spellInfo->Id == 10321)
-        { player->removeSpell(20154, true, false); }
 
     player->learnSpell(spellToLearn, false);
 

--- a/src/game/WorldHandlers/UnitAuraProcHandler.cpp
+++ b/src/game/WorldHandlers/UnitAuraProcHandler.cpp
@@ -706,6 +706,7 @@ SpellAuraProcResult Unit::HandleDummyAuraProc(Unit* pVictim, uint32 damage, Aura
                 uint32 spellId;
                 switch (triggeredByAura->GetId())
                 {
+                    case 20154:
                     case 21084: spellId = 25742; break;     // Rank 1
                     case 20287: spellId = 25740; break;     // Rank 2
                     case 20288: spellId = 25739; break;     // Rank 3

--- a/src/shared/revision.h
+++ b/src/shared/revision.h
@@ -32,12 +32,12 @@
     #define REALMD_DB_UPDATE_DESCRIPTION "dbdocs update"
 
     #define CHAR_DB_VERSION_NR 21
-    #define CHAR_DB_STRUCTURE_NR 2
+    #define CHAR_DB_STRUCTURE_NR 3
     #define CHAR_DB_CONTENT_NR 1
-    #define CHAR_DB_UPDATE_DESCRIPTION "Characters dbdocs update"
+    #define CHAR_DB_UPDATE_DESCRIPTION "Fix SoR paladin"
 
     #define WORLD_DB_VERSION_NR 21
-    #define WORLD_DB_STRUCTURE_NR 2
-    #define WORLD_DB_CONTENT_NR 3
-    #define WORLD_DB_UPDATE_DESCRIPTION "NPC 15213 event_ai fix"
+    #define WORLD_DB_STRUCTURE_NR 3
+    #define WORLD_DB_CONTENT_NR 1
+    #define WORLD_DB_UPDATE_DESCRIPTION "Fix SoR paladin"
 #endif // __REVISION_H__


### PR DESCRIPTION
    - Fixes displaying the Seal of Righteousness (SoR) ranks
    - Fixes the "double spell listing" of non-stackable spells after the learning,
      both in chat and in spellbook (applies to all classes)
    - This fix is paired with 2 database updates, one for world and one for characters
    - After applying the fixes, all paladin characters must visit their trainer to relearn the "Judgement" spell