### PR TITLE
Fix monsters casting while stunned

### DIFF
--- a/src/game/Object/Creature.cpp
+++ b/src/game/Object/Creature.cpp
@@ -3305,6 +3305,10 @@ SpellCastResult Creature::TryToCast(Unit* pTarget, const SpellEntry* pSpellInfo,
         return SPELL_FAILED_BAD_IMPLICIT_TARGETS;
     }
 
+    if (hasUnitState(UNIT_STAT_STUNNED)) {
+        return SPELL_FAILED_STUNNED;
+    }
+
     // This spell should only be cast when target does not have the aura it applies.
     if ((uiCastFlags & CF_AURA_NOT_PRESENT) && pTarget->HasAura(pSpellInfo->Id))
     {


### PR DESCRIPTION
https://www.getmangos.eu/bug-tracker/mangos-zero/monsters-can-cast-while-stunned-r1758/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/177)
<!-- Reviewable:end -->
