### PR TITLE
Fix HandleGMTicketUpdateTextOpcode

### DIFF
--- a/src/game/WorldHandlers/GMTicketHandler.cpp
+++ b/src/game/WorldHandlers/GMTicketHandler.cpp
@@ -71,6 +71,12 @@ void WorldSession::HandleGMTicketUpdateTextOpcode(WorldPacket& recv_data)
     std::string ticketText;
     recv_data >> ticketText;
 
+    // When updating the ticket , the client adds a leading '\a' char ! so we need to remove it
+    stripLineInvisibleChars(ticketText);
+
+    // Since invisible char are replaced with a ' ' if any leading space is added we remove it :
+    ltrim(ticketText);
+
     GMTicketResponse responce = GMTICKET_RESPONSE_UPDATE_SUCCESS;
     if (GMTicket* ticket = sTicketMgr.GetGMTicket(GetPlayer()->GetObjectGuid()))
     {

--- a/src/modules/Bots/playerbot/Helpers.cpp
+++ b/src/modules/Bots/playerbot/Helpers.cpp
@@ -1,5 +1,6 @@
 #include "../botpch.h"
 #include "playerbot.h"
+#include "Util.h"
 #include <algorithm>
 #include <functional>
 #include <cctype>
@@ -77,10 +78,6 @@ uint64 extractGuid(WorldPacket& packet)
     return guid;
 }
 
-std::string &ltrim(std::string &s) {
-        s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-        return s;
-}
 
 std::string &rtrim(std::string &s) {
         s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());

--- a/src/shared/Utilities/Util.cpp
+++ b/src/shared/Utilities/Util.cpp
@@ -358,6 +358,33 @@ void utf8truncate(std::string& utf8str, size_t len)
     }
 }
 
+size_t utf8limit(std::string& utf8str, size_t bytes)
+{
+    if (utf8str.size() > bytes)
+    {
+        try
+        {
+            auto end = (utf8str.cbegin() + bytes);
+            auto itr = utf8::find_invalid(utf8str.cbegin(), end);
+
+            // Fix UTF8 if it was corrupted by bytes truncated
+            if (itr != end)
+                bytes = std::distance(utf8str.cbegin(), itr);
+
+            utf8str.resize(bytes);
+            utf8str.shrink_to_fit();
+
+            return bytes;
+        }
+        catch (const std::exception&)
+        {
+            utf8str = "";
+        }
+    }
+
+    return 0;
+}
+
 bool Utf8toWStr(char const* utf8str, size_t csize, wchar_t* wstr, size_t& wsize)
 {
     try

--- a/src/shared/Utilities/Util.h
+++ b/src/shared/Utilities/Util.h
@@ -109,6 +109,13 @@ inline uint32 secsToTimeBitFields(time_t secs)
 }
 
 
+inline std::string   ltrim(std::string& s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+        }));
+    return s;
+}
+
 /**
  * @brief Return a random number in the range min..max; (max-min) must be smaller than 32768.
  *
@@ -321,6 +328,14 @@ size_t utf8length(std::string& utf8str);                    // set string to "" 
  * @param len
  */
 void utf8truncate(std::string& utf8str, size_t len);
+
+/**
+ * @brief
+ *
+ * @param utf8str
+ * @param bytes
+ */
+size_t utf8limit(std::string& utf8str, size_t bytes);
 
 /**
  * @brief


### PR DESCRIPTION
When updating the ticket , the client adds a leading '\a' char ! so we need to remove it
 Proof : 
 
![image](https://user-images.githubusercontent.com/1208311/109883483-c736a180-7c7b-11eb-8cc3-e0d933274d06.png)

![image](https://user-images.githubusercontent.com/1208311/109883537-dae20800-7c7b-11eb-9f56-31f7320afce1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/136)
<!-- Reviewable:end -->

Also added utf8limitmethod for future use.