### PR TITLE
Purges old ahbot mail from expired auctions

### DIFF
--- a/src/game/AuctionHouseBot/AuctionHouseBot.h
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.h
@@ -544,10 +544,16 @@ private:
      */
     void InitializeAgents();
 
+    /**
+     * @Brief Purges mail of all the returned unsold items.
+     */
+    void PurgeMailedItems();
+
     AuctionBotAgent* m_Buyer; /**< The buyer (\ref AuctionBotBuyer) for this \ref AuctionHouseBot */
     AuctionBotAgent* m_Seller; /**< The seller (\ref AuctionBotSeller) for this \ref AuctionHouseBot */
 
     uint32 m_OperationSelector; /**< 0..2*MAX_AUCTION_HOUSE_TYPE-1 */
+    time_t m_lastMailCleanup;  /**< Last time we cleaned up mails */
 };
 
 /// Convenience to easily access the singleton for the \ref AuctionHouseBot

--- a/src/modules/Bots/ahbot/AhBot.cpp
+++ b/src/modules/Bots/ahbot/AhBot.cpp
@@ -184,6 +184,7 @@ void AhBot::ForceUpdate()
     }
 
     CleanupHistory();
+    PurgeMailedItems();
 
     sLog.outString("AhBot auction check finished. %d auctions answered, %d new auctions added. Next check in %d seconds",
             answered, added, sAhBotConfig.updateInterval);
@@ -1137,4 +1138,25 @@ double AhBot::GetRarityPriceMultiplier(const ItemPrototype* proto)
 
     return 1.0;
 
+}
+
+void AhBot::PurgeMailedItems()
+{
+    uint32 guid = sAhBotConfig.guid;
+    if (!guid)
+        return;
+
+    CharacterDatabase.PExecute(
+        "DELETE ii FROM item_instance ii "
+        "INNER JOIN mail_items mi ON ii.guid = mi.item_guid "
+        "INNER JOIN mail m ON mi.mail_id = m.id "
+        "WHERE m.receiver = '%u'", guid);
+
+    CharacterDatabase.PExecute(
+        "DELETE mi FROM mail_items mi "
+        "INNER JOIN mail m ON mi.mail_id = m.id "
+        "WHERE m.receiver = '%u'", guid);
+
+    CharacterDatabase.PExecute(
+        "DELETE FROM mail WHERE receiver = '%u'", guid);
 }

--- a/src/modules/Bots/ahbot/AhBot.h
+++ b/src/modules/Bots/ahbot/AhBot.h
@@ -66,6 +66,7 @@ namespace ahbot
         uint32 GetTime(string category, uint32 id, uint32 auctionHouse, uint32 type);
         void SetTime(string category, uint32 id, uint32 auctionHouse, uint32 type, uint32 value);
         uint32 GetSellTime(uint32 itemId, uint32 auctionHouse, Category*& category);
+        void PurgeMailedItems();
 
     public:
         static uint32 auctionIds[MAX_AUCTIONS];


### PR DESCRIPTION
Every time the AHBot has an item that doesn't sell, and probably even when they do, they receive in-game Mail generated by the server.  The AHBot does not check his mail, and in my case, hundreds of thousands of mails had accumulated in the tables, causing my server restarts to take several minutes as it scanned them all at boot.

While this AHBot junk mail will probably be cleaned up eventually, it is nowhere near fast enough to prevent headaches.

Therefore, since the AHBot does not need mail, this change will periodically clear it out for him.

*Note: I do not quite understand why there are two AHBot systems, one in game/ and one in modules/, I went ahead and made the same change in both places.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/215)
<!-- Reviewable:end -->
