### PR TITLE
Update Duration.h

### DIFF
--- a/src/shared/Utilities/Duration.h
+++ b/src/shared/Utilities/Duration.h
@@ -43,7 +43,7 @@ typedef std::chrono::hours Hours;
 typedef std::chrono::steady_clock::time_point TimePoint;
 typedef std::chrono::system_clock::time_point SystemTimePoint;
 
-constexpr std::chrono::hours operator""_days(unsigned long long days)
+constexpr std::chrono::hours operator "" _days(unsigned long long days)
 {
     return std::chrono::hours(days * Hours(24));
 }


### PR DESCRIPTION
Fix error when compiling in CentOS - 7  src/shared/Utilities/Duration.h:46:30: error: missing space between ‘""’ and suffix identifier
 constexpr std::chrono::hours operator""_days(unsigned long long days)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/158)
<!-- Reviewable:end -->
