### PR TITLE
Auction House Limited-Vendor-Item Availability

### DIFF
--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -1380,7 +1380,7 @@ bool AuctionBotSeller::Initialize()
 
     // Load NPC vendor items for filtering
     sLog.outString("Loading npc vendor items for filter..");
-    if (QueryResult* result = WorldDatabase.Query("SELECT DISTINCT `item` FROM `npc_vendor`"))
+    if (QueryResult* result = WorldDatabase.Query("SELECT DISTINCT `item` FROM `npc_vendor` WHERE `maxcount` = 0"))
     {
         BarGoLink bar(result->GetRowCount());
         do


### PR DESCRIPTION
The Problem:
The Auction House Bot is intended to mimic real player auction behavior, which includes selling items commonly farmed and sold by players.  However, the AH Bot was designed to not sell any item that an NPC Vendor sells in any quantity. While this makes sense, it prevents items that any Vendor sells in even very limited quantities (such as all sorts of Leather) from ever being listed.

The Fix:
Better mimic desired player auction behavior by allowing the AH Bot to sell limited-quantity vendor items by narrowing the general vendor item restriction to ONLY those items that vendors sell in unlimited quantities.

The Details:
The AH Bot queries the npc_vendor table to compile a list of items it will Not list on the AH.  These query results are narrowed by adding 'WHERE maxcount = 0', which will only capture items that vendors sell in Unlimited quantities, thus allowing Leather to appear on the AH.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/212)
<!-- Reviewable:end -->
