### PR TITLE
Using /who in a Battleground should only list players in the same instance.

### DIFF
--- a/src/game/WorldHandlers/MiscHandler.cpp
+++ b/src/game/WorldHandlers/MiscHandler.cpp
@@ -148,6 +148,9 @@ void WorldSession::HandleWhoOpcode(WorldPacket& recv_data)
     bool allowTwoSideWhoList = sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_WHO_LIST);
     AccountTypes gmLevelInWhoList = (AccountTypes)sWorld.getConfig(CONFIG_UINT32_GM_LEVEL_IN_WHO_LIST);
 
+    const uint32 zone = _player->GetCachedZoneId();
+    const bool notInBattleground = !((zone == 2597) || (zone == 3277) || (zone == 3358));
+
     uint32 matchcount = 0;
     uint32 displaycount = 0;
 
@@ -202,7 +205,9 @@ void WorldSession::HandleWhoOpcode(WorldPacket& recv_data)
         {
             if (zoneids[i] == pzoneid)
             {
-                z_show = true;
+                // World of Warcraft Client Patch 1.7.0 (2005-09-13)
+                // Using the / who command while in a Battleground instance will now only display players in your instance.
+                z_show = (zone != pzoneid) || notInBattleground || (_player->GetInstanceId() == pl->GetInstanceId());
                 break;
             }
 


### PR DESCRIPTION
If you type /who while in a battleground, it should only list people who are in the same instance of the battleground. This has been a thing since patch 1.7.0, and it was mentioned in the patch notes.

> World of Warcraft Client Patch 1.7.0 (2005-09-13)
> - Using the / who command while in a Battleground instance will now only display players in your instance.