### PR TITLE
Mobs using front-facing Backstab - positioning fix

### DIFF
--- a/src/game/Object/CreatureAI.cpp
+++ b/src/game/Object/CreatureAI.cpp
@@ -127,6 +127,14 @@ CanCastResult CreatureAI::DoCastSpellIfCan(Unit* pTarget, uint32 uiSpell, uint32
         pCaster = pTarget;
     }
 
+    if (uiSpell == 53 || uiSpell == 2589 || uiSpell == 7159) // All Backstab variants
+    {
+        if (pTarget && pTarget->HasInArc(M_PI_F, pCaster))
+        {
+            return CAST_FAIL_OTHER;
+        }
+    }
+  
     if (!pCaster->IsNonMeleeSpellCasted(false) || (uiCastFlags & (CAST_TRIGGERED | CAST_INTERRUPT_PREVIOUS)))
     {
         if (const SpellEntry* pSpell = sSpellStore.LookupEntry(uiSpell))

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -4808,6 +4808,19 @@ SpellCastResult Spell::CheckCast(bool strict)
         return SPELL_FAILED_AFFECTING_COMBAT;
     }
 
+    // Backstab position check
+    if (m_spellInfo->Id == 53 || m_spellInfo->Id == 2589 || m_spellInfo->Id == 7159)
+    {
+        if (Unit* target = m_targets.getUnitTarget())
+        {
+            if (target->HasInArc(M_PI_F, m_caster))
+            {
+                SendCastResult(SPELL_FAILED_NOT_BEHIND);
+                return SPELL_FAILED_NOT_BEHIND;
+            }
+        }
+    }
+   
     if (m_caster->GetTypeId() == TYPEID_PLAYER && !((Player*)m_caster)->isGameMaster() &&
         sWorld.getConfig(CONFIG_BOOL_VMAP_INDOOR_CHECK) &&
         VMAP::VMapFactory::createOrGetVMapManager()->isLineOfSightCalcEnabled())


### PR DESCRIPTION
Added code to address an issue where certain NPCs are able to use Backstab while facing the player from the front, nullifying the positioning conditions that Backstab requires.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/208)
<!-- Reviewable:end -->
