### PR TITLE
Fix core startup message when db version is same as core

### DIFF
--- a/src/shared/Database/Database.cpp
+++ b/src/shared/Database/Database.cpp
@@ -644,15 +644,24 @@ bool Database::CheckDatabaseVersion(DatabaseTypes database)
     }
     else
     {
-        sLog.outString("The table `db_version` indicates that your [%s] database has a higher version than the one referenced by the core."
-                       "\nYou have probably applied DB updates, and that's a good thing to keep your server up to date.", core_db_requirements.dbname.c_str());
-        sLog.outString();
-        PrintNormalYouHaveDatabaseVersion(current_db_version, current_db_structure, current_db_content, description);
-        sLog.outString();
-        PrintNormalDatabaseVersionReferencedByCore(core_db_requirements);
-        sLog.outString();
-        sLog.outString("You can run the core without any problem like that.");
-        sLog.outString();
+        if (current_db_version == core_db_requirements.expected_version && current_db_structure == core_db_requirements.expected_structure)
+        {
+            sLog.outString("The table `db_version` indicates that your [%s] database hase the same version as the core requirements.", core_db_requirements.dbname.c_str());
+            sLog.outString();
+        }
+        else
+        {
+            sLog.outString("The table `db_version` indicates that your [%s] database has a higher version than the one referenced by the core."
+                "\nYou have probably applied DB updates, and that's a good thing to keep your server up to date.", core_db_requirements.dbname.c_str());
+            sLog.outString();
+            PrintNormalYouHaveDatabaseVersion(current_db_version, current_db_structure, current_db_content, description);
+            sLog.outString();
+            PrintNormalDatabaseVersionReferencedByCore(core_db_requirements);
+            sLog.outString();
+            sLog.outString("You can run the core without any problem like that.");
+            sLog.outString();
+        }
+        
     }
 
     return true;

--- a/src/shared/Database/Database.cpp
+++ b/src/shared/Database/Database.cpp
@@ -660,8 +660,7 @@ bool Database::CheckDatabaseVersion(DatabaseTypes database)
             sLog.outString();
             sLog.outString("You can run the core without any problem like that.");
             sLog.outString();
-        }
-        
+        }     
     }
 
     return true;

--- a/src/shared/Database/Database.cpp
+++ b/src/shared/Database/Database.cpp
@@ -660,7 +660,7 @@ bool Database::CheckDatabaseVersion(DatabaseTypes database)
             sLog.outString();
             sLog.outString("You can run the core without any problem like that.");
             sLog.outString();
-        }     
+        }
     }
 
     return true;


### PR DESCRIPTION
@i-am-fyre - this one fr you :p

![image](https://user-images.githubusercontent.com/1208311/111528475-7d60b780-8761-11eb-9884-7f2d69d862c6.png)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/150)
<!-- Reviewable:end -->
