### PR TITLE
ReputationMgr: set and clear AtWar flag appropriately

### DIFF
--- a/src/game/Object/ReputationMgr.cpp
+++ b/src/game/Object/ReputationMgr.cpp
@@ -293,8 +293,9 @@ bool ReputationMgr::SetOneFactionReputation(FactionEntry const* factionEntry, in
 
         SetVisible(&faction);
 
-        if (ReputationToRank(standing) <= REP_HOSTILE)
-            { SetAtWar(&itr->second, true); }
+        // check and, if needed, modify AtWar flag every rep rank crossing
+        if (ReputationToRank(standing) != ReputationToRank(BaseRep))
+            SetAtWar(&itr->second, ReputationToRank(standing) <= REP_HOSTILE);
 
         m_player->ReputationChanged(factionEntry);
 
@@ -369,12 +370,12 @@ void ReputationMgr::SetAtWar(FactionState* faction, bool atWar)
     else
         { faction->Flags &= ~FACTION_FLAG_AT_WAR; }
 
-    WorldPacket data(SMSG_SET_FACTION_ATWAR, 4 + 1);
-    data << uint32(faction->ID);
-    data << uint8(faction->Flags & FACTION_FLAG_AT_WAR);    // the client tests only FACTION_FLAG_AT_WAR
-    m_player->SendDirectMessage(&data);
+    //WorldPacket data(SMSG_SET_FACTION_ATWAR, 4 + 1);
+    //data << uint32(faction->ID);
+    //data << uint8(faction->Flags & FACTION_FLAG_AT_WAR);    // the client tests only FACTION_FLAG_AT_WAR
+    //m_player->SendDirectMessage(&data);
 
-    faction->needSend = false;
+    faction->needSend = true;
     faction->needSave = true;
 }
 

--- a/src/shared/revision.h
+++ b/src/shared/revision.h
@@ -38,6 +38,6 @@
 
     #define WORLD_DB_VERSION_NR 21
     #define WORLD_DB_STRUCTURE_NR 14
-    #define WORLD_DB_CONTENT_NR 67
-    #define WORLD_DB_UPDATE_DESCRIPTION "kodo roundup tidyup"
+    #define WORLD_DB_CONTENT_NR 77
+    #define WORLD_DB_UPDATE_DESCRIPTION "lower_npc_text_id"
 #endif // __REVISION_H__


### PR DESCRIPTION
1. Stop sending SMSG_SET_FACTION_ATWAR, it does not actually set AtWar flag but causes a crash at some weird rep use (like GM fly path cheat). The packet structure is left commented out.
2. Handle auto-change of AtWar flag when the rep crosses Hostile/Unfriendly border in either direction. Sure the implemented condition check may be more precise.
3. Update world DB version bind to the current DB update.