### PR TITLE
Fix Actions runner issues

### DIFF
--- a/.github/workflows/core_build.yml
+++ b/.github/workflows/core_build.yml
@@ -18,7 +18,7 @@ jobs:
         run: sudo apt-get update -y
 
       - name: Install Required Packages
-        run: sudo apt-get install -y git make cmake clang libssl-dev libbz2-dev build-essential default-libmysqlclient-dev libace-dev
+        run: sudo apt-get install -y git make cmake clang libssl-dev libbz2-dev build-essential default-libmysqlclient-dev libace-dev libreadline-dev
 
       - name: Update Compilers
         run: source ./apps/ci/ci-compiler-update.sh

--- a/.github/workflows/core_windows_build.yml
+++ b/.github/workflows/core_windows_build.yml
@@ -22,7 +22,7 @@ jobs:
           sdk-version: 22621
 
       - name: Install OpenSSL
-        run: choco install --no-progress openssl --version=3.4.0
+        run: choco install --no-progress openssl --version=3.4.1
 
       - name: Checkout Submodules
         shell: bash

--- a/.github/workflows/core_windows_build.yml
+++ b/.github/workflows/core_windows_build.yml
@@ -22,7 +22,7 @@ jobs:
           sdk-version: 22621
 
       - name: Install OpenSSL
-        run: choco install --no-progress openssl --version=3.3.2
+        run: choco install --no-progress openssl --version=3.3.3
 
       - name: Checkout Submodules
         shell: bash

--- a/.github/workflows/core_windows_build.yml
+++ b/.github/workflows/core_windows_build.yml
@@ -22,7 +22,7 @@ jobs:
           sdk-version: 22621
 
       - name: Install OpenSSL
-        run: choco install --no-progress openssl --version=3.3.3
+        run: choco install --no-progress openssl --version=3.4.0
 
       - name: Checkout Submodules
         shell: bash


### PR DESCRIPTION
Readline is no longer part of default libs on the Ubuntu runner images.
OpenSSL 3.3.2 is no longer hosted by slproweb, bumped to 3.4.1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/206)
<!-- Reviewable:end -->
