### PR TITLE
Fix PCH build and removed custom impl for localtime_r

### DIFF
--- a/src/game/ChatCommands/AccountCommands.cpp
+++ b/src/game/ChatCommands/AccountCommands.cpp
@@ -30,6 +30,8 @@
 #include "Chat.h"
 #include "Language.h"
 #include "AccountMgr.h"
+#include "DatabaseEnv.h"
+#include "Player.h"
 
 
 /**********************************************************************

--- a/src/game/ChatCommands/AuctionHouseCommands.cpp
+++ b/src/game/ChatCommands/AuctionHouseCommands.cpp
@@ -24,6 +24,8 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
+
 
  /**********************************************************************
      CommandTable : auctionCommandTable

--- a/src/game/ChatCommands/BanAndKickCommands.cpp
+++ b/src/game/ChatCommands/BanAndKickCommands.cpp
@@ -22,12 +22,16 @@
  * and lore are copyrighted by Blizzard Entertainment, Inc.
  */
 
+#include "ace/OS_NS_time.h"
+
 #include "Chat.h"
 #include "Language.h"
 #include "World.h"
 #include "AccountMgr.h"
 #include "Util.h"
 #include "ObjectMgr.h"
+
+
 
  /**********************************************************************
      CommandTable : banCommandTable
@@ -90,7 +94,7 @@ bool ChatHandler::HandleBanListHelper(QueryResult* result)
                 {
                     time_t timeBan = fields2[0].GetUInt64();
                     tm tmBan;
-                    localtime_r(&timeBan, &tmBan);
+                    ACE_OS::localtime_r(&timeBan, &tmBan);
 
                     if (fields2[0].GetUInt64() == fields2[1].GetUInt64())
                     {
@@ -102,7 +106,7 @@ bool ChatHandler::HandleBanListHelper(QueryResult* result)
                     {
                         time_t timeUnban = fields2[1].GetUInt64();
                         tm tmUnban;
-                        localtime_r(&timeUnban, &tmUnban);
+                        ACE_OS::localtime_r(&timeUnban, &tmUnban);
 
                         PSendSysMessage("|%-15.15s|%02d-%02d-%02d %02d:%02d|%02d-%02d-%02d %02d:%02d|%-15.15s|%-15.15s|",
                                         account_name.c_str(), tmBan.tm_year % 100, tmBan.tm_mon + 1, tmBan.tm_mday, tmBan.tm_hour, tmBan.tm_min,

--- a/src/game/ChatCommands/CastAndAuraCommands.cpp
+++ b/src/game/ChatCommands/CastAndAuraCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "SpellAuras.h"
 #include "SpellMgr.h"
 

--- a/src/game/ChatCommands/CommunicationCommands.cpp
+++ b/src/game/ChatCommands/CommunicationCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "World.h"
 
 /*

--- a/src/game/ChatCommands/EventCommands.cpp
+++ b/src/game/ChatCommands/EventCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "GameEventMgr.h"
 #include "GameEventMgr.h"
 

--- a/src/game/ChatCommands/GMCommands.cpp
+++ b/src/game/ChatCommands/GMCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "World.h"
 #include "Weather.h"
 #include "SpellMgr.h"

--- a/src/game/ChatCommands/GMTicketCommands.cpp
+++ b/src/game/ChatCommands/GMTicketCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "World.h"
 #include "GMTicketMgr.h"
 #include "Mail.h"

--- a/src/game/ChatCommands/GameObjectCommands.cpp
+++ b/src/game/ChatCommands/GameObjectCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "G3D/Quat.h"
 #include "MapManager.h"
 #include "GameEventMgr.h"

--- a/src/game/ChatCommands/InstanceCommands.cpp
+++ b/src/game/ChatCommands/InstanceCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "MapManager.h"
 #include "InstanceData.h"
 

--- a/src/game/ChatCommands/ListCommands.cpp
+++ b/src/game/ChatCommands/ListCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "SpellAuras.h"
 
  /**********************************************************************

--- a/src/game/ChatCommands/MailCommands.cpp
+++ b/src/game/ChatCommands/MailCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "Mail.h"
 #include "MassMailMgr.h"
 

--- a/src/game/ChatCommands/MiscellanousCommands.cpp
+++ b/src/game/ChatCommands/MiscellanousCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "World.h"
 #include "PlayerDump.h"
 

--- a/src/game/ChatCommands/PlayerAndCreatureCommands.cpp
+++ b/src/game/ChatCommands/PlayerAndCreatureCommands.cpp
@@ -29,6 +29,8 @@
 #include "MovementGenerator.h"
 #include "FollowerReference.h"
 #include "G3D/Vector3.h"
+#include "ObjectMgr.h"
+
 
  /**********************************************************************
       CommandTable : commandTable

--- a/src/game/ChatCommands/PlayerHonorCommands.cpp
+++ b/src/game/ChatCommands/PlayerHonorCommands.cpp
@@ -24,6 +24,8 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
+
 
  /**********************************************************************
      CommandTable : honorCommandTable

--- a/src/game/ChatCommands/PlayerLearnCommands.cpp
+++ b/src/game/ChatCommands/PlayerLearnCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "SpellMgr.h"
 
  /**********************************************************************

--- a/src/game/ChatCommands/PlayerMiscCommands.cpp
+++ b/src/game/ChatCommands/PlayerMiscCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "World.h"
 #include "Mail.h"
 

--- a/src/game/ChatCommands/PoolCommands.cpp
+++ b/src/game/ChatCommands/PoolCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 
 
 void ChatHandler::ShowPoolListHelper(uint16 pool_id)

--- a/src/game/ChatCommands/ServerCommands.cpp
+++ b/src/game/ChatCommands/ServerCommands.cpp
@@ -24,12 +24,12 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "World.h"
 #include "Config.h"
 #include "GitRevision.h"
 #include "SystemConfig.h"
 #include "UpdateTime.h"
-#include "revision_data.h"
 
  /**********************************************************************
      CommandTable : serverCommandTable

--- a/src/game/ChatCommands/TeleportationAndPositionCommands.cpp
+++ b/src/game/ChatCommands/TeleportationAndPositionCommands.cpp
@@ -24,9 +24,9 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 #include "World.h"
 #include "MapManager.h"
-#include "CellImpl.h"
 
 
 #ifdef _DEBUG_VMAPS

--- a/src/game/ChatCommands/TriggerCommands.cpp
+++ b/src/game/ChatCommands/TriggerCommands.cpp
@@ -24,6 +24,7 @@
 
 #include "Chat.h"
 #include "Language.h"
+#include "ObjectMgr.h"
 
 
 void ChatHandler::ShowTriggerTargetListHelper(uint32 id, AreaTrigger const* at, bool subpart /*= false*/)

