### PR TITLE
Fix ammo damage modifiers

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -540,7 +540,8 @@ Player::Player(WorldSession* session): Unit(), m_mover(this), m_camera(this), m_
     m_canParry = false;
     m_canBlock = false;
     m_canDualWield = false;
-    m_ammoDPS = 0.0f;
+    m_ammoDPSMin = 0.0f;
+    m_ammoDPSMax = 0.0f;
 
     m_temporaryUnsummonedPetNumber = 0;
 
@@ -8284,24 +8285,28 @@ void Player::_ApplyAmmoBonuses()
         return;
     }
 
-    float currentAmmoDPS;
+    float currentAmmoDPSMin;
+    float currentAmmoDPSMax;
 
     ItemPrototype const* ammo_proto = ObjectMgr::GetItemPrototype(ammo_id);
     if (!ammo_proto || ammo_proto->Class != ITEM_CLASS_PROJECTILE || !CheckAmmoCompatibility(ammo_proto))
     {
-        currentAmmoDPS = 0.0f;
+        currentAmmoDPSMin = 0.f;
+        currentAmmoDPSMax = 0.f;
     }
     else
     {
-        currentAmmoDPS = ammo_proto->Damage[0].DamageMin;
+        currentAmmoDPSMin = ammo_proto->Damage[0].DamageMin;
+        currentAmmoDPSMax = ammo_proto->Damage[0].DamageMax;
     }
 
-    if (currentAmmoDPS == GetAmmoDPS())
+    if (std::make_pair(currentAmmoDPSMin, currentAmmoDPSMax) == GetAmmoDPS())
     {
         return;
     }
 
-    m_ammoDPS = currentAmmoDPS;
+    m_ammoDPSMin = currentAmmoDPSMin;
+    m_ammoDPSMax = currentAmmoDPSMax;
 
     if (CanModifyStats())
     {
@@ -11621,7 +11626,8 @@ void Player::RemoveAmmo()
 {
     SetUInt32Value(PLAYER_AMMO_ID, 0);
 
-    m_ammoDPS = 0.0f;
+    m_ammoDPSMin = 0.0f;
+    m_ammoDPSMax = 0.0f;
 
     if (CanModifyStats())
     {

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -1235,10 +1235,8 @@ class Player : public Unit
         void ApplyEquipCooldown(Item* pItem);
         void SetAmmo(uint32 item);
         void RemoveAmmo();
-        float GetAmmoDPS() const
-        {
-            return m_ammoDPS;
-        }
+        std::pair<float, float> GetAmmoDPS() const { return { m_ammoDPSMin, m_ammoDPSMax }; }
+
         bool CheckAmmoCompatibility(const ItemPrototype* ammo_proto) const;
         void QuickEquipItem(uint16 pos, Item* pItem);
         void VisualizeItem(uint8 slot, Item* pItem);
@@ -2570,7 +2568,8 @@ class Player : public Unit
         bool m_canBlock;
         bool m_canDualWield;
         uint8 m_swingErrorMsg;
-        float m_ammoDPS;
+        float m_ammoDPSMin;
+        float m_ammoDPSMax;
 
         //////////////////// Rest System/////////////////////
         time_t time_inn_enter;

--- a/src/game/Object/StatSystem.cpp
+++ b/src/game/Object/StatSystem.cpp
@@ -374,8 +374,9 @@ void Player::CalculateMinMaxDamage(WeaponAttackType attType, bool normalized, fl
     }
     else if (attType == RANGED_ATTACK)                      // add ammo DPS to ranged damage
     {
-        weapon_mindamage += GetAmmoDPS() * att_speed;
-        weapon_maxdamage += GetAmmoDPS() * att_speed;
+        std::pair<float,float> ammoDps = GetAmmoDPS();
+        weapon_mindamage += ammoDps.first * att_speed;
+        weapon_maxdamage += ammoDps.second * att_speed;
     }
 
     min_damage = ((base_value + weapon_mindamage) * base_pct + total_value) * total_pct;


### PR DESCRIPTION
**Current behavior:**

The _ApplyAmmoBonuses function is using only the DamageMin component of the ammo item:
`currentAmmoDPS = ammo_proto->Damage[0].DamageMin;`

This results in ammo with different DamageMin / DamageMax values to always be rounded down, for example : 
Thorium Headed Arrow (18042) will have 17 dps instead of 17.5 dps.

**Expected behavior:**

_ApplyAmmoBonuse should apply the average between DamageMin and DamageMax.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/170)
<!-- Reviewable:end -->
