### PR TITLE
Fix wrong guid being sent in HandleQuestPushResult.

### DIFF
--- a/src/game/WorldHandlers/QuestHandler.cpp
+++ b/src/game/WorldHandlers/QuestHandler.cpp
@@ -490,7 +490,7 @@ void WorldSession::HandleQuestPushResult(WorldPacket& recvPacket)
     if (Player* pPlayer = ObjectAccessor::FindPlayer(_player->GetDividerGuid()))
     {
         WorldPacket data(MSG_QUEST_PUSH_RESULT, (8 + 1));
-        data << ObjectGuid(guid);
+        data << _player->GetObjectGuid();
         data << uint8(msg);               // enum QuestShareMessages
         pPlayer->GetSession()->SendPacket(&data);
         _player->ClearDividerGuid();


### PR DESCRIPTION
When the client sends MSG_QUEST_PUSH_RESULT to the server it contains the guid of the player to which the result should be forwarded. Currently that player is being sent his own guid instead of the guid of the player who sent the original packet. This fixes the bug where it tells you that you've declined your own quest or that you yourself are busy instead of the actual name of the person.

Before:
![before](https://user-images.githubusercontent.com/6519171/31635198-9ddcbde4-b2ce-11e7-8d0f-78d0d583edf4.jpg)

After:
![after](https://user-images.githubusercontent.com/6519171/31635203-a16114d8-b2ce-11e7-9528-95ce2d7f828f.jpg)
