### PR TITLE
Partial fix for .gm fly command

### DIFF
--- a/src/game/ChatCommands/Level3.cpp
+++ b/src/game/ChatCommands/Level3.cpp
@@ -6161,10 +6161,8 @@ bool ChatHandler::HandleGMFlyCommand(char* args)
     }
 
     // [-ZERO] Need reimplement in another way
-    {
-        SendSysMessage(LANG_USE_BOL);
-        return false;
-    }
+    // GM fly wil be achieved with the swimming moveflag
+    // Warning : Still buggy when Jump
     target->SetCanFly(value);
     PSendSysMessage(LANG_COMMAND_FLYMODE_STATUS, GetNameLink(target).c_str(), args);
     return true;

--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -4671,10 +4671,19 @@ void Player::SetLevitate(bool /*enable*/)
     // SendMessageToSet(&data, false);
 }
 
-void Player::SetCanFly(bool /*enable*/)
+void Player::SetCanFly(bool enable)
 {
-//     TODO: check if there is something similar for 1.12.x (99% chance there is not)
-
+    //     TODO: check if there is something similar for 1.12.x (99% chance there is not)
+    if (enable) 
+    {
+        m_movementInfo.SetMovementFlags((MovementFlags)(MOVEFLAG_LEVITATING | MOVEFLAG_SWIMMING | MOVEFLAG_CAN_FLY | MOVEFLAG_FLYING));
+    }
+    else
+    {
+        m_movementInfo.SetMovementFlags(MOVEFLAG_NONE);
+    }
+    
+    SendHeartBeat();
 }
 
 void Player::SetFeatherFall(bool enable)


### PR DESCRIPTION
Allow GM to use .gm fly on 1.12
Warning, there is still a buggy behaviour when jumping but can be easily stopped having a macro with .gm fly on :)
Very useful for exploring zones