### PR TITLE
Add game event hooks and update eluna version

### DIFF
--- a/src/game/WorldHandlers/GameEventMgr.cpp
+++ b/src/game/WorldHandlers/GameEventMgr.cpp
@@ -34,6 +34,7 @@
 #include "BattleGround/BattleGroundMgr.h"
 #include "MassMailMgr.h"
 #include "Policies/Singleton.h"
+#include "LuaEngine.h"
 
 INSTANTIATE_SINGLETON_1(GameEventMgr);
 
@@ -82,6 +83,8 @@ void GameEventMgr::StartEvent(uint16 event_id, bool overwrite /*=false*/, bool r
         if (mGameEvent[event_id].end <= mGameEvent[event_id].start)
             { mGameEvent[event_id].end = mGameEvent[event_id].start + mGameEvent[event_id].length; }
     }
+    if (IsActiveEvent(event_id))
+        sEluna->OnGameEventStart(event_id);
 }
 
 void GameEventMgr::StopEvent(uint16 event_id, bool overwrite)
@@ -93,6 +96,8 @@ void GameEventMgr::StopEvent(uint16 event_id, bool overwrite)
         if (mGameEvent[event_id].end <= mGameEvent[event_id].start)
             { mGameEvent[event_id].end = mGameEvent[event_id].start + mGameEvent[event_id].length; }
     }
+    if (!IsActiveEvent(event_id))
+        sEluna->OnGameEventStop(event_id);
 }
 
 void GameEventMgr::LoadFromDB()


### PR DESCRIPTION
Adds a game event start and stop hook to Eluna.
Also updates Eluna version.
For mangoszero you can see what was changed in here: https://github.com/elunaluaengine/eluna/compare/00eef91aa2acd95719a18c6c6b1bb03d8b4919fe...cd5a55522574b9d74f7abb32cd8512b1d4234753

Todo:
- [ ] apply this PR to other mangos cores