### PR TITLE
Few SMSG_CHANNEL chat opcodes

### DIFF
--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -215,7 +215,7 @@ void Opcodes::BuildOpcodeList()
     /*[-ZERO] Need check */ /*0x098*/  StoreOpcode(CMSG_LEAVE_CHANNEL,                "CMSG_LEAVE_CHANNEL",               STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleLeaveChannelOpcode);
     /*0x099*/  StoreOpcode(SMSG_CHANNEL_NOTIFY,               "SMSG_CHANNEL_NOTIFY",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x09A*/  StoreOpcode(CMSG_CHANNEL_LIST,                 "CMSG_CHANNEL_LIST",                STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleChannelListOpcode);
-    /*[-ZERO] Need check */ /*0x09B*/  StoreOpcode(SMSG_CHANNEL_LIST,                 "SMSG_CHANNEL_LIST",                STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x09B*/  StoreOpcode(SMSG_CHANNEL_LIST,                 "SMSG_CHANNEL_LIST",                STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x09C*/  StoreOpcode(CMSG_CHANNEL_PASSWORD,             "CMSG_CHANNEL_PASSWORD",            STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleChannelPasswordOpcode);
     /*[-ZERO] Need check */ /*0x09D*/  StoreOpcode(CMSG_CHANNEL_SET_OWNER,            "CMSG_CHANNEL_SET_OWNER",           STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleChannelSetOwnerOpcode);
     /*[-ZERO] Need check */ /*0x09E*/  StoreOpcode(CMSG_CHANNEL_OWNER,                "CMSG_CHANNEL_OWNER",               STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleChannelOwnerOpcode);

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -213,7 +213,7 @@ void Opcodes::BuildOpcodeList()
     /*0x096*/  StoreOpcode(SMSG_MESSAGECHAT,                  "SMSG_MESSAGECHAT",                 STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x097*/  StoreOpcode(CMSG_JOIN_CHANNEL,                 "CMSG_JOIN_CHANNEL",                STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleJoinChannelOpcode);
     /*[-ZERO] Need check */ /*0x098*/  StoreOpcode(CMSG_LEAVE_CHANNEL,                "CMSG_LEAVE_CHANNEL",               STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleLeaveChannelOpcode);
-    /*[-ZERO] Need check */ /*0x099*/  StoreOpcode(SMSG_CHANNEL_NOTIFY,               "SMSG_CHANNEL_NOTIFY",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x099*/  StoreOpcode(SMSG_CHANNEL_NOTIFY,               "SMSG_CHANNEL_NOTIFY",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x09A*/  StoreOpcode(CMSG_CHANNEL_LIST,                 "CMSG_CHANNEL_LIST",                STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleChannelListOpcode);
     /*[-ZERO] Need check */ /*0x09B*/  StoreOpcode(SMSG_CHANNEL_LIST,                 "SMSG_CHANNEL_LIST",                STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x09C*/  StoreOpcode(CMSG_CHANNEL_PASSWORD,             "CMSG_CHANNEL_PASSWORD",            STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleChannelPasswordOpcode);

--- a/src/game/WorldHandlers/Channel.cpp
+++ b/src/game/WorldHandlers/Channel.cpp
@@ -776,6 +776,12 @@ void Channel::MakeNotMember(WorldPacket* data)
     MakeNotifyPacket(data, CHAT_NOT_MEMBER_NOTICE);
 }
 
+void Channel::MakeNotOnPacket(WorldPacket* data, const std::string &name)
+{
+    data->Initialize(SMSG_CHANNEL_NOTIFY, (1 + name.length() + 1));
+    (*data) << (uint8)CHAT_NOT_MEMBER_NOTICE << name;
+}
+
 void Channel::MakeNotModerator(WorldPacket* data)
 {
     MakeNotifyPacket(data, CHAT_NOT_MODERATOR_NOTICE);

--- a/src/game/WorldHandlers/Channel.cpp
+++ b/src/game/WorldHandlers/Channel.cpp
@@ -754,16 +754,16 @@ void Channel::MakeLeft(WorldPacket* data, ObjectGuid guid)
 void Channel::MakeYouJoined(WorldPacket* data)
 {
     MakeNotifyPacket(data, CHAT_YOU_JOINED_NOTICE);
-    *data << uint8(GetFlags());
-    *data << uint32(GetChannelId());
-    *data << uint32(0);
+    *data << uint32(GetFlags());
+    *data << uint32(0);                                     // the non-zero number will be appended to the channel name
+    *data << uint8(0);                                      // CString max length 512, conditional read
 }
 
 void Channel::MakeYouLeft(WorldPacket* data)
 {
     MakeNotifyPacket(data, CHAT_YOU_LEFT_NOTICE);
-    *data << uint32(GetChannelId());
-    *data << uint8(0);                                      // can be 0x00 and 0x01
+    //*data << uint32(GetChannelId());                        //[-ZERO]
+    //*data << uint8(0);                                      //[-ZERO] can be 0x00 and 0x01 (bool)
 }
 
 void Channel::MakeWrongPassword(WorldPacket* data)

--- a/src/game/WorldHandlers/Channel.cpp
+++ b/src/game/WorldHandlers/Channel.cpp
@@ -455,13 +455,12 @@ void Channel::List(Player* player)
     }
 
     // list players in channel
-    WorldPacket data(SMSG_CHANNEL_LIST, 1 + (GetName().size() + 1) + 1 + 4 + m_players.size() * (8 + 1));
-    data << uint8(1);                                       // channel type?
+    WorldPacket data(SMSG_CHANNEL_LIST, (GetName().size() + 1) + 1 + 4 + m_players.size() * (8 + 1));   // guess size
     data << GetName();                                      // channel name
     data << uint8(GetFlags());                              // channel flags?
 
     size_t pos = data.wpos();
-    data << uint32(0);                                      // size of list, placeholder
+    data << int32(0);                                       // size of list, placeholder
 
     AccountTypes gmLevelInWhoList = (AccountTypes)sWorld.getConfig(CONFIG_UINT32_GM_LEVEL_IN_WHO_LIST);
 
@@ -481,7 +480,7 @@ void Channel::List(Player* player)
         }
     }
 
-    data.put<uint32>(pos, count);
+    data.put<int32>(pos, count);
 
     SendToOne(&data, guid);
 }

--- a/src/game/WorldHandlers/Channel.h
+++ b/src/game/WorldHandlers/Channel.h
@@ -211,7 +211,11 @@ class Channel
          * \ref Channel::SPEAK_IN_LOCALDEFENSE_RANK for more info on the 4 added.
          */
         static const uint8 SPEAK_IN_WORLDDEFENSE_RANK = 4 + 10; 
-        
+        /**
+        * This creates the packet informing client that the player is not on requested \ref name channel.
+        * See also \ref MakeNotMember for non-static version.
+        */
+        static void MakeNotOnPacket(WorldPacket* data, const std::string &name);
     private:
         // initial packet data (notify type and channel name)
         void MakeNotifyPacket(WorldPacket* data, uint8 notify_type);

--- a/src/game/WorldHandlers/ChannelMgr.cpp
+++ b/src/game/WorldHandlers/ChannelMgr.cpp
@@ -79,7 +79,7 @@ Channel* ChannelMgr::GetChannel(const std::string &name, Player* p, bool pkt)
         if (pkt)
         {
             WorldPacket data;
-            MakeNotOnPacket(&data, name);
+            Channel::MakeNotOnPacket(&data, name);
             p->GetSession()->SendPacket(&data);
         }
 
@@ -107,10 +107,4 @@ void ChannelMgr::LeftChannel(const std::string &name)
         channels.erase(wname);
         delete channel;
     }
-}
-
-void ChannelMgr::MakeNotOnPacket(WorldPacket* data, const std::string &name)
-{
-    data->Initialize(SMSG_CHANNEL_NOTIFY, (1 + 10)); // we guess size
-    (*data) << (uint8)CHAT_NOT_MEMBER_NOTICE << name;
 }

--- a/src/game/WorldHandlers/ChannelMgr.h
+++ b/src/game/WorldHandlers/ChannelMgr.h
@@ -42,7 +42,6 @@ class ChannelMgr
         void LeftChannel(const std::string &name);
     private:
         ChannelMap channels;
-        void MakeNotOnPacket(WorldPacket* data, const std::string &name);
 };
 
 class AllianceChannelMgr : public ChannelMgr {};


### PR DESCRIPTION
1. Changed structure of CHAT_YOU_JOINED_NOTICE, CHAT_YOU_LEFT_NOTICE in accord to the client reads.
2. `MakeNotOn` method is a static version of `Channel::MakeNotMember` one, so it must be implemented in the `Channel` class.
3. Fixing structure of SMSG_CHANNEL_LIST packet. This revives the `/chatlist #id` and, partially, `/chatwho` client commands.