### PR TITLE
Update revision.h

### DIFF
--- a/src/shared/revision.h
+++ b/src/shared/revision.h
@@ -38,6 +38,6 @@
 
     #define WORLD_DB_VERSION_NR 21
     #define WORLD_DB_STRUCTURE_NR 14
-    #define WORLD_DB_CONTENT_NR 2
-    #define WORLD_DB_UPDATE_DESCRIPTION "MC,AQ20,AQ40_Equipment"
+    #define WORLD_DB_CONTENT_NR 11
+    #define WORLD_DB_UPDATE_DESCRIPTION "Verog_increase_spawn_chance"
 #endif // __REVISION_H__


### PR DESCRIPTION
Rel21_14_011_Verog_increase_spawn_chance.sql is the newst DB Update for mangoszero.
Maybe we should change define REVISION_NR "21014" to define REVISION_NR "21014011" for the last change on the world db.