### PR TITLE
File location fix for getmangos.sh - MMap generation

### DIFF
--- a/linux/getmangos.sh
+++ b/linux/getmangos.sh
@@ -1417,9 +1417,9 @@ function ExtractResources
         Log "Copying MMaps extractor" 0
         rm -f "$GAMEPATH/MoveMapGen.sh"
         cp "$INSTPATH/bin/tools/MoveMapGen.sh" "$GAMEPATH"
-        cp "$INSTPATH/bin/tools/offmesh.txt" "$GAMEPATH"
-        cp "$INSTPATH/bin/tools/mmap_excluded.txt" "$GAMEPATH"
-        cp "$INSTPATH/bin/tools/mmap-extractor" "$GAMEPATH"
+        cp "$INSTPATH/bin/offmesh.txt" "$GAMEPATH"
+        cp "$INSTPATH/bin/mmap_excluded.txt" "$GAMEPATH"
+        cp "$INSTPATH/bin/mmap-extractor" "$GAMEPATH"
 
         CPU=$($DLGAPP --backtitle "MaNGOS Linux Build Configuration" --title "Please provide the number of CPU to be used to generate MMaps (1-4)" \
          --inputbox "Default: 1" 8 80 3>&2 2>&1 1>&3)
@@ -1473,9 +1473,9 @@ function ExtractResources
 	Log "Copying MMaps extractor" 0
         rm -f "$GAMEPATH/MoveMapGen.sh"
         cp "$INSTPATH/bin/tools/MoveMapGen.sh" "$GAMEPATH"
-        cp "$INSTPATH/bin/tools/offmesh.txt" "$GAMEPATH"
-        cp "$INSTPATH/bin/tools/mmap_excluded.txt" "$GAMEPATH"
-        cp "$INSTPATH/bin/tools/mmap-extractor" "$GAMEPATH"
+        cp "$INSTPATH/bin/offmesh.txt" "$GAMEPATH"
+        cp "$INSTPATH/bin/mmap_excluded.txt" "$GAMEPATH"
+        cp "$INSTPATH/bin/mmap-extractor" "$GAMEPATH"
 	CPU=$($DLGAPP --backtitle "MaNGOS Linux Build Configuration" --title "Please provide the number of CPU to be used to generate MMaps (1-4)" \
          --inputbox "Default: 1" 8 80 3>&2 2>&1 1>&3)
 

--- a/linux/getmangos.sh
+++ b/linux/getmangos.sh
@@ -1416,10 +1416,10 @@ function ExtractResources
 
         Log "Copying MMaps extractor" 0
         rm -f "$GAMEPATH/MoveMapGen.sh"
-        cp "$INSTPATH/bin/tools/MoveMapGen.sh" "$GAMEPATH"
+        cp "$INSTPATH/bin/MoveMapGen.sh" "$GAMEPATH"
         cp "$INSTPATH/bin/offmesh.txt" "$GAMEPATH"
         cp "$INSTPATH/bin/mmap_excluded.txt" "$GAMEPATH"
-        cp "$INSTPATH/bin/mmap-extractor" "$GAMEPATH"
+        cp "$INSTPATH/bin/tools/mmap-extractor" "$GAMEPATH"
 
         CPU=$($DLGAPP --backtitle "MaNGOS Linux Build Configuration" --title "Please provide the number of CPU to be used to generate MMaps (1-4)" \
          --inputbox "Default: 1" 8 80 3>&2 2>&1 1>&3)
@@ -1472,10 +1472,10 @@ function ExtractResources
     else
 	Log "Copying MMaps extractor" 0
         rm -f "$GAMEPATH/MoveMapGen.sh"
-        cp "$INSTPATH/bin/tools/MoveMapGen.sh" "$GAMEPATH"
+        cp "$INSTPATH/bin/MoveMapGen.sh" "$GAMEPATH"
         cp "$INSTPATH/bin/offmesh.txt" "$GAMEPATH"
         cp "$INSTPATH/bin/mmap_excluded.txt" "$GAMEPATH"
-        cp "$INSTPATH/bin/mmap-extractor" "$GAMEPATH"
+        cp "$INSTPATH/bin/tools/mmap-extractor" "$GAMEPATH"
 	CPU=$($DLGAPP --backtitle "MaNGOS Linux Build Configuration" --title "Please provide the number of CPU to be used to generate MMaps (1-4)" \
          --inputbox "Default: 1" 8 80 3>&2 2>&1 1>&3)
 


### PR DESCRIPTION
The getmangos.sh script fails in my Gentoo box in the MMap generation step.
I have found that the location of 3 files (mmap_excluded.txt, MoveMapGen.sh and offmesh.txt) differs.

This PR bundles the change of these 3 locations, and the script has run fine in my machine.

Please test this change, since I don't know if this is reproduced in other environments.

Regards,

krequena.