### PR TITLE
SMSG_MOUNTRESULT, SMSG_DISMOUNTRESULT

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -17242,6 +17242,20 @@ void Player::Unmount(bool from_aura)
     }
 }
 
+void Player::SendMountResult(PlayerMountResult result)
+{
+    WorldPacket data(SMSG_MOUNTRESULT, 4);
+    data << uint32(result);
+    GetSession()->SendPacket(&data);
+}
+
+void Player::SendDismountResult(PlayerDismountResult result)
+{
+    WorldPacket data(SMSG_DISMOUNTRESULT, 4);
+    data << uint32(result);
+    GetSession()->SendPacket(&data);
+}
+
 void Player::ProhibitSpellSchool(SpellSchoolMask idSchoolMask, uint32 unTimeMs)
 {
     // last check 1.12

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -725,6 +725,29 @@ enum PlayerRestState
     REST_STATE_RAF_LINKED       = 0x04                      // Exact use unknown
 };
 
+enum PlayerMountResult
+{
+    MOUNTRESULT_INVALIDMOUNTEE  = 0,    // You can't mount that unit!
+    MOUNTRESULT_TOOFARAWAY      = 1,    // That mount is too far away!
+    MOUNTRESULT_ALREADYMOUNTED  = 2,    // You're already mounted!
+    MOUNTRESULT_NOTMOUNTABLE    = 3,    // That unit can't be mounted!
+    MOUNTRESULT_NOTYOURPET      = 4,    // That mount isn't your pet!
+    MOUNTRESULT_OTHER           = 5,    // internal
+    MOUNTRESULT_LOOTING         = 6,    // You can't mount while looting!
+    MOUNTRESULT_RACECANTMOUNT   = 7,    // You can't mount because of your race!
+    MOUNTRESULT_SHAPESHIFTED    = 8,    // You can't mount while shapeshifted!
+    MOUNTRESULT_FORCEDDISMOUNT  = 9,    // You dismount before continuing.
+    MOUNTRESULT_OK              = 10    // no error
+};
+
+enum PlayerDismountResult
+{
+    DISMOUNTRESULT_NOPET        = 0,    // internal
+    DISMOUNTRESULT_NOTMOUNTED   = 1,    // You're not mounted!
+    DISMOUNTRESULT_NOTYOURPET   = 2,    // internal
+    DISMOUNTRESULT_OK           = 3     // no error
+};
+
 class PlayerTaxi
 {
     public:
@@ -994,6 +1017,8 @@ class Player : public Unit
         void ContinueTaxiFlight();
         void Mount(uint32 mount, uint32 spellId = 0) override;
         void Unmount(bool from_aura = false) override;
+        void SendMountResult(PlayerMountResult result);
+        void SendDismountResult(PlayerDismountResult result);
         bool isAcceptTickets() const { return GetSession()->GetSecurity() >= SEC_GAMEMASTER && (m_ExtraFlags & PLAYER_EXTRA_GM_ACCEPT_TICKETS); }
         void SetAcceptTicket(bool on) { if (on) { m_ExtraFlags |= PLAYER_EXTRA_GM_ACCEPT_TICKETS; } else { m_ExtraFlags &= ~PLAYER_EXTRA_GM_ACCEPT_TICKETS; } }
         bool isAcceptWhispers() const { return m_ExtraFlags & PLAYER_EXTRA_ACCEPT_WHISPERS; }

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -992,6 +992,8 @@ class Player : public Unit
         bool ActivateTaxiPathTo(uint32 taxi_path_id, uint32 spellid = 0);
         // mount_id can be used in scripting calls
         void ContinueTaxiFlight();
+        void Mount(uint32 mount, uint32 spellId = 0) override;
+        void Unmount(bool from_aura = false) override;
         bool isAcceptTickets() const { return GetSession()->GetSecurity() >= SEC_GAMEMASTER && (m_ExtraFlags & PLAYER_EXTRA_GM_ACCEPT_TICKETS); }
         void SetAcceptTicket(bool on) { if (on) { m_ExtraFlags |= PLAYER_EXTRA_GM_ACCEPT_TICKETS; } else { m_ExtraFlags &= ~PLAYER_EXTRA_GM_ACCEPT_TICKETS; } }
         bool isAcceptWhispers() const { return m_ExtraFlags & PLAYER_EXTRA_ACCEPT_WHISPERS; }

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -602,13 +602,12 @@ enum TradeSlots
     TRADE_SLOT_NONTRADED        = 6
 };
 
