### PR TITLE
Adjust the source code and build enviornment so that Mangos Zero will…

### DIFF
--- a/src/shared/Database/SQLStorageImpl.h
+++ b/src/shared/Database/SQLStorageImpl.h
@@ -40,6 +40,14 @@ template<class S, class D>
  */
 void SQLStorageLoaderBase<DerivedLoader, StorageClass>::convert(uint32 /*field_pos*/, S src, D& dst)
 {
+#if defined(__arm__)
+    if (((unsigned) &dst) % sizeof(D)) {
+        //The address is not aligned. Use memcpy to avoid ARM unaligned trap
+       D converted(src);
+       memcpy((void*) &dst, (void*) &converted, sizeof(D));
+    }
+    else
+#endif
     dst = D(src);
 }
 
@@ -92,6 +100,14 @@ template<class D>
  */
 void SQLStorageLoaderBase<DerivedLoader, StorageClass>::convert_from_str(uint32 /*field_pos*/, char const* /*src*/, D& dst)
 {
+#if defined(__arm__)
+    if (((unsigned) &dst) % sizeof(D)) {
+       //The address is not aligned. Use memcpy to avoid ARM unaligned trap
+       D converted(0);
+       memcpy((void*) &dst, (void*) &converted, sizeof(D));
+    }
+    else
+#endif
     dst = 0;
 }
 
@@ -106,6 +122,14 @@ template<class S, class D>
  */
 void SQLStorageLoaderBase<DerivedLoader, StorageClass>::default_fill(uint32 /*field_pos*/, S src, D& dst)
 {
+#if defined(__arm__)
+    if (((unsigned) &dst) % sizeof(D)) {
+       //The address is not aligned. Use memcpy to avoid ARM unaligned trap
+       D converted(src);
+       memcpy((void*) &dst, (void*) &converted, sizeof(D));
+    }
+    else
+#endif
     dst = D(src);
 }
 

--- a/src/shared/Utilities/ByteBuffer.h
+++ b/src/shared/Utilities/ByteBuffer.h
@@ -534,7 +534,13 @@ class ByteBuffer
         {
             if (pos + sizeof(T) > size())
                 { throw ByteBufferException(false, pos, sizeof(T), size()); }
+#if defined(__arm__)
+            // ARM has alignment issues, we need to use memcpy to avoid them
+            T val;
+            memcpy((void*)&val, (void*)&_storage[pos], sizeof(T));
+#else
             T val = *((T const*)&_storage[pos]);
+#endif
             EndianConvert(val);
             return val;
         }


### PR DESCRIPTION
… build on ARM.

Note, this commit depends on the following pull request to mangosDeps:

  https://github.com/mangos/mangosDeps/pull/20

This was primarily done to test the feasibility of running on a RPi4 running
Debian Buster (it works quite well).

Summary of changes:

  - Reworked patches I found on the Mangos forum, original pastebins here:
      https://pastebin.com/BxqCmCML
  - Adjusted cmake's arch detection to include ARM32/ARM64
  - Adjusted compiler flags for Linux builds and suppressed some extraneous notes

I have played for about an hour and noticed no issues or differences from i386/x86_64 VMs.
