### PR TITLE
Implement .reset mail command + Increase max bags slots to 36

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -18065,7 +18065,7 @@ void Player::SaveToDB()
 
     if (m_mailsUpdated)                                     // save mails only when needed
     {
-        _SaveMail();
+        SaveMail();
     }
 
     _SaveBGData();
@@ -18394,14 +18394,14 @@ void Player::_SaveHonorCP()
     tempList.clear();
 }
 
-void Player::_SaveMail()
+void Player::SaveMail()
 {
     static SqlStatementID updateMail ;
     static SqlStatementID deleteMailItems ;
 
     static SqlStatementID deleteItem ;
     static SqlStatementID deleteItemText;
-    static SqlStatementID deleteMain ;
+    static SqlStatementID deleteMail ;
     static SqlStatementID deleteItems ;
 
     for (PlayerMails::iterator itr = m_mail.begin(); itr != m_mail.end(); ++itr)
@@ -18450,7 +18450,7 @@ void Player::_SaveMail()
                 stmt.PExecute(m->itemTextId);
             }
 
-            SqlStatement stmt = CharacterDatabase.CreateStatement(deleteMain, "DELETE FROM `mail` WHERE `id` = ?");
+            SqlStatement stmt = CharacterDatabase.CreateStatement(deleteMail, "DELETE FROM `mail` WHERE `id` = ?");
             stmt.PExecute(m->messageID);
 
             stmt = CharacterDatabase.CreateStatement(deleteItems, "DELETE FROM `mail_items` WHERE `mail_id` = ?");

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -2393,7 +2393,7 @@ class Player : public Unit
         void SetBotDeathTimer() { m_deathTimer = 0; }
         //PlayerTalentMap& GetTalentMap(uint8 spec) { return m_talents[spec]; }
 #endif
-
+        void SaveMail();
     protected:
 
         uint32 m_contestedPvPTimer;
@@ -2453,7 +2453,7 @@ class Player : public Unit
         void _SaveAuras();
         void _SaveInventory();
         void _SaveHonorCP();
-        void _SaveMail();
+        
         void _SaveQuestStatus();
         void _SaveSkills();
         void _SaveSpells();

--- a/src/game/Tools/Language.h
+++ b/src/game/Tools/Language.h
@@ -1047,6 +1047,12 @@ enum MangosStrings
     LANG_COMMAND_RESET_ITEMS_ALL        = 1527,
     LANG_COMMAND_RESET_ITEMS_ALLBAGS    = 1528,
 
+    LANG_COMMAND_RESET_MAIL_COD          = 1529,
+    LANG_COMMAND_RESET_MAIL_GM           = 1530,
+    LANG_COMMAND_RESET_MAIL_FROM         = 1531,
+    LANG_COMMAND_RESET_MAIL_PLAYER_NOTIF = 1532,
+    LANG_COMMAND_RESET_MAIL_RECAP        = 1533,
+
     // Room for more Level 2              1522-1599 not used
 
     // Outdoor PvP

--- a/src/game/WorldHandlers/Chat.cpp
+++ b/src/game/WorldHandlers/Chat.cpp
@@ -574,6 +574,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "stats",          SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleResetStatsCommand,          "", NULL },
         { "talents",        SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleResetTalentsCommand,        "", NULL },
         { "items",          SEC_ADMINISTRATOR,  false,  &ChatHandler::HandleResetItemsCommand,         "", NULL },
+        { "mail",          SEC_ADMINISTRATOR,  false,  &ChatHandler::HandleResetMailCommand,           "", NULL },
         { "all",            SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleResetAllCommand,            "", NULL },
         { NULL,             0,                  false, NULL,                                           "", NULL }
     };

--- a/src/game/WorldHandlers/Chat.h
+++ b/src/game/WorldHandlers/Chat.h
@@ -109,6 +109,12 @@ static const uint32 ReputationRankStrIndex[MAX_REPUTATION_RANK] =
 #define RESET_ITEMS_COMMAND_ARG_OPTION_ALL "all"
 #define RESET_ITEMS_COMMAND_ARG_OPTION_ALL_BAGS "allbags"
 
+#define RESET_MAIL_COMMAND_ARG_OPTION_COD  "cod"
+#define RESET_MAIL_COMMAND_ARG_OPTION_GM   "gm"
+#define RESET_MAIL_COMMAND_ARG_OPTION_ALL  "all"
+#define RESET_MAIL_COMMAND_ARG_OPTION_FROM "from"
+
+
 #define BITMASK_AND_SWITCH(x) \
     for (uint64_t bit = 1; bit <= x+1; bit *= 2) if (x & bit) switch (bit)
 
@@ -129,6 +135,15 @@ enum  ResetItemCommandArgFlags
       | RESET_ITEMS_COMMAND_FLAG_OPTION_BUYBACK
       ),
     RESET_ITEMS_COMMAND_FLAG_OPTION_ALL_BAGS = RESET_ITEMS_COMMAND_FLAG_OPTION_ALL << 1 | 1, // Will also delete bank bags and equiped bags
+};
+
+enum ResetMailCommandArgFlags
+{
+    RESET_MAIL_COMMAND_FLAG_OPTION_NONE    = 0x00,
+    RESET_MAIL_COMMAND_FLAG_OPTION_COD     = 0x01,
+    RESET_MAIL_COMMAND_FLAG_OPTION_GM      = 0x02,
+    RESET_MAIL_COMMAND_FLAG_OPTION_ALL     = ( RESET_MAIL_COMMAND_FLAG_OPTION_COD | RESET_MAIL_COMMAND_FLAG_OPTION_GM ),
+    RESET_MAIL_COMMAND_FLAG_OPTION_FROM    = 0x04,
 };
 
 class ChatHandler
@@ -540,6 +555,7 @@ class ChatHandler
         bool HandleResetStatsCommand(char* args);
         bool HandleResetTalentsCommand(char* args);
         bool HandleResetItemsCommand(char* args);
+        bool HandleResetMailCommand(char* args);
 
         bool HandleSendItemsCommand(char* args);
         bool HandleSendMailCommand(char* args);

--- a/src/game/WorldHandlers/MailHandler.cpp
+++ b/src/game/WorldHandlers/MailHandler.cpp
@@ -513,7 +513,7 @@ void WorldSession::HandleMailTakeItem(WorldPacket& recv_data)
 
         CharacterDatabase.BeginTransaction();
         pl->SaveInventoryAndGoldToDB();
-        pl->_SaveMail();
+        pl->SaveMail();
         CharacterDatabase.CommitTransaction();
 
         pl->SendMailResult(mailId, MAIL_ITEM_TAKEN, MAIL_OK, 0, itemId, count);
@@ -557,7 +557,7 @@ void WorldSession::HandleMailTakeMoney(WorldPacket& recv_data)
     // save money and mail to prevent cheating
     CharacterDatabase.BeginTransaction();
     pl->SaveGoldToDB();
-    pl->_SaveMail();
+    pl->SaveMail();
     CharacterDatabase.CommitTransaction();
 }
 


### PR DESCRIPTION
 **Default behaviour :**
  - delete checked mails (even if its is GM stationery and if it contains items in it, but not deleted COD)

 **Options :**
- cod : delete only cod mail (even if it is unchecked)
            TODO -> to improve => return cod to sender instead of delete
- gm : delete only GM stationery emails (even if it is unchecked)
- all : delete all mails (even if it is unchecked)
- from XXXX : delete all mails from specific sender in the slected player mailbox, name or guid
          TODO  -> to improve, if unchecked return letter to sender to inform it was not read and purged by GM for tech. reason.

 TODO : in the future => handle reset mail for Offline char ?