-// [-ZERO] Need fix, or maybe not exists
 enum TransferAbortReason
 {
-    TRANSFER_ABORT_NONE                         = 0x00,
     TRANSFER_ABORT_MAX_PLAYERS                  = 0x01,     // Transfer Aborted: instance is full
     TRANSFER_ABORT_NOT_FOUND                    = 0x02,     // Transfer Aborted: instance not found
     TRANSFER_ABORT_TOO_MANY_INSTANCES           = 0x03,     // You have entered too many instances recently.
+    TRANSFER_ABORT_SILENTLY                     = 0x04,     // no message shown; the same effect give values above 5
     TRANSFER_ABORT_ZONE_IN_COMBAT               = 0x05,     // Unable to zone in while an encounter is in progress.
 };
 

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -6407,28 +6407,6 @@ void Unit::Mount(uint32 mount, uint32 spellId)
     RemoveAurasWithInterruptFlags(AURA_INTERRUPT_FLAG_MOUNTING);
 
     SetUInt32Value(UNIT_FIELD_MOUNTDISPLAYID, mount);
-
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        // Called by Taxi system / GM command
-        if (!spellId)
-            { ((Player*)this)->UnsummonPetTemporaryIfAny(); }
-        // Called by mount aura
-        else
-        {
-            // Normal case (Unsummon only permanent pet)
-            if (Pet* pet = GetPet())
-            {
-                if (pet->IsPermanentPetFor((Player*)this) &&
-                    sWorld.getConfig(CONFIG_BOOL_PET_UNSUMMON_AT_MOUNT))
-                {
-                    ((Player*)this)->UnsummonPetTemporaryIfAny();
-                }
-                else
-                    { pet->ApplyModeFlags(PET_MODE_DISABLE_ACTIONS, true); }
-            }
-        }
-    }
 }
 
 void Unit::Unmount(bool from_aura)
@@ -6446,17 +6424,6 @@ void Unit::Unmount(bool from_aura)
         WorldPacket data(SMSG_DISMOUNT, 8);
         data << GetPackGUID();
         SendMessageToSet(&data, true);
-    }
-
-    // only resummon old pet if the player is already added to a map
-    // this prevents adding a pet to a not created map which would otherwise cause a crash
-    // (it could probably happen when logging in after a previous crash)
-    if (GetTypeId() == TYPEID_PLAYER)
-    {
-        if (Pet* pet = GetPet())
-            { pet->ApplyModeFlags(PET_MODE_DISABLE_ACTIONS, false); }
-        else
-            { ((Player*)this)->ResummonPetTemporaryUnSummonedIfAny(); }
     }
 }
 

--- a/src/game/Object/Unit.h
+++ b/src/game/Object/Unit.h
@@ -1815,7 +1815,7 @@ class Unit : public WorldObject
          * @param spellId id of the spell used to summon the mount, if 0 is passed in this is treated
          * as a GM command or the Taxi service mounting the Player.
          */
-        void Mount(uint32 mount, uint32 spellId = 0);
+        virtual void Mount(uint32 mount, uint32 spellId = 0);
         /**
          * Unmounts this Unit by sending the SMSG_DISMOUNT to the client if it was a dismount
          * not issued by a GM / the Taxi service. Also changes the UNIT_FIELD_MOUNTDISPLAYID
@@ -1823,7 +1823,7 @@ class Unit : public WorldObject
          * @param from_aura if this was true the Unit was probably interrupted by a spell
          * or something hitting it forcing a dismount.
          */
