### PR TITLE
Fix Eluna logging by defining ENABLE_ELUNA

### DIFF
--- a/src/mangosd/CMakeLists.txt
+++ b/src/mangosd/CMakeLists.txt
@@ -66,6 +66,11 @@ target_include_directories(mangosd
         ${OPENSSL_INCLUDE_DIR}
 )
 
+target_compile_definitions(mangosd
+    PUBLIC
+        $<$<BOOL:${SCRIPT_LIB_ELUNA}>:ENABLE_ELUNA>
+)
+
 target_link_libraries(mangosd
     PUBLIC
         game

--- a/src/shared/CMakeLists.txt
+++ b/src/shared/CMakeLists.txt
@@ -226,6 +226,7 @@ target_compile_definitions(shared
         $<$<CONFIG:Debug>:MANGOS_DEBUG>
         MANGOS_ENDIAN=${ENDIAN_VALUE}
         $<$<BOOL:${ENDIAN_VALUE}>:ARCH_IS_BIG_ENDIAN>
+        $<$<BOOL:${SCRIPT_LIB_ELUNA}>:ENABLE_ELUNA>
 )
 
 target_link_libraries(shared


### PR DESCRIPTION
`Log.cpp` that is in shared project [uses `ENABLE_ELUNA`](https://github.com/mangoszero/server/blob/dc04a78ad0ce61886cd38e5c9aa2477870241711/src/shared/Log/Log.cpp#L76), but it does not have the definition available.
As a result, logging is disabled for Eluna despite Eluna being compiled.

The `ENABLE_ELUNA` definition should be included in all projects or every project that uses it
This should probably be applied to all cores (zero, one, two, ...)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/179)
<!-- Reviewable:end -->
