### PR TITLE
Fixes all the memory leaks in the AIPlayerBot system I could find

### DIFF
--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -1219,6 +1219,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target)
         LootObject loot = *aiObjectContext->GetValue<LootObject>("loot target");
         if (!loot.IsLootPossible(bot))
         {
+            delete spell;
             return false;
         }
 
@@ -1247,6 +1248,7 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target)
     {
         bot->SetFacingTo(bot->GetAngle(faceTo));
         SetNextCheckDelay(sPlayerbotAIConfig.globalCoolDown);
+        delete spell;
         return false;
     }
 

--- a/src/modules/Bots/playerbot/strategy/Action.cpp
+++ b/src/modules/Bots/playerbot/strategy/Action.cpp
@@ -98,6 +98,7 @@ void NextAction::destroy(NextAction** actions)
     {
         delete actions[i];
     }
+    delete [] actions;
 }
 
 Value<Unit*>* Action::GetTargetValue()

--- a/src/modules/Bots/playerbot/strategy/Engine.cpp
+++ b/src/modules/Bots/playerbot/strategy/Engine.cpp
@@ -271,6 +271,10 @@ bool Engine::MultiplyAndPush(NextAction** actions, float forceRelevance, bool sk
                     queue.Push(new ActionBasket(action, k, skipPrerequisites, event));
                     pushed = true;
                 }
+                else
+                {
+                    delete action;
+                }
 
                 delete nextAction;
             }
@@ -279,7 +283,7 @@ bool Engine::MultiplyAndPush(NextAction** actions, float forceRelevance, bool sk
                 break;
             }
         }
-        delete actions;
+        delete [] actions;
     }
     return pushed;
 }

--- a/src/modules/Bots/playerbot/strategy/Queue.cpp
+++ b/src/modules/Bots/playerbot/strategy/Queue.cpp
@@ -19,6 +19,7 @@ void Queue::Push(ActionBasket *action)
                 {
                     basket->setRelevance(action->getRelevance());
                 }
+                delete action->getAction();
                 delete action;
                 return;
             }


### PR DESCRIPTION
Fixes several memory leaks in the PlayerBot module.
This brought mangosd+playerbot from leaking about 1gb per day to 0, so I think I got them all.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/213)
<!-- Reviewable:end -->
