### PR TITLE
Fix timers and game overall playability

### DIFF
--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -1677,7 +1677,7 @@ void World::Update(uint32 diff)
 
     ///- Update the game time and check for shutdown time
     _UpdateGameTime();
-
+    GameTime::UpdateGameTimers();
     sWorldUpdateTime.UpdateWithDiff(diff);
 
     ///-Update mass mailer tasks if any


### PR DESCRIPTION
Since the commit related to timers (https://github.com/mangoszero/server/commit/1c4e25cba0b5bfd6bbfc93e68cdcb65f6dae469b), weird behaviours were encounterd in game so it was unplayable : 
-  When attacking a mob it would aggro but not fight back 
- After 1st spell cats you will hang forever not being able to cast another spell 
- Item spells with cast duraction were not casted properly (Earthstone etc..)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/146)
<!-- Reviewable:end -->
