### PR TITLE
Fix .send mail and .send item commands

### DIFF
--- a/src/game/ChatCommands/Level1.cpp
+++ b/src/game/ChatCommands/Level1.cpp
@@ -1862,6 +1862,11 @@ bool ChatHandler::HandleSaveAllCommand(char* /*args*/)
 // Send mail by command
 bool ChatHandler::HandleSendMailCommand(char* args)
 {
+    if (!*args)
+    {
+        return false;
+    }
+
     // format: name "subject text" "mail text"
     Player* target;
     ObjectGuid target_guid;
@@ -1873,14 +1878,23 @@ bool ChatHandler::HandleSendMailCommand(char* args)
 
     MailDraft draft;
 
-    // fill draft
-    if (!HandleSendMailHelper(draft, args))
+    // Subject and content should not be empty : 
+    if (!*args)
     {
         return false;
     }
+    else
+    {
+        // fill draft
+        if (!HandleSendMailHelper(draft, args))
+        {
+            return false;
+        }
+    }
 
+    
     // GM mail
-    MailSender sender(MAIL_NORMAL, (uint32)0, MAIL_STATIONERY_GM);
+    MailSender sender(MAIL_NORMAL, m_session ? m_session->GetPlayer()->GetGUIDLow() : (uint32)0, MAIL_STATIONERY_GM);
 
     draft.SendMailTo(MailReceiver(target, target_guid), sender);
 

--- a/src/game/ChatCommands/Level3.cpp
+++ b/src/game/ChatCommands/Level3.cpp
@@ -7041,14 +7041,14 @@ bool ChatHandler::HandleAccountSetAddonCommand(char* args)
 bool ChatHandler::HandleSendMailHelper(MailDraft& draft, char* args)
 {
     // format: "subject text" "mail text"
-    std::string msgSubject = ExtractQuotedArg(&args);
-    if (msgSubject.empty())
+    char* msgSubject = ExtractQuotedArg(&args);
+    if (!msgSubject)
     {
         return false;
     }
 
-    std::string msgText = ExtractQuotedArg(&args);
-    if (msgText.empty())
+    char* msgText = ExtractQuotedArg(&args);
+    if (!msgText)
     {
         return false;
     }
@@ -7094,14 +7094,14 @@ bool ChatHandler::HandleSendMassMailCommand(char* args)
 bool ChatHandler::HandleSendItemsHelper(MailDraft& draft, char* args)
 {
     // format: "subject text" "mail text" item1[:count1] item2[:count2] ... item12[:count12]
-    std::string msgSubject = ExtractQuotedArg(&args);
-    if (msgSubject.empty())
+    char * msgSubject = ExtractQuotedArg(&args);
+    if (!msgSubject)
     {
         return false;
     }
 
-    std::string msgText = ExtractQuotedArg(&args);
-    if (msgText.empty())
+    char * msgText = ExtractQuotedArg(&args);
+    if (!msgText)
     {
         return false;
     }
@@ -7195,7 +7195,7 @@ bool ChatHandler::HandleSendItemsCommand(char* args)
         return false;
     }
 
-    MailSender sender(MAIL_NORMAL, (uint32)0, MAIL_STATIONERY_GM);
+    MailSender sender(MAIL_NORMAL, m_session ? m_session->GetPlayer()->GetGUIDLow() : (uint32)0, MAIL_STATIONERY_GM);
 
     draft.SendMailTo(MailReceiver(receiver, receiver_guid), sender);
 
@@ -7239,8 +7239,8 @@ bool ChatHandler::HandleSendMoneyHelper(MailDraft& draft, char* args)
 {
     /// format: "subject text" "mail text" money
 
-    std::string  msgSubject = ExtractQuotedArg(&args);
-    if (msgSubject.empty())
+    char * msgSubject = ExtractQuotedArg(&args);
+    if (!msgSubject)
     {
         return false;
     }

--- a/src/game/Tools/Language.h
+++ b/src/game/Tools/Language.h
@@ -1012,7 +1012,9 @@ enum MangosStrings
     LANG_HONOR_THIS_WEEK                = 1437,
     LANG_HONOR_LAST_WEEK                = 1438,
     LANG_HONOR_LIFE                     = 1439,
-    // Room for old clients 1.x           1440-1499 not used
+    LANG_COMMAND_TICKETUPDATED          = 1440,
+    // Room for old clients 1.x           1441499 not used
+
 
     // Level 2 (continue)
     LANG_POOL_CHANCE_POOL_LIST_CONSOLE  = 1500,

--- a/src/game/WorldHandlers/GMTicketHandler.cpp
+++ b/src/game/WorldHandlers/GMTicketHandler.cpp
@@ -35,18 +35,6 @@ void WorldSession::SendGMTicketGetTicket(uint32 status, GMTicket* ticket /*= NUL
 {
     std::string text = ticket ? ticket->GetText() : "";
 
-    // Removed : Was adding ticket response to ticket text !
-    /*if (ticket && ticket->HasResponse())
-    {
-        text += "\n\n";
-
-        std::string textFormat = GetMangosString(LANG_COMMAND_TICKETRESPONSE);
-        char textBuf[1024];
-        snprintf(textBuf, 1024, textFormat.c_str(), ticket->GetResponse());
-
-        text += textBuf;
-    }*/
-
     int len = text.size() + 1;
     WorldPacket data(SMSG_GMTICKET_GETTICKET, (4 + len + 1 + 4 + 2 + 4 + 4));
     data << uint32(status);                                 // standard 0x0A, 0x06 if text present
@@ -137,18 +125,31 @@ void WorldSession::HandleGMTicketDeleteTicketOpcode(WorldPacket& /*recv_data*/)
 
 void WorldSession::HandleGMTicketCreateOpcode(WorldPacket& recv_data)
 {
-    uint32 map;
+    uint32 mapId;
+    uint8 category;
     float x, y, z;
     std::string ticketText = "";
-
-    recv_data >> map >> x >> y >> z;                        // last check 2.4.3
+    recv_data >> category ;
+    recv_data >> mapId >> x >> y >> z;                        // last check 2.4.3
     recv_data >> ticketText;
 
-    recv_data.read_skip<uint32>();                          // unk1, 0
-    recv_data.read_skip<uint32>();                          // unk2, 1
-    recv_data.read_skip<uint32>();                          // unk3, 0
+    std::string reserved;
+    recv_data >> reserved;                                  // Pre-TBC: "Reserved for future use"
 
-    DEBUG_LOG("TicketCreate: map %u, x %f, y %f, z %f, text %s", map, x, y, z, ticketText.c_str());
+    if (category == 2)                                      // Pre-TBC: "Behavior/Harassment"
+    {
+        uint32 chatDataLineCount;
+        recv_data >> chatDataLineCount;
+
+        uint32 chatDataSizeInflated;
+        recv_data >> chatDataSizeInflated;
+
+        if (size_t chatDataSizeDeflated = (recv_data.size() - recv_data.rpos()))
+            recv_data.read_skip(chatDataSizeDeflated);          // Compressed chat data
+    }
+
+
+    DEBUG_LOG("TicketCreate: map %u, x %f, y %f, z %f, text %s", mapId, x, y, z, ticketText.c_str());
 
     if (sTicketMgr.GetGMTicket(GetPlayer()->GetObjectGuid()))
     {

--- a/src/game/WorldHandlers/Mail.cpp
+++ b/src/game/WorldHandlers/Mail.cpp
@@ -323,6 +323,9 @@ void MailDraft::SendMailTo(MailReceiver const& receiver, MailSender const& sende
 
     // expire time if COD 3 days, if no COD 30 days, if auction sale pending 1 hour
     uint32 expire_delay;
+    
+    // Normal Mail Expire Timer
+    expire_delay = 30 * DAY;
 
     // auction mail without any items and money
     if (sender.GetMailMessageType() == MAIL_AUCTION && m_items.empty() && !m_money)
@@ -334,20 +337,19 @@ void MailDraft::SendMailTo(MailReceiver const& receiver, MailSender const& sende
     {
         expire_delay = DAY;
     }
-    // TODO: GameMaster expire timer (90 Days)
-    else
+    else if (m_COD)
     {
-        if (m_COD)
-        {
-            // COD Mail Expire Timer
-            expire_delay = 3 * DAY;
-        }
-        else
-        {
-            // Normal Mail Expire Timer
-            expire_delay = 30 * DAY;
-        }
+        // COD Mail Expire Timer
+        expire_delay = 3 * DAY;
     }
+    //Mail from GM 
+    else if (sender.GetStationery() == MAIL_STATIONERY_GM)
+    {
+        expire_delay = 90 * DAY;
+    }
+    
+
+    
 
     time_t expire_time = deliver_time + expire_delay;
 

--- a/src/shared/revision.h
+++ b/src/shared/revision.h
@@ -37,7 +37,7 @@
     #define CHAR_DB_UPDATE_DESCRIPTION "Add_Field_Comments"
 
     #define WORLD_DB_VERSION_NR 21
-    #define WORLD_DB_STRUCTURE_NR 18
+    #define WORLD_DB_STRUCTURE_NR 19
     #define WORLD_DB_CONTENT_NR 001
-    #define WORLD_DB_UPDATE_DESCRIPTION "UBRS_equip_models_add"
+    #define WORLD_DB_UPDATE_DESCRIPTION "GM_tickets_handling_fixes_pt2"
 #endif // __REVISION_H__


### PR DESCRIPTION
Server was crashing when no args provided instead of returning command help syntax.