### PR TITLE
Fixed Player Count Bug Battlegrounds

### DIFF
--- a/src/game/BattleGround/BattleGround.cpp
+++ b/src/game/BattleGround/BattleGround.cpp
@@ -1309,7 +1309,11 @@ void BattleGround::AddPlayer(Player* plr)
     // Add to list/maps
     m_Players[guid] = bp;
 
-    UpdatePlayersCountByTeam(team, false);                  // +1 player
+    bool const isInBattleground = IsPlayerInBattleGround(guid);
+    if (!isInBattleground)
+    {
+        UpdatePlayersCountByTeam(team, false); // +1 player
+    }
 
     WorldPacket data;
     sBattleGroundMgr.BuildPlayerJoinedBattleGroundPacket(&data, plr);


### PR DESCRIPTION
**Changes Made:**
- Avoid increasing player count per team when re-logging if a player was already in a battleground.

**Note:**
This can be ported to all versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/165)
<!-- Reviewable:end -->
