### PR TITLE
Command: debug recv

### DIFF
--- a/src/game/Tools/Language.h
+++ b/src/game/Tools/Language.h
@@ -582,7 +582,7 @@ enum MangosStrings
     LANG_YOURS_EXPLORE_SET_ALL          = 553,
     LANG_YOURS_EXPLORE_SET_NOTHING      = 554,
 
-    //                                    555,              // not used
+    LANG_COMMAND_OPCODEGOT              = 555,
     //                                    556,              // not used
     LANG_YOURS_LEVEL_UP                 = 557,
     LANG_YOURS_LEVEL_DOWN               = 558,

--- a/src/game/WorldHandlers/Chat.cpp
+++ b/src/game/WorldHandlers/Chat.cpp
@@ -224,6 +224,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "moditemvalue",   SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugModItemValueCommand,        "", NULL },
         { "modvalue",       SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugModValueCommand,            "", NULL },
         { "play",           SEC_MODERATOR,      false, NULL,                                                "", debugPlayCommandTable },
+        { "recv",           SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugRecvOpcodeCommand,          "", NULL },
         { "send",           SEC_ADMINISTRATOR,  false, NULL,                                                "", debugSendCommandTable },
         { "setaurastate",   SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugSetAuraStateCommand,        "", NULL },
         { "setitemvalue",   SEC_ADMINISTRATOR,  false, &ChatHandler::HandleDebugSetItemValueCommand,        "", NULL },

--- a/src/game/WorldHandlers/Chat.h
+++ b/src/game/WorldHandlers/Chat.h
@@ -226,6 +226,7 @@ class ChatHandler
         bool HandleDebugPlayCinematicCommand(char* args);
         bool HandleDebugPlaySoundCommand(char* args);
 
+        bool HandleDebugRecvOpcodeCommand(char* args);
         bool HandleDebugSendBuyErrorCommand(char* args);
         bool HandleDebugSendChannelNotifyCommand(char* args);
         bool HandleDebugSendChatMsgCommand(char* args);

--- a/src/shared/revision.h
+++ b/src/shared/revision.h
@@ -38,6 +38,6 @@
 
     #define WORLD_DB_VERSION_NR 21
     #define WORLD_DB_STRUCTURE_NR 14
-    #define WORLD_DB_CONTENT_NR 14
-    #define WORLD_DB_UPDATE_DESCRIPTION "Script_Binding"
+    #define WORLD_DB_CONTENT_NR 58
+    #define WORLD_DB_UPDATE_DESCRIPTION "debug recv Command"
 #endif // __REVISION_H__


### PR DESCRIPTION
Places the packet described in the ropcode.txt server-side file into own packet queue (counterpart of debug send opcode).
It means the server "receives" the opcode from the player used this command. It is much more convenient for testing than forging the CMSG packet clientside with a cheat engine.
The DB update is encouraged. Note also some additional allowed field types in the packet description, both for recv and send opcode.