--- a/src/game/Object/ObjectMgr.cpp
+++ b/src/game/Object/ObjectMgr.cpp
@@ -22,6 +22,8 @@
  * and lore are copyrighted by Blizzard Entertainment, Inc.
  */
 
+#include "ace/OS_NS_time.h"
+
 #include "ObjectMgr.h"
 #include "Database/DatabaseEnv.h"
 #include "Policies/Singleton.h"
@@ -4994,7 +4996,7 @@ void ObjectMgr::ReturnOrDeleteOldMails(bool serverUp)
 {
     time_t curTime = time(NULL);
     tm lt;
-    localtime_r(&curTime, &lt);
+    ACE_OS::localtime_r(&curTime, &lt);
     uint64 basetime(curTime);
     sLog.outString("Returning mails current time: hour: %d, minute: %d, second: %d ", lt.tm_hour, lt.tm_min, lt.tm_sec);
 

--- a/src/game/WorldHandlers/Chat.h
+++ b/src/game/WorldHandlers/Chat.h
@@ -41,6 +41,7 @@ class QueryResult;
 class ChatHandler;
 class WorldSession;
 class WorldPacket;
+class WorldObject;
 class GMTicket;
 class MailDraft;
 class Object;

--- a/src/game/WorldHandlers/Weather.cpp
+++ b/src/game/WorldHandlers/Weather.cpp
@@ -26,6 +26,8 @@
     \ingroup world
 */
 
+#include "ace/OS_NS_time.h"
+
 #include "Weather.h"
 #include "WorldSession.h"
 #include "Player.h"
@@ -124,7 +126,7 @@ bool Weather::ReGenerate()
     // season source http://aa.usno.navy.mil/data/docs/EarthSeasons.html
     time_t gtime = sWorld.GetGameTime();
     struct tm ltime;
-    localtime_r(&gtime, &ltime);
+    ACE_OS::localtime_r(&gtime, &ltime);
     uint32 season = ((ltime.tm_yday - 78 + 365) / 91) % 4;
 
     static char const* seasonName[WEATHER_SEASONS] = { "spring", "summer", "fall", "winter" };

--- a/src/shared/Common/Common.h
+++ b/src/shared/Common/Common.h
@@ -25,55 +25,7 @@
 #ifndef MANGOSSERVER_COMMON_H
 #define MANGOSSERVER_COMMON_H
 
-// config.h needs to be included 1st
-#ifdef HAVE_CONFIG_H
-#ifdef PACKAGE
-#undef PACKAGE
-#endif // PACKAGE
-
-#ifdef PACKAGE_BUGREPORT
-#undef PACKAGE_BUGREPORT
-#endif // PACKAGE_BUGREPORT
-
-#ifdef PACKAGE_NAME
-#undef PACKAGE_NAME
-#endif // PACKAGE_NAME
-
-#ifdef PACKAGE_STRING
-#undef PACKAGE_STRING
-#endif // PACKAGE_STRING
-
-#ifdef PACKAGE_TARNAME
-#undef PACKAGE_TARNAME
-#endif // PACKAGE_TARNAME
-
-#ifdef PACKAGE_VERSION
-#undef PACKAGE_VERSION
-#endif // PACKAGE_VERSION
-
-#ifdef VERSION
-#undef VERSION
-#endif // VERSION
-
-#undef PACKAGE
-#undef PACKAGE_BUGREPORT
-#undef PACKAGE_NAME
-#undef PACKAGE_STRING
-#undef PACKAGE_TARNAME
-#undef PACKAGE_VERSION
-#undef VERSION
-#endif // HAVE_CONFIG_H
-
 #include "Platform/Define.h"
-
-#if COMPILER == COMPILER_MICROSOFT
-#  pragma warning(disable:4996)                             // 'function': was declared deprecated
-#ifndef __SHOW_STUPID_WARNINGS__
-#  pragma warning(disable:4244)                             // 'argument' : conversion from 'type1' to 'type2', possible loss of data
-#  pragma warning(disable:4355)                             // 'this' : used in base member initializer list
-#endif                                                      // __SHOW_STUPID_WARNINGS__
-
-#endif                                                      // __GNUC__
 
 #include "Utilities/UnorderedMapSet.h"
 #include <stdio.h>

--- a/src/shared/Log/Log.cpp
+++ b/src/shared/Log/Log.cpp
@@ -22,6 +22,8 @@
  * and lore are copyrighted by Blizzard Entertainment, Inc.
  */
 
+#include "ace/OS_NS_time.h"
+
 #include "Common/Common.h"
 #include "Log.h"
 #include "Policies/Singleton.h"
@@ -360,7 +362,7 @@ void Log::outTimestamp(FILE* file)
     time_t tt = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
     std::tm aTm;
-    localtime_r(&tt, &aTm);
+    ACE_OS::localtime_r(&tt, &aTm);
     //       YYYY   year
     //       MM     month (2 digits 01-12)
     //       DD     day (2 digits 01-31)
@@ -375,7 +377,7 @@ void Log::outTime()
     time_t tt = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
     std::tm aTm;
-    localtime_r(&tt, &aTm);
+    ACE_OS::localtime_r(&tt, &aTm);
     //       YYYY   year
     //       MM     month (2 digits 01-12)
     //       DD     day (2 digits 01-31)
@@ -390,7 +392,7 @@ std::string Log::GetTimestampStr()
     time_t tt = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
     std::tm aTm;
-    localtime_r(&tt, &aTm);
+    ACE_OS::localtime_r(&tt, &aTm);
     //       YYYY   year
     //       MM     month (2 digits 01-12)
     //       DD     day (2 digits 01-31)

--- a/src/shared/Utilities/Util.cpp
+++ b/src/shared/Utilities/Util.cpp
@@ -22,6 +22,8 @@
  * and lore are copyrighted by Blizzard Entertainment, Inc.
  */
 
+#include "ace/OS_NS_time.h"
+
 #include "Util.h"
 #include "Timer.h"
 
@@ -152,85 +154,6 @@ void stripLineInvisibleChars(std::string& str)
     {
         str.erase(wpos, str.size());
     }
-}
-
-/**
- * It's a wrapper for the localtime_r function that works on Windows
- *
- * @param time The time to convert.
- * @param result A pointer to a tm structure to receive the broken-down time.
- *
- * @return A pointer to the result.
- */
-#if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
-struct tm* localtime_r(time_t const* time, struct tm *result)
-{
-    localtime_s(result, time);
-    return result;
-}
-#endif
-
-/**
- * It takes a time_t value and returns a tm structure with the same time, but in local time
- *
- * @param time The time to break down.
- *
- * @return A struct tm
- */
-tm TimeBreakdown(time_t time)
-{
-    tm timeLocal;
-    localtime_r(&time, &timeLocal);
-    return timeLocal;
-}
-
-/**
- * Convert local time to UTC time.
- *
- * @param time The time to convert.
- *
- * @return The time in UTC.
- */
-time_t LocalTimeToUTCTime(time_t time)
-{
-    #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__))
-        return time + _timezone;
-    #else
-        return time + timezone;
-    #endif
-}
-
-/**
- * "Get the timestamp of the next time the given hour occurs in the local timezone."
- *
- * The function takes a timestamp, an hour, and a boolean. The timestamp is the time you want to find
- * the next occurrence of the given hour. The hour is the hour you want to find the next occurrence of.
- * The boolean is whether or not you want to find the next occurrence of the hour after the given
- * timestamp
- *
- * @param time The time you want to get the hour timestamp for.
- * @param hour The hour of the day you want to get the timestamp for.
- * @param onlyAfterTime If true, the function will return the next hour after the current time. If
- * false, it will return the current hour.
- *
- * @return A timestamp for the given hour of the day.
- */
-time_t GetLocalHourTimestamp(time_t time, uint8 hour, bool onlyAfterTime)
-{
-    tm timeLocal = TimeBreakdown(time);
-    timeLocal.tm_hour = 0;
-    timeLocal.tm_min  = 0;
-    timeLocal.tm_sec  = 0;
-
-    time_t midnightLocal = mktime(&timeLocal);
-    time_t hourLocal = midnightLocal + hour * HOUR;
-
-    if (onlyAfterTime && hourLocal < time)
-    {
-        hourLocal += DAY;
-    }
-
-    return hourLocal;
 }
 
 std::string secsToTimeString(time_t timeInSecs, TimeFormat timeFormat, bool hoursOnly)
