### PR TITLE
Few more SMSG_ packets

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -8493,10 +8493,31 @@ void Unit::SendPetCastFail(uint32 spellid, SpellCastResult msg)
     if (!owner || owner->GetTypeId() != TYPEID_PLAYER)
         { return; }
 
-    WorldPacket data(SMSG_PET_CAST_FAILED, 4 + 1);
+    WorldPacket data(SMSG_PET_CAST_FAILED, 4 + 1 + 1);
     data << uint32(spellid);
+    data << uint8(0);               // unknown, maybe unused
     data << uint8(msg);
-    ((Player*)owner)->GetSession()->SendPacket(&data);
+    switch (msg)
+    {
+    case SPELL_FAILED_EQUIPPED_ITEM_CLASS:
+    case SPELL_FAILED_EQUIPPED_ITEM_CLASS_MAINHAND:
+    case SPELL_FAILED_EQUIPPED_ITEM_CLASS_OFFHAND:
+        data << int32(0);           // required and actual item class?
+        data << int32(0);
+        break;
+    case SPELL_FAILED_REQUIRES_SPELL_FOCUS:
+        data << int32(0);           // required spellfocus id?
+        break;
+    case SPELL_FAILED_REQUIRES_AREA:
+        data << int32(GetAreaId()); // untested
+        break;
+    case SPELL_FAILED_PREVENTED_BY_MECHANIC:
+        data << int32(0);           // mechanic id?
+        break;
+    default:
+        break;
+    }
+    owner->ToPlayer()->SendDirectMessage(&data);
 }
 
 void Unit::SendPetActionFeedback(uint8 msg)

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -236,10 +236,10 @@ void Opcodes::BuildOpcodeList()
     /*[-ZERO] Need check */ /*0x0AD*/  StoreOpcode(CMSG_READ_ITEM,                    "CMSG_READ_ITEM",                   STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleReadItemOpcode);
     /*0x0AE*/  StoreOpcode(SMSG_READ_ITEM_OK,                 "SMSG_READ_ITEM_OK",                STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x0AF*/  StoreOpcode(SMSG_READ_ITEM_FAILED,             "SMSG_READ_ITEM_FAILED",            STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
-    /*[-ZERO] Need check */ /*0x0B0*/  StoreOpcode(SMSG_ITEM_COOLDOWN,                "SMSG_ITEM_COOLDOWN",               STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x0B0*/  StoreOpcode(SMSG_ITEM_COOLDOWN,                "SMSG_ITEM_COOLDOWN",               STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x0B1*/  StoreOpcode(CMSG_GAMEOBJ_USE,                  "CMSG_GAMEOBJ_USE",                 STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleGameObjectUseOpcode);
     /*0x0B2*/  StoreOpcode(CMSG_GAMEOBJ_CHAIR_USE_OBSOLETE,   "CMSG_GAMEOBJ_CHAIR_USE_OBSOLETE",  STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
-    /*[-ZERO] Need check */ /*0x0B3*/  StoreOpcode(SMSG_GAMEOBJECT_CUSTOM_ANIM,       "SMSG_GAMEOBJECT_CUSTOM_ANIM",      STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x0B3*/  StoreOpcode(SMSG_GAMEOBJECT_CUSTOM_ANIM,       "SMSG_GAMEOBJECT_CUSTOM_ANIM",      STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x0B4*/  StoreOpcode(CMSG_AREATRIGGER,                  "CMSG_AREATRIGGER",                 STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE,      &WorldSession::HandleAreaTriggerOpcode);
     /*0x0B5*/  StoreOpcode(MSG_MOVE_START_FORWARD,            "MSG_MOVE_START_FORWARD",           STATUS_LOGGEDIN,  PROCESS_THREADSAFE,   &WorldSession::HandleMovementOpcodes);
     /*0x0B6*/  StoreOpcode(MSG_MOVE_START_BACKWARD,           "MSG_MOVE_START_BACKWARD",          STATUS_LOGGEDIN,  PROCESS_THREADSAFE,   &WorldSession::HandleMovementOpcodes);
@@ -276,7 +276,7 @@ void Opcodes::BuildOpcodeList()
     /*0x0D5*/  StoreOpcode(MSG_MOVE_SET_SWIM_BACK_SPEED,      "MSG_MOVE_SET_SWIM_BACK_SPEED",     STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*0x0D6*/  StoreOpcode(MSG_MOVE_SET_ALL_SPEED_CHEAT,      "MSG_MOVE_SET_ALL_SPEED_CHEAT",     STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*0x0D7*/  StoreOpcode(MSG_MOVE_SET_TURN_RATE_CHEAT,      "MSG_MOVE_SET_TURN_RATE_CHEAT",     STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
-    /*[-ZERO] Need check */ /*0x0D8*/  StoreOpcode(MSG_MOVE_SET_TURN_RATE,            "MSG_MOVE_SET_TURN_RATE",           STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
+    /*[-ZERO] No effect */ /*0x0D8*/  StoreOpcode(MSG_MOVE_SET_TURN_RATE,            "MSG_MOVE_SET_TURN_RATE",           STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*0x0D9*/  StoreOpcode(MSG_MOVE_TOGGLE_COLLISION_CHEAT,   "MSG_MOVE_TOGGLE_COLLISION_CHEAT",  STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*0x0DA*/  StoreOpcode(MSG_MOVE_SET_FACING,               "MSG_MOVE_SET_FACING",              STATUS_LOGGEDIN,  PROCESS_THREADSAFE,   &WorldSession::HandleMovementOpcodes);
     /*0x0DB*/  StoreOpcode(MSG_MOVE_SET_PITCH,                "MSG_MOVE_SET_PITCH",               STATUS_LOGGEDIN,  PROCESS_THREADSAFE,   &WorldSession::HandleMovementOpcodes);
@@ -319,9 +319,9 @@ void Opcodes::BuildOpcodeList()
     /*0x100*/  StoreOpcode(CMSG_TUTORIAL_RESET,               "CMSG_TUTORIAL_RESET",              STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleTutorialResetOpcode);
     /*0x101*/  StoreOpcode(CMSG_STANDSTATECHANGE,             "CMSG_STANDSTATECHANGE",            STATUS_LOGGEDIN,  PROCESS_THREADSAFE,   &WorldSession::HandleStandStateChangeOpcode);
     /*[-ZERO] Need check */ /*0x102*/  StoreOpcode(CMSG_EMOTE,                        "CMSG_EMOTE",                       STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleEmoteOpcode);
-    /*[-ZERO] Need check */ /*0x103*/  StoreOpcode(SMSG_EMOTE,                        "SMSG_EMOTE",                       STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x103*/  StoreOpcode(SMSG_EMOTE,                        "SMSG_EMOTE",                       STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x104*/  StoreOpcode(CMSG_TEXT_EMOTE,                   "CMSG_TEXT_EMOTE",                  STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleTextEmoteOpcode);
-    /*[-ZERO] Need check */ /*0x105*/  StoreOpcode(SMSG_TEXT_EMOTE,                   "SMSG_TEXT_EMOTE",                  STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x105*/  StoreOpcode(SMSG_TEXT_EMOTE,                   "SMSG_TEXT_EMOTE",                  STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x106*/  StoreOpcode(CMSG_AUTOEQUIP_GROUND_ITEM,        "CMSG_AUTOEQUIP_GROUND_ITEM",       STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*0x107*/  StoreOpcode(CMSG_AUTOSTORE_GROUND_ITEM,        "CMSG_AUTOSTORE_GROUND_ITEM",       STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*0x108*/  StoreOpcode(CMSG_AUTOSTORE_LOOT_ITEM,          "CMSG_AUTOSTORE_LOOT_ITEM",         STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleAutostoreLootItemOpcode);
@@ -348,7 +348,7 @@ void Opcodes::BuildOpcodeList()
     /*[-ZERO] Need check */ /*0x11D*/  StoreOpcode(CMSG_SET_TRADE_ITEM,               "CMSG_SET_TRADE_ITEM",              STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleSetTradeItemOpcode);
     /*[-ZERO] Need check */ /*0x11E*/  StoreOpcode(CMSG_CLEAR_TRADE_ITEM,             "CMSG_CLEAR_TRADE_ITEM",            STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleClearTradeItemOpcode);
     /*[-ZERO] Need check */ /*0x11F*/  StoreOpcode(CMSG_SET_TRADE_GOLD,               "CMSG_SET_TRADE_GOLD",              STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleSetTradeGoldOpcode);
-    /*[-ZERO] Need check */ /*0x120*/  StoreOpcode(SMSG_TRADE_STATUS,                 "SMSG_TRADE_STATUS",                STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x120*/  StoreOpcode(SMSG_TRADE_STATUS,                 "SMSG_TRADE_STATUS",                STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x121*/  StoreOpcode(SMSG_TRADE_STATUS_EXTENDED,        "SMSG_TRADE_STATUS_EXTENDED",       STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x122*/  StoreOpcode(SMSG_INITIALIZE_FACTIONS,          "SMSG_INITIALIZE_FACTIONS",         STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x123*/  StoreOpcode(SMSG_SET_FACTION_VISIBLE,          "SMSG_SET_FACTION_VISIBLE",         STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -349,7 +349,7 @@ void Opcodes::BuildOpcodeList()
     /*[-ZERO] Need check */ /*0x11E*/  StoreOpcode(CMSG_CLEAR_TRADE_ITEM,             "CMSG_CLEAR_TRADE_ITEM",            STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleClearTradeItemOpcode);
     /*[-ZERO] Need check */ /*0x11F*/  StoreOpcode(CMSG_SET_TRADE_GOLD,               "CMSG_SET_TRADE_GOLD",              STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleSetTradeGoldOpcode);
     /*0x120*/  StoreOpcode(SMSG_TRADE_STATUS,                 "SMSG_TRADE_STATUS",                STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
-    /*[-ZERO] Need check */ /*0x121*/  StoreOpcode(SMSG_TRADE_STATUS_EXTENDED,        "SMSG_TRADE_STATUS_EXTENDED",       STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x121*/  StoreOpcode(SMSG_TRADE_STATUS_EXTENDED,        "SMSG_TRADE_STATUS_EXTENDED",       STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x122*/  StoreOpcode(SMSG_INITIALIZE_FACTIONS,          "SMSG_INITIALIZE_FACTIONS",         STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x123*/  StoreOpcode(SMSG_SET_FACTION_VISIBLE,          "SMSG_SET_FACTION_VISIBLE",         STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x124*/  StoreOpcode(SMSG_SET_FACTION_STANDING,         "SMSG_SET_FACTION_STANDING",        STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
@@ -367,7 +367,7 @@ void Opcodes::BuildOpcodeList()
     /*[-ZERO] Need check */ /*0x130*/  StoreOpcode(SMSG_CAST_FAILED,                  "SMSG_CAST_FAILED",                 STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x131*/  StoreOpcode(SMSG_SPELL_START,                  "SMSG_SPELL_START",                 STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x132*/  StoreOpcode(SMSG_SPELL_GO,                     "SMSG_SPELL_GO",                    STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
-    /*[-ZERO] Need check */ /*0x133*/  StoreOpcode(SMSG_SPELL_FAILURE,                "SMSG_SPELL_FAILURE",               STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x133*/  StoreOpcode(SMSG_SPELL_FAILURE,                "SMSG_SPELL_FAILURE",               STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x134*/  StoreOpcode(SMSG_SPELL_COOLDOWN,               "SMSG_SPELL_COOLDOWN",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x135*/  StoreOpcode(SMSG_COOLDOWN_EVENT,               "SMSG_COOLDOWN_EVENT",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x136*/  StoreOpcode(CMSG_CANCEL_AURA,                  "CMSG_CANCEL_AURA",                 STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleCancelAuraOpcode);
@@ -736,7 +736,7 @@ void Opcodes::BuildOpcodeList()
     /*[-ZERO] Need check */ /*0x2A3*/  StoreOpcode(CMSG_LOOT_MASTER_GIVE,             "CMSG_LOOT_MASTER_GIVE",            STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleLootMasterGiveOpcode);
     /*[-ZERO] Need check */ /*0x2A4*/  StoreOpcode(SMSG_LOOT_MASTER_LIST,             "SMSG_LOOT_MASTER_LIST",            STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x2A5*/  StoreOpcode(SMSG_SET_FORCED_REACTIONS,         "SMSG_SET_FORCED_REACTIONS",        STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
-    /*[-ZERO] Need check */ /*0x2A6*/  StoreOpcode(SMSG_SPELL_FAILED_OTHER,           "SMSG_SPELL_FAILED_OTHER",          STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x2A6*/  StoreOpcode(SMSG_SPELL_FAILED_OTHER,           "SMSG_SPELL_FAILED_OTHER",          STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x2A7*/  StoreOpcode(SMSG_GAMEOBJECT_RESET_STATE,       "SMSG_GAMEOBJECT_RESET_STATE",      STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x2A8*/  StoreOpcode(CMSG_REPAIR_ITEM,                  "CMSG_REPAIR_ITEM",                 STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleRepairItemOpcode);
     /*[-ZERO] Need check */ /*0x2A9*/  StoreOpcode(SMSG_CHAT_PLAYER_NOT_FOUND,        "SMSG_CHAT_PLAYER_NOT_FOUND",       STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -229,13 +229,13 @@ void Opcodes::BuildOpcodeList()
     /*[-ZERO] Need check */ /*0x0A6*/  StoreOpcode(CMSG_CHANNEL_UNBAN,                "CMSG_CHANNEL_UNBAN",               STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleChannelUnbanOpcode);
     /*[-ZERO] Need check */ /*0x0A7*/  StoreOpcode(CMSG_CHANNEL_ANNOUNCEMENTS,        "CMSG_CHANNEL_ANNOUNCEMENTS",       STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleChannelAnnouncementsOpcode);
     /*[-ZERO] Need check */ /*0x0A8*/  StoreOpcode(CMSG_CHANNEL_MODERATE,             "CMSG_CHANNEL_MODERATE",            STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleChannelModerateOpcode);
-    /*[-ZERO] Need check */ /*0x0A9*/  StoreOpcode(SMSG_UPDATE_OBJECT,                "SMSG_UPDATE_OBJECT",               STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
-    /*[-ZERO] Need check */ /*0x0AA*/  StoreOpcode(SMSG_DESTROY_OBJECT,               "SMSG_DESTROY_OBJECT",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x0A9*/  StoreOpcode(SMSG_UPDATE_OBJECT,                "SMSG_UPDATE_OBJECT",               STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x0AA*/  StoreOpcode(SMSG_DESTROY_OBJECT,               "SMSG_DESTROY_OBJECT",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x0AB*/  StoreOpcode(CMSG_USE_ITEM,                     "CMSG_USE_ITEM",                    STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleUseItemOpcode);
     /*[-ZERO] Need check */ /*0x0AC*/  StoreOpcode(CMSG_OPEN_ITEM,                    "CMSG_OPEN_ITEM",                   STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleOpenItemOpcode);
     /*[-ZERO] Need check */ /*0x0AD*/  StoreOpcode(CMSG_READ_ITEM,                    "CMSG_READ_ITEM",                   STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleReadItemOpcode);
-    /*[-ZERO] Need check */ /*0x0AE*/  StoreOpcode(SMSG_READ_ITEM_OK,                 "SMSG_READ_ITEM_OK",                STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
-    /*[-ZERO] Need check */ /*0x0AF*/  StoreOpcode(SMSG_READ_ITEM_FAILED,             "SMSG_READ_ITEM_FAILED",            STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x0AE*/  StoreOpcode(SMSG_READ_ITEM_OK,                 "SMSG_READ_ITEM_OK",                STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x0AF*/  StoreOpcode(SMSG_READ_ITEM_FAILED,             "SMSG_READ_ITEM_FAILED",            STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x0B0*/  StoreOpcode(SMSG_ITEM_COOLDOWN,                "SMSG_ITEM_COOLDOWN",               STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x0B1*/  StoreOpcode(CMSG_GAMEOBJ_USE,                  "CMSG_GAMEOBJ_USE",                 STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleGameObjectUseOpcode);
     /*0x0B2*/  StoreOpcode(CMSG_GAMEOBJ_CHAIR_USE_OBSOLETE,   "CMSG_GAMEOBJ_CHAIR_USE_OBSOLETE",  STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);

--- a/src/game/Server/Opcodes.cpp
+++ b/src/game/Server/Opcodes.cpp
@@ -369,10 +369,10 @@ void Opcodes::BuildOpcodeList()
     /*0x132*/  StoreOpcode(SMSG_SPELL_GO,                     "SMSG_SPELL_GO",                    STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x133*/  StoreOpcode(SMSG_SPELL_FAILURE,                "SMSG_SPELL_FAILURE",               STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x134*/  StoreOpcode(SMSG_SPELL_COOLDOWN,               "SMSG_SPELL_COOLDOWN",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
-    /*[-ZERO] Need check */ /*0x135*/  StoreOpcode(SMSG_COOLDOWN_EVENT,               "SMSG_COOLDOWN_EVENT",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x135*/  StoreOpcode(SMSG_COOLDOWN_EVENT,               "SMSG_COOLDOWN_EVENT",              STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*[-ZERO] Need check */ /*0x136*/  StoreOpcode(CMSG_CANCEL_AURA,                  "CMSG_CANCEL_AURA",                 STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleCancelAuraOpcode);
-    /*[-ZERO] Need check */ /*0x137*/  StoreOpcode(SMSG_UPDATE_AURA_DURATION,         "SMSG_UPDATE_AURA_DURATION",        STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
-    /*[-ZERO] Need check */ /*0x138*/  StoreOpcode(SMSG_PET_CAST_FAILED,              "SMSG_PET_CAST_FAILED",             STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x137*/  StoreOpcode(SMSG_UPDATE_AURA_DURATION,         "SMSG_UPDATE_AURA_DURATION",        STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
+    /*0x138*/  StoreOpcode(SMSG_PET_CAST_FAILED,              "SMSG_PET_CAST_FAILED",             STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_ServerSide);
     /*0x139*/  StoreOpcode(MSG_CHANNEL_START,                 "MSG_CHANNEL_START",                STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*0x13A*/  StoreOpcode(MSG_CHANNEL_UPDATE,                "MSG_CHANNEL_UPDATE",               STATUS_NEVER,     PROCESS_INPLACE,      &WorldSession::Handle_NULL);
     /*[-ZERO] Need check */ /*0x13B*/  StoreOpcode(CMSG_CANCEL_CHANNELLING,           "CMSG_CANCEL_CHANNELLING",          STATUS_LOGGEDIN,  PROCESS_THREADUNSAFE, &WorldSession::HandleCancelChanneling);

--- a/src/game/Server/SharedDefines.h
+++ b/src/game/Server/SharedDefines.h
@@ -2511,7 +2511,7 @@ enum TradeStatus
     TRADE_STATUS_TARGET_TO_FAR  = 10,
     TRADE_STATUS_WRONG_FACTION  = 11,
     TRADE_STATUS_CLOSE_WINDOW   = 12,
-    // 13?
+    TRADE_STATUS_UNKNOWN_13     = 13,                       // handled with TRADE_STATUS_TRADE_CANCELED
     TRADE_STATUS_IGNORE_YOU     = 14,
     TRADE_STATUS_YOU_STUNNED    = 15,
     TRADE_STATUS_TARGET_STUNNED = 16,
@@ -2520,8 +2520,7 @@ enum TradeStatus
     TRADE_STATUS_YOU_LOGOUT     = 19,
     TRADE_STATUS_TARGET_LOGOUT  = 20,
     TRADE_STATUS_TRIAL_ACCOUNT  = 21,                       // Trial accounts can not perform that action
-    TRADE_STATUS_WRONG_REALM    = 22,                       // You can only trade conjured items... (cross realm BG related).
-    TRADE_STATUS_NOT_ON_TAPLIST = 23
+    TRADE_STATUS_WRONG_REALM    = 22                        // You can only trade conjured items... (cross realm BG related).
 };
 
 enum WorldStateType

--- a/src/game/WorldHandlers/Spell.h
+++ b/src/game/WorldHandlers/Spell.h
@@ -367,7 +367,7 @@ class Spell
         void SendSpellGo();
         void SendSpellCooldown();
         void SendLogExecute();
-        void SendInterrupted(uint8 result);
+        void SendInterrupted(SpellCastResult result);
         void SendChannelUpdate(uint32 time);
         void SendChannelStart(uint32 duration);
         void SendResurrectRequest(Player* target);

--- a/src/game/WorldHandlers/TradeHandler.cpp
+++ b/src/game/WorldHandlers/TradeHandler.cpp
@@ -51,7 +51,6 @@ void WorldSession::SendTradeStatus(const TradeStatusInfo& info)
             data << uint32(info.ItemLimitCategoryId);       // ItemLimitCategory.dbc entry
             break;
         case TRADE_STATUS_WRONG_REALM:
-        case TRADE_STATUS_NOT_ON_TAPLIST:
             data << uint8(info.Slot);                       // Trade slot; -1 here clears CGTradeInfo::m_tradeMoney
             break;
         default:


### PR DESCRIPTION
1. A bit better description for SMSG_READ_ITEM_FAILED.
2. Minor cleaning of the `TradeStatus` constants for SMSG_TRADE_STATUS.
3. SMSG_SPELL_FAILURE contains actual `SpellCastResult`. Also, duplicating it with SMSG_SPELL_FAILED_OTHER is avoided now. It would be better to do not merge this with any other commit due to a possible revert. However, a basic local testing was done.
4. SMSG_PET_CAST_FAILED structure is fixed, though some details are left to work on. Just do not ask me about usage of the spells with checked restrictions :) The client handles it that way.


