### PR TITLE
More on SMSG_ packets

### DIFF
--- a/src/game/Object/GMTicketMgr.h
+++ b/src/game/Object/GMTicketMgr.h
@@ -33,6 +33,16 @@
 #include "SharedDefines.h"
 #include <map>
 
+enum GMTicketResponse
+{
+    GMTICKET_RESPONSE_ALREADY_EXIST     = 1,
+    GMTICKET_RESPONSE_CREATE_SUCCESS    = 2,
+    GMTICKET_RESPONSE_CREATE_ERROR      = 3,
+    GMTICKET_RESPONSE_UPDATE_SUCCESS    = 4,
+    GMTICKET_RESPONSE_UPDATE_ERROR      = 5,
+    GMTICKET_RESPONSE_TICKET_DELETED    = 9
+};
+
 /**
  * \addtogroup game
  * @{

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -11212,6 +11212,14 @@ void Player::SendEquipError(InventoryResult msg, Item* pItem, Item* pItem2, uint
     GetSession()->SendPacket(&data);
 }
 
+void Player::SendOpenContainer()
+{
+    DEBUG_LOG("WORLD: Sent SMSG_OPEN_CONTAINER");
+    WorldPacket data(SMSG_OPEN_CONTAINER, 8);   // opens the main bag in the UI
+    data << GetObjectGuid();
+    GetSession()->SendPacket(&data);
+}
+
 void Player::SendBuyError(BuyResult msg, Creature* pCreature, uint32 item, uint32 param)
 {
     DEBUG_LOG("WORLD: Sent SMSG_BUY_FAILED");

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -17464,7 +17464,7 @@ void Player::UpdateHomebindTime(uint32 time)
             // hide reminder
             WorldPacket data(SMSG_RAID_GROUP_ONLY, 4 + 4);
             data << uint32(0);
-            data << uint32(ERR_RAID_GROUP_NONE);            // error used only when timer = 0
+            data << uint32(ERR_RAID_GROUP_REQUIRED);        // error used only when timer = 0
             GetSession()->SendPacket(&data);
         }
         // instance is valid, reset homebind timer
@@ -17487,7 +17487,7 @@ void Player::UpdateHomebindTime(uint32 time)
         // send message to player
         WorldPacket data(SMSG_RAID_GROUP_ONLY, 4 + 4);
         data << uint32(m_HomebindTimer);
-        data << uint32(ERR_RAID_GROUP_NONE);                // error used only when timer = 0
+        data << uint32(ERR_RAID_GROUP_REQUIRED);        // error used only when timer = 0
         GetSession()->SendPacket(&data);
         DEBUG_LOG("PLAYER: Player '%s' (GUID: %u) will be teleported to homebind in 60 seconds", GetName(), GetGUIDLow());
     }

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -1222,6 +1222,7 @@ class Player : public Unit
         void SendEquipError(InventoryResult msg, Item* pItem, Item* pItem2 = NULL, uint32 itemid = 0) const;
         void SendBuyError(BuyResult msg, Creature* pCreature, uint32 item, uint32 param);
         void SendSellError(SellResult msg, Creature* pCreature, ObjectGuid itemGuid, uint32 param);
+        void SendOpenContainer();
         void AddWeaponProficiency(uint32 newflag)
         {
             m_WeaponProficiency |= newflag;

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -330,11 +330,13 @@ typedef std::list<Item*> ItemDurationList;
 
 enum RaidGroupError
 {
-    ERR_RAID_GROUP_NONE                 = 0,
-    ERR_RAID_GROUP_LOWLEVEL             = 1,
-    ERR_RAID_GROUP_ONLY                 = 2,
-    ERR_RAID_GROUP_FULL                 = 3,
-    ERR_RAID_GROUP_REQUIREMENTS_UNMATCH = 4
+    ERR_RAID_GROUP_REQUIRED = 1,
+    ERR_RAID_GROUP_FULL     = 2
+    //ERR_RAID_GROUP_NONE                 = 0,
+    //ERR_RAID_GROUP_LOWLEVEL             = 1,
+    //ERR_RAID_GROUP_ONLY                 = 2,
+    //ERR_RAID_GROUP_FULL                 = 3,
+    //ERR_RAID_GROUP_REQUIREMENTS_UNMATCH = 4
 };
 
 enum DrunkenState

--- a/src/game/Object/SpellMgr.cpp
+++ b/src/game/Object/SpellMgr.cpp
@@ -904,16 +904,6 @@ bool IsPositiveSpell(SpellEntry const* spellproto)
 
 bool IsSingleTargetSpell(SpellEntry const* spellInfo)
 {
-    switch (spellInfo->Id)
-    {
-        case 339:                                           // Druid Roots Rank 1
-        case 1062:                                          // Druid Roots Rank 2
-        case 5195:                                          // Druid Roots Rank 3
-        case 5196:                                          // Druid Roots Rank 4
-        case 9852:                                          // Druid Roots Rank 5
-        case 9853:                                          // Druid Roots Rank 6
-            return true;
-    }
     // hunter's mark and similar
     if (spellInfo->SpellVisual == 3239)
         { return true; }
@@ -943,19 +933,21 @@ bool IsSingleTargetSpell(SpellEntry const* spellInfo)
         case 24664:                                         // Sleep (group targets)
             return false;
     }
-    // can not be cast on another target while not cooled down anyway
-    if (GetSpellDuration(spellInfo) < int32(GetSpellRecoveryTime(spellInfo)))
-        { return false; }
-
     // all other single target spells have if it has AttributesEx
-    if (spellInfo->AttributesEx & (1 << 18))
+    if (spellInfo->HasAttribute(SPELL_ATTR_EX_UNK18))
         { return true; }
+
+    // can not be cast on another target while not cooled down anyway
+    //if (GetSpellDuration(spellInfo) < int32(GetSpellRecoveryTime(spellInfo)))
+    //    { return true; }
 
     // other single target
     // Fear
     if ((spellInfo->SpellIconID == 98 && spellInfo->SpellVisual == 336)
         // Banish
         || (spellInfo->SpellIconID == 96 && spellInfo->SpellVisual == 1305)
+        // Entangling roots
+        || spellInfo->IsFitToFamily(SPELLFAMILY_DRUID, ClassFamilyMask(UI64LIT(0x0200)))
        ) { return true; }
 
     // TODO - need found Judgements rule

--- a/src/game/WorldHandlers/PetHandler.cpp
+++ b/src/game/WorldHandlers/PetHandler.cpp
@@ -695,10 +695,6 @@ void WorldSession::HandlePetCastSpellOpcode(WorldPacket& recvPacket)
 
 void WorldSession::SendPetNameInvalid(uint32 error, const std::string& name)
 {
-    // [-ZERO] Need check
-    WorldPacket data(SMSG_PET_NAME_INVALID, 4 + name.size() + 1 + 1);
-    data << uint32(error);
-    data << name;
-    data << uint8(0);                                       // possible not exist in 1.12.*
+    WorldPacket data(SMSG_PET_NAME_INVALID, 0);
     SendPacket(&data);
 }


### PR DESCRIPTION
1. Removed excessive packet data for SMSG_PET_NAME_INVALID
2. Added usage of SMSG_GMTICKET_UPDATETEXT, clarified code.
3. Fixed values of `enum RaidGroupError` for SMSG_RAID_GROUP_ONLY.
5. SMSG_OPEN_CONTAINER implemented. When got, it opens the main bag in the player UI. Just don't ask me, where it finds usage :)

All info comes from 5875 client build.

4. #14 refactored: removing spell IDs, clarifying code.