### PR TITLE
Fixes daze absorb and duplicate target flags

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -1767,43 +1767,28 @@ void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
     DealDamage(pVictim, damageInfo->damage, &cleanDamage, DIRECT_DAMAGE, SpellSchoolMask(damageInfo->damageSchoolMask), NULL, durabilityLoss);
 
     // If this is a creature and it attacks from behind it has a probability to daze it's victim
-	if ((damageInfo->hitOutCome == MELEE_HIT_CRIT || damageInfo->hitOutCome == MELEE_HIT_CRUSHING || damageInfo->hitOutCome == MELEE_HIT_NORMAL || damageInfo->hitOutCome == MELEE_HIT_GLANCING) &&
-		GetTypeId() != TYPEID_PLAYER && !((Creature*)this)->GetCharmerOrOwnerGuid() && !pVictim->HasInArc(M_PI_F, this))
-	{
-		// -probability is between 0% and 40%
-		// 20% base chance
-		float Probability = 20.0f;
+    if ((damageInfo->hitOutCome == MELEE_HIT_CRIT || damageInfo->hitOutCome == MELEE_HIT_CRUSHING || damageInfo->hitOutCome == MELEE_HIT_NORMAL || damageInfo->hitOutCome == MELEE_HIT_GLANCING) &&
+        GetTypeId() != TYPEID_PLAYER && !((Creature*)this)->GetCharmerOrOwnerGuid() && !pVictim->HasInArc(M_PI_F, this))
+    {
+        // -probability is between 0% and 40%
+        // 20% base chance
+        float Probability = 20.0f;
 
-		// Probability is 0 if they absorb
-		if (damageInfo->absorb)
-		{
-			Probability = 0.0f;
-		}
-		else
-		{
-			// there is a newbie protection, at level 10 just 7% base chance; assuming linear function
-			if (pVictim->getLevel() < 30)
-			{
-				Probability = 0.65f * pVictim->getLevel() + 0.5f;
-			}
+        // there is a newbie protection, at level 10 just 7% base chance; assuming linear function
+        if (pVictim->getLevel() < 30)
+            { Probability = 0.65f * pVictim->getLevel() + 0.5f; }
 
-			uint32 VictimDefense = pVictim->GetDefenseSkillValue();
-			uint32 AttackerMeleeSkill = GetUnitMeleeSkill();
+        uint32 VictimDefense = pVictim->GetDefenseSkillValue();
+        uint32 AttackerMeleeSkill = GetUnitMeleeSkill();
 
-			Probability *= AttackerMeleeSkill / (float)VictimDefense;
+        Probability *= AttackerMeleeSkill / (float)VictimDefense;
 
-			if (Probability > 40.0f)
-			{
-				Probability = 40.0f;
-			}
+        if (Probability > 40.0f)
+            { Probability = 40.0f; }
 
-			if (roll_chance_f(Probability))
-			{
-				CastSpell(pVictim, 1604, true);
-			}
-
-		}
-	}
+        if (roll_chance_f(Probability))
+            { CastSpell(pVictim, 1604, true); }
+    }
 
     // update at damage Judgement aura duration that applied by attacker at victim
     if (damageInfo->damage)

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -1767,28 +1767,43 @@ void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
     DealDamage(pVictim, damageInfo->damage, &cleanDamage, DIRECT_DAMAGE, SpellSchoolMask(damageInfo->damageSchoolMask), NULL, durabilityLoss);
 
     // If this is a creature and it attacks from behind it has a probability to daze it's victim
