### PR TITLE
Standardize Account Handling

### DIFF
--- a/src/game/ChatCommands/AccountCommands.cpp
+++ b/src/game/ChatCommands/AccountCommands.cpp
@@ -222,30 +222,38 @@ bool ChatHandler::HandleAccountCreateCommand(char* args)
     std::string password = szPassword;
 
     AccountOpResult result;
-    result = sAccountMgr.CreateAccount(account_name, password);
-    switch (result)
+    uint32 expansion = 0;
+    if(ExtractUInt32(&args, expansion))
     {
-        case AOR_OK:
-            PSendSysMessage(LANG_ACCOUNT_CREATED, account_name.c_str());
-            break;
-        case AOR_NAME_TOO_LONG:
-            SendSysMessage(LANG_ACCOUNT_TOO_LONG);
-            SetSentErrorMessage(true);
-            return false;
-        case AOR_NAME_ALREADY_EXIST:
-            SendSysMessage(LANG_ACCOUNT_ALREADY_EXIST);
-            SetSentErrorMessage(true);
-            return false;
-        case AOR_DB_INTERNAL_ERROR:
-            PSendSysMessage(LANG_ACCOUNT_NOT_CREATED_SQL_ERROR, account_name.c_str());
-            SetSentErrorMessage(true);
-            return false;
-        default:
-            PSendSysMessage(LANG_ACCOUNT_NOT_CREATED, account_name.c_str());
-            SetSentErrorMessage(true);
-            return false;
+        // No point in assigning to result as it's never used on this side of the if/else branch
+        sAccountMgr.CreateAccount(account_name, password, expansion);
     }
-
+    else
+    {
+        result = sAccountMgr.CreateAccount(account_name, password);
+        switch (result)
+        {
+            case AOR_OK:
+                PSendSysMessage(LANG_ACCOUNT_CREATED, account_name.c_str());
+                break;
+            case AOR_NAME_TOO_LONG:
+                SendSysMessage(LANG_ACCOUNT_TOO_LONG);
+                SetSentErrorMessage(true);
+                return false;
+            case AOR_NAME_ALREADY_EXIST:
+                SendSysMessage(LANG_ACCOUNT_ALREADY_EXIST);
+                SetSentErrorMessage(true);
+                return false;
+            case AOR_DB_INTERNAL_ERROR:
+                PSendSysMessage(LANG_ACCOUNT_NOT_CREATED_SQL_ERROR, account_name.c_str());
+                SetSentErrorMessage(true);
+                return false;
+            default:
+                PSendSysMessage(LANG_ACCOUNT_NOT_CREATED, account_name.c_str());
+                SetSentErrorMessage(true);
+                return false;
+        }
+    }
     return true;
 }
 

--- a/src/game/WorldHandlers/AccountMgr.h
+++ b/src/game/WorldHandlers/AccountMgr.h
@@ -38,7 +38,7 @@ enum AccountOpResult
     AOR_DB_INTERNAL_ERROR
 };
 
-#define MAX_ACCOUNT_STR  16
+#define MAX_ACCOUNT_STR 16
 #define MAX_PASSWORD_STR 16
 
 /* A class that is used to manage accounts. */
@@ -49,6 +49,7 @@ class AccountMgr
         ~AccountMgr();
 
         AccountOpResult CreateAccount(std::string username, std::string password);
+        AccountOpResult CreateAccount(std::string username, std::string password, uint32 expansion);
         AccountOpResult DeleteAccount(uint32 accid);
         AccountOpResult ChangeUsername(uint32 accid, std::string new_uname, std::string new_passwd);
         AccountOpResult ChangePassword(uint32 accid, std::string new_passwd);


### PR DESCRIPTION
Standardize account handling between cores since account data is handled by realm-daemon.

These changes allow to set wow expansion during account creation inside mangosd console even in MangosZero.
Calling function without specifying expansion still defaults to "0".

With this commit the account creation is aligned with at least M1 and M2.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/182)
<!-- Reviewable:end -->
