### PR TITLE
Player::UpdateCombatSkills -> compare 5 x PlayerLevel with GetBaseWea…

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -18793,7 +18793,7 @@ uint32 Player::GetBaseWeaponSkillValue(WeaponAttackType attType) const
 
     // weapon skill or (unarmed for base attack)
     uint32  skill = item ? item->GetSkill() : uint32(SKILL_UNARMED);
-    return GetBaseSkillValue(skill);
+    return GetPureSkillValue(skill);
 }
 
 void Player::ResurectUsingRequestData()

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -1750,7 +1750,7 @@ class Player : public Unit
 
         uint32 GetBaseDefenseSkillValue() const
         {
-            return GetBaseSkillValue(SKILL_DEFENSE);
+            return GetPureSkillValue(SKILL_DEFENSE);
         }
         uint32 GetBaseWeaponSkillValue(WeaponAttackType attType) const;
 


### PR DESCRIPTION
Racial Skill Bonus Fix
Player::UpdateCombatSkills -> compare 5 x PlayerLevel with GetBaseWeaponSkillValue / GetBaseDefenseSkillValue
GetBaseWeaponSkillValue and GetBaseDefenseSkillValue -> return GetBaseSkillValue, but this return with added SKILL_PERM_BONUS
Due to this the skilldif formula in Player::UpdateCombatSkills is miscalculating maximum value
I have changed GetBaseWeaponSkillValue and GetBaseDefenseSkillValue to utilize GetPureSkillValue correcting the calculation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/160)
<!-- Reviewable:end -->
