### PR TITLE
A bit of SMSG packet structure

### DIFF
--- a/src/game/ChatCommands/debugcmds.cpp
+++ b/src/game/ChatCommands/debugcmds.cpp
@@ -309,8 +309,10 @@ bool ChatHandler::HandleDebugSendQuestPartyMsgCommand(char* args)
     uint32 msg;
     if (!ExtractUInt32(&args, msg))
         { return false; }
+    if (msg > 0xFF)
+        { return false; }
 
-    m_session->GetPlayer()->SendPushToPartyResponse(m_session->GetPlayer(), msg);
+    m_session->GetPlayer()->SendPushToPartyResponse(m_session->GetPlayer(), uint8(msg));
     return true;
 }
 

--- a/src/game/Object/Creature.cpp
+++ b/src/game/Object/Creature.cpp
@@ -456,7 +456,8 @@ bool Creature::UpdateEntry(uint32 Entry, Team team, const CreatureData* data /*=
         if (factionTemplate->factionFlags & FACTION_TEMPLATE_FLAG_PVP)
             SetPvP(true);
         else
-            SetPvP(false);
+            if (!IsRacialLeader())
+                SetPvP(false);
     }
 
     // Try difficulty dependend version before falling back to base entry

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -13742,14 +13742,13 @@ void Player::SendQuestConfirmAccept(const Quest* pQuest, Player* pReceiver)
     }
 }
 
-void Player::SendPushToPartyResponse(Player* pPlayer, uint32 msg)
+void Player::SendPushToPartyResponse(Player* pPlayer, uint8 msg)
 {
     if (pPlayer)
     {
-        WorldPacket data(MSG_QUEST_PUSH_RESULT, (8 + 4 + 1));
+        WorldPacket data(MSG_QUEST_PUSH_RESULT, (8 + 1));
         data << pPlayer->GetObjectGuid();
-        data << uint32(msg);                                // valid values: 0-8
-        data << uint8(0);
+        data << uint8(msg);                   // enum QuestShareMessages
         GetSession()->SendPacket(&data);
         DEBUG_LOG("WORLD: Sent MSG_QUEST_PUSH_RESULT");
     }

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -1385,7 +1385,7 @@ class Player : public Unit
         void SendQuestTimerFailed(uint32 quest_id);
         void SendCanTakeQuestResponse(uint32 msg) const;
         void SendQuestConfirmAccept(Quest const* pQuest, Player* pReceiver);
-        void SendPushToPartyResponse(Player* pPlayer, uint32 msg);
+        void SendPushToPartyResponse(Player* pPlayer, uint8 msg);
         void SendQuestUpdateAddItem(Quest const* pQuest, uint32 item_idx, uint32 count);
         void SendQuestUpdateAddCreatureOrGo(Quest const* pQuest, ObjectGuid guid, uint32 creatureOrGO_idx, uint32 count);
 

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -688,7 +688,7 @@ void Opcodes::BuildOpcodeList()
     /*[-ZERO] Need check */ /*0x273*/  StoreOpcode(SMSG_STABLE_RESULT,                "SMSG_STABLE_RESULT",               STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x274*/  StoreOpcode(CMSG_STABLE_REVIVE_PET,            "CMSG_STABLE_REVIVE_PET",           STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleStableRevivePet);
     /*0x275*/  StoreOpcode(CMSG_STABLE_SWAP_PET,              "CMSG_STABLE_SWAP_PET",             STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleStableSwapPet);
-    /*[-ZERO] Need check */ /*0x276*/  StoreOpcode(MSG_QUEST_PUSH_RESULT,             "MSG_QUEST_PUSH_RESULT",            STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleQuestPushResult);
+    /*0x276*/  StoreOpcode(MSG_QUEST_PUSH_RESULT,             "MSG_QUEST_PUSH_RESULT",            STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleQuestPushResult);
     /*[-ZERO] Need check */ /*0x277*/  StoreOpcode(SMSG_PLAY_MUSIC,                   "SMSG_PLAY_MUSIC",                  STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x278*/  StoreOpcode(SMSG_PLAY_OBJECT_SOUND,            "SMSG_PLAY_OBJECT_SOUND",           STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x279*/  StoreOpcode(CMSG_REQUEST_PET_INFO,             "CMSG_REQUEST_PET_INFO",            STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleRequestPetInfoOpcode);

--- a/src/game/WorldHandlers/GossipDef.cpp
+++ b/src/game/WorldHandlers/GossipDef.cpp
@@ -457,9 +457,10 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* pQuest, ObjectGuid guid
     {
         ItemPrototype const* IProto;
 
-        data << uint32(pQuest->GetRewChoiceItemsCount());
+        uint32 count = pQuest->GetRewChoiceItemsCount();
+        data << uint32(count);
 
-        for (uint32 i = 0; i < QUEST_REWARD_CHOICES_COUNT; ++i)
+        for (uint32 i = 0; i < count; ++i)
         {
             data << uint32(pQuest->RewChoiceItemId[i]);
             data << uint32(pQuest->RewChoiceItemCount[i]);
@@ -472,9 +473,10 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* pQuest, ObjectGuid guid
                 { data << uint32(0x00); }
         }
 
-        data << uint32(pQuest->GetRewItemsCount());
+        count = pQuest->GetRewItemsCount();
+        data << uint32(count);
 
-        for (uint32 i = 0; i < QUEST_REWARDS_COUNT; ++i)
+        for (uint32 i = 0; i < count; ++i)
         {
             data << uint32(pQuest->RewItemId[i]);
             data << uint32(pQuest->RewItemCount[i]);
@@ -490,19 +492,14 @@ void PlayerMenu::SendQuestGiverQuestDetails(Quest const* pQuest, ObjectGuid guid
         data << uint32(pQuest->GetRewOrReqMoney());
     }
 
-    data << pQuest->GetReqItemsCount();
-    for (uint32 i = 0; i <  QUEST_OBJECTIVES_COUNT; i++)
-    {
-        data << pQuest->ReqItemId[i];
-        data << pQuest->ReqItemCount[i];
-    }
+    data << uint32(pQuest->GetRewSpell());
 
-
-    data << pQuest->GetReqCreatureOrGOcount();
-    for (uint32 i = 0; i < QUEST_OBJECTIVES_COUNT; i++)
+    uint32 count = pQuest->GetDetailsEmoteCount();
+    data << uint32(count);
+    for (uint32 i = 0; i < count; ++i)
     {
-        data << uint32(pQuest->ReqCreatureOrGOId[i]);
-        data << pQuest->ReqCreatureOrGOCount[i];
+        data << uint32(pQuest->DetailsEmote[i]);
+        data << uint32(pQuest->DetailsEmoteDelay[i]); // delay between emotes in ms
     }
 
     GetMenuSession()->SendPacket(&data);

--- a/src/game/WorldHandlers/QueryHandler.cpp
+++ b/src/game/WorldHandlers/QueryHandler.cpp
@@ -165,7 +165,8 @@ void WorldSession::HandleCreatureQueryOpcode(WorldPacket& recv_data)
         else
             { data << uint32(Creature::ChooseDisplayId(ci)); }  // workaround, way to manage models must be fixed
 
-        data << uint16(ci->civilian);                       // wdbFeild14
+        data << uint8(ci->civilian);                       // wdbFeild14
+        data << uint8(ci->RacialLeader);
         SendPacket(&data);
         DEBUG_LOG("WORLD: Sent SMSG_CREATURE_QUERY_RESPONSE");
     }

--- a/src/game/WorldHandlers/QuestDef.cpp
+++ b/src/game/WorldHandlers/QuestDef.cpp
@@ -115,8 +115,13 @@ Quest::Quest(Field* questRecord)
     PointY = questRecord[103].GetFloat();
     PointOpt = questRecord[104].GetUInt32();
 
+    m_detailsemotecount = 0;
     for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
-        { DetailsEmote[i] = questRecord[105 + i].GetUInt32(); }
+    {
+        DetailsEmote[i] = questRecord[105 + i].GetUInt32();
+        if (DetailsEmote[i] != 0)
+            m_detailsemotecount = i + 1;
+    }
 
     for (int i = 0; i < QUEST_EMOTE_COUNT; ++i)
         { DetailsEmoteDelay[i] = questRecord[109 + i].GetUInt32(); }

--- a/src/game/WorldHandlers/QuestDef.h
+++ b/src/game/WorldHandlers/QuestDef.h
@@ -249,6 +249,7 @@ class Quest
         uint32 GetPointOpt() const { return PointOpt; }
         uint32 GetIncompleteEmote() const { return IncompleteEmote; }
         uint32 GetCompleteEmote() const { return CompleteEmote; }
+        uint32 GetDetailsEmoteCount() const { return m_detailsemotecount; }
         uint32 GetQuestStartScript() const { return QuestStartScript; }
         uint32 GetQuestCompleteScript() const { return QuestCompleteScript; }
 
@@ -296,6 +297,7 @@ class Quest
         uint32 m_reqCreatureOrGOcount;
         uint32 m_rewchoiceitemscount;
         uint32 m_rewitemscount;
+        uint32 m_detailsemotecount; // actual allowed value 0..4
 
         bool m_isActive;
 

--- a/src/game/WorldHandlers/QuestHandler.cpp
+++ b/src/game/WorldHandlers/QuestHandler.cpp
@@ -489,10 +489,9 @@ void WorldSession::HandleQuestPushResult(WorldPacket& recvPacket)
 
     if (Player* pPlayer = ObjectAccessor::FindPlayer(_player->GetDividerGuid()))
     {
-        WorldPacket data(MSG_QUEST_PUSH_RESULT, (8 + 4 + 1));
+        WorldPacket data(MSG_QUEST_PUSH_RESULT, (8 + 1));
         data << ObjectGuid(guid);
-        data << uint32(msg);                             // valid values: 0-8
-        data << uint8(0);
+        data << uint8(msg);               // enum QuestShareMessages
         pPlayer->GetSession()->SendPacket(&data);
         _player->ClearDividerGuid();
     }


### PR DESCRIPTION
1. DetailsEmote. Thanks to brotalnia and the Elysium Project. The code resembles the Elysium's solution closely except one minor improvement. The placeholder for `DetailsEmote` array in the SMSG_QUESTGIVER_QUEST_DETAILS packet has also variable length.

2+3. Racial Leaders. Minor fix of SMSG_CREATURE_QUERY_RESPONSE packet, which includes now `bool RacialLeader` flag. Prevent the leaders dropping PvP due to usual faction rules in `Creature::UpdateEntry()`.

4. MSG_QUEST_PUSH_RESULT had 1 excessive uint32 field.

All this info comes from 5875 client build.