-    if ((damageInfo->hitOutCome == MELEE_HIT_CRIT || damageInfo->hitOutCome == MELEE_HIT_CRUSHING || damageInfo->hitOutCome == MELEE_HIT_NORMAL || damageInfo->hitOutCome == MELEE_HIT_GLANCING) &&
-        GetTypeId() != TYPEID_PLAYER && !((Creature*)this)->GetCharmerOrOwnerGuid() && !pVictim->HasInArc(M_PI_F, this))
-    {
-        // -probability is between 0% and 40%
-        // 20% base chance
-        float Probability = 20.0f;
+	if ((damageInfo->hitOutCome == MELEE_HIT_CRIT || damageInfo->hitOutCome == MELEE_HIT_CRUSHING || damageInfo->hitOutCome == MELEE_HIT_NORMAL || damageInfo->hitOutCome == MELEE_HIT_GLANCING) &&
+		GetTypeId() != TYPEID_PLAYER && !((Creature*)this)->GetCharmerOrOwnerGuid() && !pVictim->HasInArc(M_PI_F, this))
+	{
+		// -probability is between 0% and 40%
+		// 20% base chance
+		float Probability = 20.0f;
 
-        // there is a newbie protection, at level 10 just 7% base chance; assuming linear function
-        if (pVictim->getLevel() < 30)
-            { Probability = 0.65f * pVictim->getLevel() + 0.5f; }
+		// Probability is 0 if they absorb
+		if (damageInfo->absorb)
+		{
+			Probability = 0.0f;
+		}
+		else
+		{
+			// there is a newbie protection, at level 10 just 7% base chance; assuming linear function
+			if (pVictim->getLevel() < 30)
+			{
+				Probability = 0.65f * pVictim->getLevel() + 0.5f;
+			}
 
-        uint32 VictimDefense = pVictim->GetDefenseSkillValue();
-        uint32 AttackerMeleeSkill = GetUnitMeleeSkill();
+			uint32 VictimDefense = pVictim->GetDefenseSkillValue();
+			uint32 AttackerMeleeSkill = GetUnitMeleeSkill();
 
-        Probability *= AttackerMeleeSkill / (float)VictimDefense;
+			Probability *= AttackerMeleeSkill / (float)VictimDefense;
 
-        if (Probability > 40.0f)
-            { Probability = 40.0f; }
+			if (Probability > 40.0f)
+			{
+				Probability = 40.0f;
+			}
 
-        if (roll_chance_f(Probability))
-            { CastSpell(pVictim, 1604, true); }
-    }
+			if (roll_chance_f(Probability))
+			{
+				CastSpell(pVictim, 1604, true);
+			}
+
+		}
+	}
 
     // update at damage Judgement aura duration that applied by attacker at victim
     if (damageInfo->damage)

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -1767,28 +1767,35 @@ void Unit::DealMeleeDamage(CalcDamageInfo* damageInfo, bool durabilityLoss)
     DealDamage(pVictim, damageInfo->damage, &cleanDamage, DIRECT_DAMAGE, SpellSchoolMask(damageInfo->damageSchoolMask), NULL, durabilityLoss);
 
     // If this is a creature and it attacks from behind it has a probability to daze it's victim
-    if ((damageInfo->hitOutCome == MELEE_HIT_CRIT || damageInfo->hitOutCome == MELEE_HIT_CRUSHING || damageInfo->hitOutCome == MELEE_HIT_NORMAL || damageInfo->hitOutCome == MELEE_HIT_GLANCING) &&
-        GetTypeId() != TYPEID_PLAYER && !((Creature*)this)->GetCharmerOrOwnerGuid() && !pVictim->HasInArc(M_PI_F, this))
-    {
-        // -probability is between 0% and 40%
-        // 20% base chance
-        float Probability = 20.0f;
+	if ((!damageInfo->absorb) && (damageInfo->hitOutCome == MELEE_HIT_CRIT || damageInfo->hitOutCome == MELEE_HIT_CRUSHING || damageInfo->hitOutCome == MELEE_HIT_NORMAL || damageInfo->hitOutCome == MELEE_HIT_GLANCING) &&
+		GetTypeId() != TYPEID_PLAYER && !((Creature*)this)->GetCharmerOrOwnerGuid() && !pVictim->HasInArc(M_PI_F, this))
+	{
+		// -probability is between 0% and 40%
+		// 20% base chance
+		float Probability = 20.0f;
 
-        // there is a newbie protection, at level 10 just 7% base chance; assuming linear function
-        if (pVictim->getLevel() < 30)
-            { Probability = 0.65f * pVictim->getLevel() + 0.5f; }
+			// there is a newbie protection, at level 10 just 7% base chance; assuming linear function
+			if (pVictim->getLevel() < 30)
+			{
+				Probability = 0.65f * pVictim->getLevel() + 0.5f;
+			}
 
-        uint32 VictimDefense = pVictim->GetDefenseSkillValue();
-        uint32 AttackerMeleeSkill = GetUnitMeleeSkill();
+			uint32 VictimDefense = pVictim->GetDefenseSkillValue();
+			uint32 AttackerMeleeSkill = GetUnitMeleeSkill();
 
-        Probability *= AttackerMeleeSkill / (float)VictimDefense;
+			Probability *= AttackerMeleeSkill / (float)VictimDefense;
 
-        if (Probability > 40.0f)
-            { Probability = 40.0f; }
+			if (Probability > 40.0f)
+			{
+				Probability = 40.0f;
+			}
 
-        if (roll_chance_f(Probability))
-            { CastSpell(pVictim, 1604, true); }
-    }
+			if (roll_chance_f(Probability))
+			{
+				CastSpell(pVictim, 1604, true);
+			}
+
+		}
 
     // update at damage Judgement aura duration that applied by attacker at victim
     if (damageInfo->damage)

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -4980,7 +4980,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                         { return SPELL_FAILED_ALREADY_OPEN; }
 
                     // Is the lock within the spell max range?