-        void Unmount(bool from_aura = false);
+        virtual void Unmount(bool from_aura = false);
 
         /**
          * Returns the maximum skill value the given Unit can have. Ie: the sword skill can

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -426,8 +426,8 @@ void Opcodes::BuildOpcodeList()
     /*[-ZERO] Need check */ /*0x16B*/  StoreOpcode(SMSG_DUEL_WINNER,                  "SMSG_DUEL_WINNER",                 STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x16C*/  StoreOpcode(CMSG_DUEL_ACCEPTED,                "CMSG_DUEL_ACCEPTED",               STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleDuelAcceptedOpcode);
     /*[-ZERO] Need check */ /*0x16D*/  StoreOpcode(CMSG_DUEL_CANCELLED,               "CMSG_DUEL_CANCELLED",              STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleDuelCancelledOpcode);
-    /*[-ZERO] Need check */ /*0x16E*/  StoreOpcode(SMSG_MOUNTRESULT,                  "SMSG_MOUNTRESULT",                 STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
-    /*[-ZERO] Need check */ /*0x16F*/  StoreOpcode(SMSG_DISMOUNTRESULT,               "SMSG_DISMOUNTRESULT",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x16E*/  StoreOpcode(SMSG_MOUNTRESULT,                  "SMSG_MOUNTRESULT",                 STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x16F*/  StoreOpcode(SMSG_DISMOUNTRESULT,               "SMSG_DISMOUNTRESULT",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x170*/  StoreOpcode(SMSG_PUREMOUNT_CANCELLED_OBSOLETE, "SMSG_PUREMOUNT_CANCELLED_OBSOLETE", STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x171*/  StoreOpcode(CMSG_MOUNTSPECIAL_ANIM,            "CMSG_MOUNTSPECIAL_ANIM",           STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleMountSpecialAnimOpcode);
     /*[-ZERO] Need check */ /*0x172*/  StoreOpcode(SMSG_MOUNTSPECIAL_ANIM,            "SMSG_MOUNTSPECIAL_ANIM",           STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -124,7 +124,7 @@ void Opcodes::BuildOpcodeList()
     /*0x03D*/  StoreOpcode(CMSG_PLAYER_LOGIN,                 "CMSG_PLAYER_LOGIN",                STATUS_AUTHED,    PROCESS_INPLACE,      &WorldSession::HandlePlayerLoginOpcode);
     /*[-ZERO] Need check */ /*0x03E*/  StoreOpcode(SMSG_NEW_WORLD,                    "SMSG_NEW_WORLD",                   STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x03F*/  StoreOpcode(SMSG_TRANSFER_PENDING,             "SMSG_TRANSFER_PENDING",            STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
-    /*[-ZERO] Need check */ /*0x040*/  StoreOpcode(SMSG_TRANSFER_ABORTED,             "SMSG_TRANSFER_ABORTED",            STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x040*/  StoreOpcode(SMSG_TRANSFER_ABORTED,             "SMSG_TRANSFER_ABORTED",            STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x041*/  StoreOpcode(SMSG_CHARACTER_LOGIN_FAILED,       "SMSG_CHARACTER_LOGIN_FAILED",      STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x042*/  StoreOpcode(SMSG_LOGIN_SETTIMESPEED,           "SMSG_LOGIN_SETTIMESPEED",          STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x043*/  StoreOpcode(SMSG_GAMETIME_UPDATE,              "SMSG_GAMETIME_UPDATE",             STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);

--- a/src/game/Server/WorldSession.cpp
+++ b/src/game/Server/WorldSession.cpp
@@ -780,10 +780,8 @@ void WorldSession::SaveTutorialsData()
 // Send chat information about aborted transfer (mostly used by Player::SendTransferAbortedByLockstatus())
 void WorldSession::SendTransferAborted(uint32 mapid, uint8 reason, uint8 arg)
 {
-    WorldPacket data(SMSG_TRANSFER_ABORTED, 4 + 2);
-    data << uint32(mapid);
+    WorldPacket data(SMSG_TRANSFER_ABORTED, 1);
     data << uint8(reason);                                  // transfer abort reason
-    data << uint8(0);                                       // arg. not used
     SendPacket(&data);
 }
 


### PR DESCRIPTION
1. Refactoring Mount/Unmount to the OO-style.
2. Implementing SMSG_MOUNTRESULT, SMSG_DISMOUNTRESULT. The packets are not used yet. Maybe most of the mount/dismount errors were transferred to spell system, but not all ones, e.g.,
`MOUNTRESULT_FORCEDDISMOUNT  = 9,    // You dismount before continuing.`
Looks like Mount/Unmount in Player class must use it instead of silent return.
3. uint8 TransferAbortReason is the only data within SMSG_TRANSFER_ABORTED packet.