### PR TITLE
DetailsEmote for quests (SMSG packet structure)

### DIFF
--- a/src/game/Object/Creature.cpp
+++ b/src/game/Object/Creature.cpp
@@ -456,7 +456,8 @@ bool Creature::UpdateEntry(uint32 Entry, Team team, const CreatureData* data /*=
         if (factionTemplate->factionFlags & FACTION_TEMPLATE_FLAG_PVP)
             SetPvP(true);
         else
-            SetPvP(false);
+            if (!IsRacialLeader())
+                SetPvP(false);
     }
 
     // Try difficulty dependend version before falling back to base entry

--- a/src/game/WorldHandlers/GossipDef.cpp
+++ b/src/game/WorldHandlers/GossipDef.cpp
@@ -457,9 +457,10 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* pQuest, ObjectGuid guid
     {
         ItemPrototype const* IProto;
 
-        data << uint32(pQuest->GetRewChoiceItemsCount());
+        uint32 count = pQuest->GetRewChoiceItemsCount();
+        data << uint32(count);
 
-        for (uint32 i = 0; i < QUEST_REWARD_CHOICES_COUNT; ++i)
+        for (uint32 i = 0; i < count; ++i)
         {
             data << uint32(pQuest->RewChoiceItemId[i]);
             data << uint32(pQuest->RewChoiceItemCount[i]);
@@ -472,9 +473,10 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* pQuest, ObjectGuid guid
                 { data << uint32(0x00); }
         }
 
-        data << uint32(pQuest->GetRewItemsCount());
+        count = pQuest->GetRewItemsCount();
+        data << uint32(count);
 
-        for (uint32 i = 0; i < QUEST_REWARDS_COUNT; ++i)
+        for (uint32 i = 0; i < count; ++i)
         {
             data << uint32(pQuest->RewItemId[i]);
             data << uint32(pQuest->RewItemCount[i]);
@@ -490,19 +492,14 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* pQuest, ObjectGuid guid
         data << uint32(pQuest->GetRewOrReqMoney());
     }
 
-    data << pQuest->GetReqItemsCount();
-    for (uint32 i = 0; i <  QUEST_OBJECTIVES_COUNT; i++)
-    {
-        data << pQuest->ReqItemId[i];
-        data << pQuest->ReqItemCount[i];
-    }
+    data << uint32(pQuest->GetRewSpell());
 
-
-    data << pQuest->GetReqCreatureOrGOcount();
-    for (uint32 i = 0; i < QUEST_OBJECTIVES_COUNT; i++)
+    uint32 count = pQuest->GetDetailsEmoteCount();
+    data << uint32(count);
+    for (uint32 i = 0; i < count; ++i)
     {
-        data << uint32(pQuest->ReqCreatureOrGOId[i]);
-        data << pQuest->ReqCreatureOrGOCount[i];
+        data << uint32(pQuest->DetailsEmote[i]);
+        data << uint32(pQuest->DetailsEmoteDelay[i]); // delay between emotes in ms
     }
 
     GetMenuSession()->SendPacket(&data);

--- a/src/game/WorldHandlers/QueryHandler.cpp
+++ b/src/game/WorldHandlers/QueryHandler.cpp
@@ -165,7 +165,8 @@ void WorldSession::HandleCreatureQueryOpcode(WorldPacket& recv_data)
         else
             { data << uint32(Creature::ChooseDisplayId(ci)); }  // workaround, way to manage models must be fixed
 
-        data << uint16(ci->civilian);                       // wdbFeild14
+        data << uint8(ci->civilian);                       // wdbFeild14
+        data << uint8(ci->RacialLeader);
         SendPacket(&data);
         DEBUG_LOG("WORLD: Sent SMSG_CREATURE_QUERY_RESPONSE");
     }

--- a/src/game/WorldHandlers/QuestDef.cpp
+++ b/src/game/WorldHandlers/QuestDef.cpp
@@ -115,8 +115,13 @@ Quest::Quest(Field* questRecord)
     PointY = questRecord[103].GetFloat();
     PointOpt = questRecord[104].GetUInt32();
 
+    m_detailsemotecount = 0;
     for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
-        { DetailsEmote[i] = questRecord[105 + i].GetUInt32(); }
+    {
+        DetailsEmote[i] = questRecord[105 + i].GetUInt32();
+        if (DetailsEmote[i] != 0)
+            m_detailsemotecount = i + 1;
+    }
 
     for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
         { DetailsEmoteDelay[i] = questRecord[109 + i].GetUInt32(); }

--- a/src/game/WorldHandlers/QuestDef.h
+++ b/src/game/WorldHandlers/QuestDef.h
@@ -249,6 +249,7 @@ class Quest
         uint32 GetPointOpt() const { return PointOpt; }
         uint32 GetIncompleteEmote() const { return IncompleteEmote; }
         uint32 GetCompleteEmote() const { return CompleteEmote; }
+        uint32 GetDetailsEmoteCount() const { return m_detailsemotecount; }
         uint32 GetQuestStartScript() const { return QuestStartScript; }
         uint32 GetQuestCompleteScript() const { return QuestCompleteScript; }
 
@@ -296,6 +297,7 @@ class Quest
         uint32 m_reqCreatureOrGOcount;
         uint32 m_rewchoiceitemscount;
         uint32 m_rewitemscount;
+        uint32 m_detailsemotecount; // actual allowed value 0..4
 
         bool m_isActive;
 


### PR DESCRIPTION
1. Emotes. Thanks to [brotalnia](url="https://www.getmangos.eu/profile/4331-brotalnia/") and the Elysium Project.

The code closely resembles the Elysium's solution except one minor improvement. The placeholder for DetailsEmote array has variable length in the SMSG_QUESTGIVER_QUEST_DETAILS packet (confirmed at 5875 client build).

2,3. Racial Leaders. SMSG_CREATURE_QUERY_RESPONSE packet structure is corrected slightly, now including `bool RacialLeader` flag. The leaders are prevented to drop PvP in `Creature::UpdateEntry()`. Oh, and the commit titles are exchanged here :(