### PR TITLE
Changed email return for item that can't be equiped anymore. 

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -14833,11 +14833,11 @@ void Player::_LoadInventory(QueryResult* result, uint32 timediff)
         // send by mail problematic items
         while (!problematicItems.empty())
         {
-            std::string subject = GetSession()->GetMangosString(LANG_NOT_EQUIPPED_ITEM);
-
+			std::string subject = "Item could not be loaded to inventory.";
+			std::string content = GetSession()->GetMangosString(LANG_NOT_EQUIPPED_ITEM);
             // fill mail
             MailDraft draft(subject);
-
+			draft.SetSubjectAndBody(subject,content); 
             for (int i = 0; !problematicItems.empty() && i < MAX_MAIL_ITEMS; ++i)
             {
                 Item* item = problematicItems.front();


### PR DESCRIPTION
Before the email was sent with an empty body and the subject was to long to be displayed in the player email. Now the Email is sent with the subject 'Item could not be loaded to inventory.' and the body as the subject message before.