-                    if (!IsLockInRange(go) && (go->GetGoType() != GAMEOBJECT_TYPE_DOOR || GAMEOBJECT_TYPE_BUTTON || GAMEOBJECT_TYPE_QUESTGIVER || GAMEOBJECT_TYPE_CHEST || GAMEOBJECT_TYPE_GOOBER || GAMEOBJECT_TYPE_FLAGSTAND || GAMEOBJECT_TYPE_FLAGDROP))
+                    if (!IsLockInRange(go))
                         { return SPELL_FAILED_OUT_OF_RANGE; }
                 }
                 else if (Item* item = m_targets.getItemTarget())

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -1575,11 +1575,17 @@ void Spell::SetTargetMap(SpellEffectIndex effIndex, uint32 targetMode, UnitList&
                     Cell::VisitAllObjects(m_caster, searcher, max_range);
                     break;
                 }
-				case TARGET_RANDOM_UNIT_CHAIN_IN_AREA: // This works the same as Target_random_friend_chain_in_area but is named differently for some reason
                 case TARGET_RANDOM_FRIEND_CHAIN_IN_AREA:
                 {
                     MaNGOS::AnyFriendlyUnitInObjectRangeCheck u_check(m_caster, max_range);
                     MaNGOS::UnitListSearcher<MaNGOS::AnyFriendlyUnitInObjectRangeCheck> searcher(tempTargetUnitMap, u_check);
+                    Cell::VisitAllObjects(m_caster, searcher, max_range);
+                    break;
+                }
+                case TARGET_RANDOM_UNIT_CHAIN_IN_AREA:
+                {
+                    MaNGOS::AnyUnitInObjectRangeCheck u_check(m_caster, max_range);
+                    MaNGOS::UnitListSearcher<MaNGOS::AnyUnitInObjectRangeCheck> searcher(tempTargetUnitMap, u_check);
                     Cell::VisitAllObjects(m_caster, searcher, max_range);
                     break;
                 }

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -4974,7 +4974,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                         { return SPELL_FAILED_ALREADY_OPEN; }
 
                     // Is the lock within the spell max range?
-                    if (!IsLockInRange(go))
+                    if (!IsLockInRange(go) && go->GetGoType() != GAMEOBJECT_TYPE_CHEST)
                         { return SPELL_FAILED_OUT_OF_RANGE; }
                 }
                 else if (Item* item = m_targets.getItemTarget())

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -4974,7 +4974,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                         { return SPELL_FAILED_ALREADY_OPEN; }
 
                     // Is the lock within the spell max range?
-                    if (!IsLockInRange(go))
+                    if (!IsLockInRange(go) && (go->GetGoType() != GAMEOBJECT_TYPE_DOOR || GAMEOBJECT_TYPE_BUTTON || GAMEOBJECT_TYPE_QUESTGIVER || GAMEOBJECT_TYPE_CHEST || GAMEOBJECT_TYPE_GOOBER || GAMEOBJECT_TYPE_FLAGSTAND || GAMEOBJECT_TYPE_FLAGDROP))
                         { return SPELL_FAILED_OUT_OF_RANGE; }
                 }
                 else if (Item* item = m_targets.getItemTarget())

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -4974,7 +4974,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                         { return SPELL_FAILED_ALREADY_OPEN; }
 
                     // Is the lock within the spell max range?