@@ -385,7 +308,7 @@ uint32 TimeStringToSecs(const std::string& timestring)
 std::string TimeToTimestampStr(time_t t)
 {
     tm aTm;
-    localtime_r(&t, &aTm);
+    ACE_OS::localtime_r(&t, &aTm);
     //       YYYY   year
     //       MM     month (2 digits 01-12)
     //       DD     day (2 digits 01-31)

--- a/src/shared/Utilities/Util.h
+++ b/src/shared/Utilities/Util.h
@@ -79,12 +79,6 @@ float GetFloatValueFromArray(Tokens const& data, uint16 index);
  */
 void stripLineInvisibleChars(std::string& src);
 
-struct tm* localtime_r(const time_t* time, struct tm* result);
-
-time_t LocalTimeToUTCTime(time_t time);
-time_t GetLocalHourTimestamp(time_t time, uint8 hour, bool onlyAfterTime = true);
-tm TimeBreakdown(time_t t);
-
 /**
  * @brief
  *


### PR DESCRIPTION
  - One reason we use ACE is it's awesome support for non-standard functions written in a portable way. Whenever you feel tempted to reinvent the wheel, take a look in ace/OS_NS_***.h files, which are wrappers for C library headers  (eg. time.h ->ace/OS_NS_time.h, stdio.h -> ace/OS_NS_stdio.h... you get the point). You'll discover things like localtime_r, strcasecmp, vsnprintf and many other goodies you didn't know they exist.
  - Soon, MaNGOS needs a serious sanitizing process. The headers are so cluttered and so unrelated that building process has become independent of using or not PCH.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/188)
<!-- Reviewable:end -->
