### PR TITLE
Now we can inspect player when GM mode is ON

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -2465,9 +2465,9 @@ void Player::SetGameMaster(bool on)
     if (on)
     {
         m_ExtraFlags |= PLAYER_EXTRA_GM_ON;
-        setFaction(35);
+        //setFaction(35);
+        SetFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNK_0);
         SetFlag(PLAYER_FLAGS, PLAYER_FLAGS_GM);
-
         CallForAllControlledUnits(SetGameMasterOnHelper(), CONTROLLED_PET | CONTROLLED_TOTEMS | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
 
         SetFFAPvP(false);
@@ -2479,8 +2479,10 @@ void Player::SetGameMaster(bool on)
     else
     {
         m_ExtraFlags &= ~ PLAYER_EXTRA_GM_ON;
-        setFactionForRace(getRace());
+        //setFactionForRace(getRace());
+        RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_UNK_0);
         RemoveFlag(PLAYER_FLAGS, PLAYER_FLAGS_GM);
+
 
         CallForAllControlledUnits(SetGameMasterOffHelper(getFaction()), CONTROLLED_PET | CONTROLLED_TOTEMS | CONTROLLED_GUARDIANS | CONTROLLED_CHARM);
 

--- a/src/game/WorldHandlers/Chat.cpp
+++ b/src/game/WorldHandlers/Chat.cpp
@@ -1546,7 +1546,7 @@ bool ChatHandler::ShowHelpForCommand(ChatCommand* table, const char* cmd)
             break;
     }
 
-    if (!command->Help.empty())
+    if (command && !command->Help.empty())
     {
         std::string helpText = command->Help;
 


### PR DESCRIPTION
It has been reported on our Bug-Tracker  : 
[https://www.getmangos.eu/bug-tracker/mangos-zero/0-enhancement-requests/Inspecting-players-as-GM-r401](https://www.getmangos.eu/bug-tracker/mangos-zero/0-enhancement-requests/Inspecting-players-as-GM-r401)

**Now it is working** 
![gminspect01](https://user-images.githubusercontent.com/1208311/82685886-3430fb80-9c55-11ea-803c-85a940599eb0.PNG)

![gminspect02](https://user-images.githubusercontent.com/1208311/82685914-41e68100-9c55-11ea-92c1-7257e2992938.PNG)

(Sorry my client is in French :) )