### PR TITLE
Fix quests 4512 & 4513

### DIFF
--- a/src/game/Server/SharedDefines.h
+++ b/src/game/Server/SharedDefines.h
@@ -2608,4 +2608,23 @@ enum WhisperLoggingLevels
     WHISPER_LOGGING_EVERYTHING = 2
 };
 
+/*
+    Creature entries for more readable code
+*/
+enum CreatureEntriesConsts
+{
+    CREATURE_TAINTED_OOZE   = 7092,
+    CREATURE_CURSED_OOZE    = 7086,
+    CREATURE_MUCULENT_OOZE  = 6556,
+    CREATURE_PRIMAL_OOZE    = 6557,
+    CREATURE_GLUTINOUS_OOZE = 6559,
+};
+
+enum SpellEntriesConsts 
+{
+    SPELL_FILLING_EMPTY_JAR__CURSED_OOZE    = 15698,
+    SPELL_FILLING_EMPTY_JAR__TAINTED_OOZE   = 15699,
+    SPELL_FILLING_EMPTY_JAR__PURE_OOZE      = 15702, // (Works on  Primal, Muculent and Glutonous Ooze)
+};
+
 #endif

--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -2259,6 +2259,40 @@ void Spell::DoCreateItem(SpellEffectIndex eff_idx, uint32 itemtype)
 
 void Spell::EffectCreateItem(SpellEffectIndex eff_idx)
 {
+    switch (m_spellInfo->Id)
+    {
+        case SPELL_FILLING_EMPTY_JAR__CURSED_OOZE: // Spell 15698 (for Cursed Ooze)
+        case SPELL_FILLING_EMPTY_JAR__TAINTED_OOZE: // Spell 15699 (for Tainted Ooze)        
+        {
+            if (unitTarget->GetTypeId() == TYPEID_UNIT) {
+
+                Creature* creature = static_cast<Creature*>(unitTarget);
+                if (creature->IsDead() && (creature->GetEntry() == CREATURE_TAINTED_OOZE || creature->GetEntry() == CREATURE_CURSED_OOZE))
+                {
+                    creature->ForcedDespawn();
+                }
+            }
+            
+            break;
+        }
+        case SPELL_FILLING_EMPTY_JAR__PURE_OOZE: // Spell 15702 (for Primal, Muculent and Glutonous Ooze): 
+        {
+            if (unitTarget->GetTypeId() == TYPEID_UNIT) {
+
+                Creature* creature = static_cast<Creature*>(unitTarget);
+                if (creature->IsDead() && (
+                    creature->GetEntry() == CREATURE_MUCULENT_OOZE ||
+                    creature->GetEntry() == CREATURE_PRIMAL_OOZE ||
+                    creature->GetEntry() == CREATURE_GLUTINOUS_OOZE
+                    ))
+                {
+                    creature->ForcedDespawn();
+                }
+            }
+
+            break;
+        }
+    }
     DoCreateItem(eff_idx, m_spellInfo->EffectItemType[eff_idx]);
 }
 


### PR DESCRIPTION
Q4512 : https://classic.wowhead.com/quest=4512/a-little-slime-goes-a-long-way
Q4513 : https://classic.wowhead.com/quest=4513/a-little-slime-goes-a-long-way

This core fix also needs the latests DB updates :
https://github.com/mangoszero/database/commit/497cde5487e77adee829d6dc7028c5643ad31035
https://github.com/mangoszero/database/commit/5a49250018d7c7ca4ca249ae2e75ac740fdd625d

Now the mobs will disappear after item use. The player will no more be able to reuse the item on the same dead mob.
The empty flasks will also be usable on only good mobs (it was usable on any attackable mobs before).