-                    if (!IsLockInRange(go) && go->GetGoType() != GAMEOBJECT_TYPE_CHEST)
+                    if (!IsLockInRange(go))
                         { return SPELL_FAILED_OUT_OF_RANGE; }
                 }
                 else if (Item* item = m_targets.getItemTarget())

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -1575,17 +1575,11 @@ void Spell::SetTargetMap(SpellEffectIndex effIndex, uint32 targetMode, UnitList&
                     Cell::VisitAllObjects(m_caster, searcher, max_range);
                     break;
                 }
+				case TARGET_RANDOM_UNIT_CHAIN_IN_AREA: // This works the same as Target_random_friend_chain_in_area but is named differently for some reason
                 case TARGET_RANDOM_FRIEND_CHAIN_IN_AREA:
                 {
                     MaNGOS::AnyFriendlyUnitInObjectRangeCheck u_check(m_caster, max_range);
                     MaNGOS::UnitListSearcher<MaNGOS::AnyFriendlyUnitInObjectRangeCheck> searcher(tempTargetUnitMap, u_check);
-                    Cell::VisitAllObjects(m_caster, searcher, max_range);
-                    break;
-                }
-                case TARGET_RANDOM_UNIT_CHAIN_IN_AREA:
-                {
-                    MaNGOS::AnyUnitInObjectRangeCheck u_check(m_caster, max_range);
-                    MaNGOS::UnitListSearcher<MaNGOS::AnyUnitInObjectRangeCheck> searcher(tempTargetUnitMap, u_check);
                     Cell::VisitAllObjects(m_caster, searcher, max_range);
                     break;
                 }

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -1575,17 +1575,11 @@ void Spell::SetTargetMap(SpellEffectIndex effIndex, uint32 targetMode, UnitList&
                     Cell::VisitAllObjects(m_caster, searcher, max_range);
                     break;
                 }
+				case TARGET_RANDOM_UNIT_CHAIN_IN_AREA: // This works the same as Target_random_friend_chain_in_area but is named differently for some reason
                 case TARGET_RANDOM_FRIEND_CHAIN_IN_AREA:
                 {
                     MaNGOS::AnyFriendlyUnitInObjectRangeCheck u_check(m_caster, max_range);
                     MaNGOS::UnitListSearcher<MaNGOS::AnyFriendlyUnitInObjectRangeCheck> searcher(tempTargetUnitMap, u_check);
-                    Cell::VisitAllObjects(m_caster, searcher, max_range);
-                    break;
-                }
-                case TARGET_RANDOM_UNIT_CHAIN_IN_AREA:
-                {
-                    MaNGOS::AnyUnitInObjectRangeCheck u_check(m_caster, max_range);
-                    MaNGOS::UnitListSearcher<MaNGOS::AnyUnitInObjectRangeCheck> searcher(tempTargetUnitMap, u_check);
                     Cell::VisitAllObjects(m_caster, searcher, max_range);
                     break;
                 }
@@ -4980,7 +4974,7 @@ SpellCastResult Spell::CheckCast(bool strict)
                         { return SPELL_FAILED_ALREADY_OPEN; }
 
                     // Is the lock within the spell max range?
-                    if (!IsLockInRange(go))
+                    if (!IsLockInRange(go) && go->GetGoType() == GAMEOBJECT_TYPE_TRAP)
                         { return SPELL_FAILED_OUT_OF_RANGE; }
                 }
                 else if (Item* item = m_targets.getItemTarget())


### PR DESCRIPTION
Fixes Daze effect applying on shielded tagets that absorb the damage. Also fixes a target type that had a broken function that was identical to another(Fixes Nightlash)

Fixes these two bugs for sure(possibly some others, but unknown at this time.)
https://www.getmangos.eu/bug-tracker/mangos-zero/Daze-state-is-applied-incorrec-r752/

https://www.getmangos.eu/bug-tracker/mangos-zero/Nightlash-hurt-too-high-spike--r1065/