### PR TITLE
Deprecated Code Replacements

### DIFF
--- a/src/game/WorldHandlers/MassMailMgr.h
+++ b/src/game/WorldHandlers/MassMailMgr.h
@@ -117,7 +117,7 @@ class MassMailMgr
             }
 
             /// m_protoMail is owned by MassMail, so at copy original MassMail field set to NULL
-            std::auto_ptr<MailDraft> m_protoMail;
+            std::shared_ptr<MailDraft> m_protoMail;
 
             MailSender m_sender;
             ReceiversList m_receivers;

--- a/src/shared/Database/Database.cpp
+++ b/src/shared/Database/Database.cpp
@@ -670,7 +670,7 @@ bool Database::ExecuteStmt(const SqlStatementID& id, SqlStmtParameters* params)
 bool Database::DirectExecuteStmt(const SqlStatementID& id, SqlStmtParameters* params)
 {
     MANGOS_ASSERT(params);
-    std::auto_ptr<SqlStmtParameters> p(params);
+    std::shared_ptr<SqlStmtParameters> p(params);
     // execute statement
     SqlConnection::Lock _guard(getAsyncConnection());
     return _guard->ExecuteStmt(id.ID(), *params);


### PR DESCRIPTION
Replacing deprecated & warning code too kill their warning outputs.

- [x] Replace `std::auto_ptr` with `std::shared_ptr`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/133)
<!-- Reviewable:end -->
