### PR TITLE
Add status_failed_mangos_string_id column in areatrigger_teleport

### DIFF
--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -5597,7 +5597,7 @@ void ObjectMgr::LoadAreaTriggerTeleports()
 
     uint32 count = 0;
 
-    //                                                0         1                2                       3                  4                  5                                6                    7  
+    //                                                0         1                2                       3                  4                  5                                6                    7
     QueryResult* result = WorldDatabase.Query("SELECT `id`, `target_map`, `target_position_x`, `target_position_y`, `target_position_z`, `target_orientation`, `status_failed_mangos_string_id`, `condition_id` FROM `areatrigger_teleport`");
     if (!result)
     {

--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -5597,8 +5597,8 @@ void ObjectMgr::LoadAreaTriggerTeleports()
 
     uint32 count = 0;
 
-    //                                                0   1           2                  3                  4                  5                   6                  7                  8                  9
-    QueryResult* result = WorldDatabase.Query("SELECT `id`, `target_map`, `target_position_x`, `target_position_y`, `target_position_z`, `target_orientation`, `condition_id` FROM `areatrigger_teleport`");
+    //                                                0         1                2                       3                  4                  5                                6                    7  
+    QueryResult* result = WorldDatabase.Query("SELECT `id`, `target_map`, `target_position_x`, `target_position_y`, `target_position_z`, `target_orientation`, `status_failed_mangos_string_id`, `condition_id` FROM `areatrigger_teleport`");
     if (!result)
     {
         BarGoLink bar(1);
@@ -5622,12 +5622,13 @@ void ObjectMgr::LoadAreaTriggerTeleports()
 
         AreaTrigger at;
 
-        at.target_mapId         = fields[1].GetUInt32();
-        at.target_X             = fields[2].GetFloat();
-        at.target_Y             = fields[3].GetFloat();
-        at.target_Z             = fields[4].GetFloat();
-        at.target_Orientation   = fields[5].GetFloat();
-        at.condition            = fields[6].GetUInt16();
+        at.target_mapId                 = fields[1].GetUInt32();
+        at.target_X                     = fields[2].GetFloat();
+        at.target_Y                     = fields[3].GetFloat();
+        at.target_Z                     = fields[4].GetFloat();
+        at.target_Orientation           = fields[5].GetFloat();
+        at.failed_text_mangos_string_id = fields[6].GetUInt32();
+        at.condition                    = fields[7].GetUInt16();
 
         AreaTriggerEntry const* atEntry = sAreaTriggerStore.LookupEntry(Trigger_ID);
         if (!atEntry)

--- a/src/game/Object/ObjectMgr.h
+++ b/src/game/Object/ObjectMgr.h
@@ -69,6 +69,7 @@ struct AreaTrigger
     float  target_Y;
     float  target_Z;
     float  target_Orientation;
+    uint32 failed_text_mangos_string_id = 0;
 
     // Operators
     bool IsMinimal() const

--- a/src/game/Object/Player.h
+++ b/src/game/Object/Player.h
@@ -2359,7 +2359,7 @@ class Player : public Unit
         DungeonPersistentState* GetBoundInstanceSaveForSelfOrGroup(uint32 mapid);
 
         AreaLockStatus GetAreaTriggerLockStatus(AreaTrigger const* at, uint32& miscRequirement);
-        void SendTransferAbortedByLockStatus(MapEntry const* mapEntry, AreaLockStatus lockStatus, uint32 miscRequirement = 0);
+        void SendTransferAbortedByLockStatus(MapEntry const* mapEntry, AreaTrigger const* at, AreaLockStatus lockStatus, uint32 miscRequirement = 0);
 
         /*********************************************************/
         /***                   GROUP SYSTEM                    ***/

--- a/src/game/Tools/Language.h
+++ b/src/game/Tools/Language.h
@@ -877,6 +877,8 @@ Faction Template: %u. */
     LANG_COMMAND_FREEZE_PLAYER_YOU_HAVE_BEEN_UNFROZEN         = 1712,    /* You have been unfrozen. You can now move freely, use spells or even logout. */
     LANG_COMMAND_FREEZE_PLAYER_PLAYER_NOT_FOUND               = 1713,    /* You can only freeze online characters. */
     LANG_COMMAND_UNFREEZE_PLAYER_PLAYER_NOT_FOUND             = 1714,    /* You can only unfreeze online characters. */
+    LANG_CANNOT_ENTER_CHAMPIONS_HALL                          = 1715,    /* You must be a Knight or higher rank in order to enter the Champions Hall. */
+    LANG_CANNOT_ENTER_LEGENDS_HALL                            = 1716,    /* You must be a Stone Guard or higher rank in order to enter the Hall of Legends. */
 
         // FREE IDS                           1701-9999
         // Use for not-in-official-sources patches

--- a/src/game/WorldHandlers/MiscHandler.cpp
+++ b/src/game/WorldHandlers/MiscHandler.cpp
@@ -953,7 +953,7 @@ void WorldSession::HandleAreaTriggerOpcode(WorldPacket& recv_data)
     AreaLockStatus lockStatus = player->GetAreaTriggerLockStatus(at, miscRequirement);
     if (lockStatus != AREA_LOCKSTATUS_OK)
     {
-        player->SendTransferAbortedByLockStatus(targetMapEntry, lockStatus, miscRequirement);
+        player->SendTransferAbortedByLockStatus(targetMapEntry, at, lockStatus, miscRequirement);
         return;
     }
 

--- a/src/shared/revision.h
+++ b/src/shared/revision.h
@@ -37,7 +37,7 @@
     #define CHAR_DB_UPDATE_DESCRIPTION "add_character_createdDate_col"
 
     #define WORLD_DB_VERSION_NR 22
-    #define WORLD_DB_STRUCTURE_NR 2
+    #define WORLD_DB_STRUCTURE_NR 3
     #define WORLD_DB_CONTENT_NR 001
-    #define WORLD_DB_UPDATE_DESCRIPTION "Fix_Additem_LANG_REMOVEITEM"
+    #define WORLD_DB_UPDATE_DESCRIPTION "Alter_areatrigger_teleport"
 #endif // __REVISION_H__

--- a/src/shared/revision.h
+++ b/src/shared/revision.h
@@ -37,7 +37,7 @@
     #define CHAR_DB_UPDATE_DESCRIPTION "add_character_createdDate_col"
 
     #define WORLD_DB_VERSION_NR 22
-    #define WORLD_DB_STRUCTURE_NR 3
+    #define WORLD_DB_STRUCTURE_NR 4
     #define WORLD_DB_CONTENT_NR 001
-    #define WORLD_DB_UPDATE_DESCRIPTION "Alter_areatrigger_teleport"
+    #define WORLD_DB_UPDATE_DESCRIPTION "Fix_messages_for_areatrigger"
 #endif // __REVISION_H__


### PR DESCRIPTION
Will be able to handle specific areatrigger_teleport message ina  generic way using mangos_string table as storage table for messages
/!\ WARNING  REQUIRE DB STRUCTURE UPDATE /!\

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/173)
<!-- Reviewable:end -->
