### PR TITLE
Incomplete text should not be shown for completed quests

### DIFF
--- a/src/game/WorldHandlers/GossipDef.cpp
+++ b/src/game/WorldHandlers/GossipDef.cpp
@@ -726,8 +726,11 @@ void PlayerMenu::SendQuestGiverRequestItems(Quest const* pQuest, ObjectGuid npcG
         }
     }
 
-    // We may wish a better check, perhaps checking the real quest requirements
-    if (RequestItemsText.empty())
+    // Quests that don't require items use the RequestItemsText field to store the text
+    // that is shown when you talk to the quest giver while the quest is incomplete.
+    // Therefore the text should not be shown for them when the quest is complete.
+    // For quests that do require items, it is self explanatory.
+    if (RequestItemsText.empty() || (!pQuest->HasItemsRequirement() && Completable))
     {
         SendQuestGiverOfferReward(pQuest, npcGUID, true);
         return;

--- a/src/game/WorldHandlers/GossipDef.cpp
+++ b/src/game/WorldHandlers/GossipDef.cpp
@@ -730,7 +730,7 @@ void PlayerMenu::SendQuestGiverRequestItems(Quest const* pQuest, ObjectGuid npcG
     // that is shown when you talk to the quest giver while the quest is incomplete.
     // Therefore the text should not be shown for them when the quest is complete.
     // For quests that do require items, it is self explanatory.
-    if (RequestItemsText.empty() || (!pQuest->HasItemsRequirement() && Completable))
+    if (RequestItemsText.empty() || ((pQuest->GetReqItemsCount() == 0) && Completable))
     {
         SendQuestGiverOfferReward(pQuest, npcGUID, true);
         return;

--- a/src/game/WorldHandlers/QuestDef.h
+++ b/src/game/WorldHandlers/QuestDef.h
@@ -256,6 +256,7 @@ class Quest
         bool   IsRepeatable() const { return m_SpecialFlags & QUEST_SPECIAL_FLAG_REPEATABLE; }
         bool   IsAutoComplete() const { return QuestMethod ? false : true; }
         bool   IsAllowedInRaid() const;
+        bool   HasItemsRequirement() const { return (ReqItemId[0] || ReqItemId[1] || ReqItemId[2] || ReqItemId[03]); }
 
         // quest can be fully deactivated and will not be available for any player
         void SetQuestActiveState(bool state) { m_isActive = state; }

--- a/src/game/WorldHandlers/QuestDef.h
+++ b/src/game/WorldHandlers/QuestDef.h
@@ -256,7 +256,6 @@ class Quest
         bool   IsRepeatable() const { return m_SpecialFlags & QUEST_SPECIAL_FLAG_REPEATABLE; }
         bool   IsAutoComplete() const { return QuestMethod ? false : true; }
         bool   IsAllowedInRaid() const;
-        bool   HasItemsRequirement() const { return (ReqItemId[0] || ReqItemId[1] || ReqItemId[2] || ReqItemId[03]); }
 
         // quest can be fully deactivated and will not be available for any player
         void SetQuestActiveState(bool state) { m_isActive = state; }


### PR DESCRIPTION
This fixes incorrect behavior where the incomplete quest text was being shown for completed quests.

More information in the bug report - https://www.getmangos.eu/bug-tracker/mangos-zero/incomplete-quest-text-is-shown-for-completed-quests-r1406/