### PR TITLE
Bot->Taxi crash fix

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/CheckMountStateAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/CheckMountStateAction.cpp
@@ -13,10 +13,13 @@ bool CheckMountStateAction::Execute(Event event)
     {
         return false;
     }
-
     if (bot->IsTaxiFlying())
     {
         return false;
+    }
+    if (master->IsTaxiFlying())
+    {
+        return false;  // not the kind of mounting this is supposed to react to
     }
 
     if (master->IsMounted() && !bot->IsMounted())
@@ -36,6 +39,11 @@ bool CheckMountStateAction::Mount()
 {
     Player* master = GetMaster();
     ai->RemoveShapeshift();
+    Unit::AuraList const& auras = master->GetAurasByType(SPELL_AURA_MOUNTED);
+    if (auras.empty())
+    {
+        return false;
+    }
 
     const SpellEntry* masterSpell = master->GetAurasByType(SPELL_AURA_MOUNTED).front()->GetSpellProto();
     int32 masterSpeed = max(masterSpell->EffectBasePoints[1], masterSpell->EffectBasePoints[2]);


### PR DESCRIPTION
I discovered this crash by having a player take a taxi  flight while a non-following grouped bot was standing around elsewhere.  The bot hit this code assuming I'd mounted a horse or something, and tried to copy my horse-mounting spell.  Since I had no such spell, the server crashed.

In addition to checking for the spell now, I also put in a shortcut to stop the bot from trying to mount its horse when the master jumps on a taxi flight.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/214)
<!-- Reviewable:end -->
