### PR TITLE
AIBots get Quest Spells they need

### DIFF
--- a/src/modules/Bots/playerbot/PlayerbotFactory.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotFactory.cpp
@@ -129,6 +129,7 @@ void PlayerbotFactory::Randomize(bool incremental)
     InitTalents();
     InitAvailableSpells();
     InitSpecialSpells();
+    InitQuestSpells();
     InitMounts();
     UpdateTradeSkills();
     bot->SaveToDB();
@@ -1337,6 +1338,123 @@ void PlayerbotFactory::InitSpecialSpells()
     {
         uint32 spellId = *i;
         bot->learnSpell(spellId, false);
+    }
+}
+
+/**
+ * Initializes quest-reward and auto-learned spells for the player bot.
+ * These are class-specific spells that aren't learned from trainers.
+ */
+void PlayerbotFactory::InitQuestSpells()
+{
+    uint8 cls = bot->getClass();
+    uint32 level = bot->getLevel();
+
+    switch (cls)
+    {
+        case CLASS_HUNTER:
+            if (level >= 10)
+            {
+                if (!bot->HasSpell(883))   bot->learnSpell(883, false);   // Call Pet
+                if (!bot->HasSpell(982))   bot->learnSpell(982, false);   // Revive Pet
+                if (!bot->HasSpell(1515))  bot->learnSpell(1515, false);  // Tame Beast
+                if (!bot->HasSpell(6991))  bot->learnSpell(6991, false);  // Feed Pet
+                if (!bot->HasSpell(5149))  bot->learnSpell(5149, false);  // Beast Training
+            }
+            if (level >= 12)
+            {
+                if (!bot->HasSpell(136))   bot->learnSpell(136, false);   // Mend Pet
+            }
+            break;
+
+        case CLASS_WARLOCK:
+            if (level >= 1)
+            {
+                if (!bot->HasSpell(688))   bot->learnSpell(688, false);   // Summon Imp
+            }
+            if (level >= 10)
+            {
+                if (!bot->HasSpell(697))   bot->learnSpell(697, false);   // Summon Voidwalker
+            }
+            if (level >= 20)
+            {
+                if (!bot->HasSpell(712))   bot->learnSpell(712, false);   // Summon Succubus
+            }
+            if (level >= 30)
+            {
+                if (!bot->HasSpell(691))   bot->learnSpell(691, false);   // Summon Felhunter
+            }
+            break;
+
+        case CLASS_WARRIOR:
+            if (level >= 10)
+            {
+                if (!bot->HasSpell(71))    bot->learnSpell(71, false);    // Defensive Stance
+            }
+            if (level >= 30)
+            {
+                if (!bot->HasSpell(2458))  bot->learnSpell(2458, false);  // Berserker Stance
+            }
+            break;
+
+        case CLASS_DRUID:
+            if (level >= 10)
+            {
+                if (!bot->HasSpell(5487))  bot->learnSpell(5487, false);  // Bear Form
+            }
+            if (level >= 16)
+            {
+                if (!bot->HasSpell(1066))  bot->learnSpell(1066, false);  // Aquatic Form
+            }
+            if (level >= 20)
+            {
+                if (!bot->HasSpell(768))   bot->learnSpell(768, false);   // Cat Form
+            }
+            if (level >= 30)
+            {
+                if (!bot->HasSpell(783))   bot->learnSpell(783, false);   // Travel Form
+            }
+            if (level >= 40)
+            {
+                if (!bot->HasSpell(9634))  bot->learnSpell(9634, false);  // Dire Bear Form
+            }
+            break;
+
+        case CLASS_PALADIN:
+            if (level >= 12)
+            {
+                if (!bot->HasSpell(7328))  bot->learnSpell(7328, false);  // Redemption
+            }
+            if (level >= 40)
+            {
+                if (!bot->HasSpell(13819)) bot->learnSpell(13819, false); // Summon Warhorse
+            }
+            if (level >= 60)
+            {
+                if (!bot->HasSpell(23214)) bot->learnSpell(23214, false); // Summon Charger
+            }
+            // Horde-specific
+            if (bot->GetTeam() == HORDE && level >= 50)
+            {
+                if (!bot->HasSpell(31892)) bot->learnSpell(31892, false); // Seal of Blood
+            }
+            break;
+
+        case CLASS_SHAMAN:
+            // Totem quests - these vary by race/level but add common ones
+            if (level >= 10)
+            {
+                if (!bot->HasSpell(8012))  bot->learnSpell(8012, false);  // Purge (often quest)
+            }
+            break;
+        case CLASS_PRIEST:
+            break;
+        case CLASS_ROGUE:
+            break;
+        case CLASS_MAGE:
+            break;
+        default:
+            break;
     }
 }
 

--- a/src/modules/Bots/playerbot/PlayerbotFactory.h
+++ b/src/modules/Bots/playerbot/PlayerbotFactory.h
@@ -128,6 +128,11 @@ private:
     void InitSpecialSpells();
 
     /**
+     * @brief Initializes spells not taught by trainers.
+     */
+    void InitQuestSpells();
+
+    /**
      * @brief Initializes the talents for the player bot.
      */
     void InitTalents();


### PR DESCRIPTION
During an AI Bot creation, skills are added from various sources, including the config file and trainers.  But some skills only come from Quests, many of which are vitally necessary for a class, such as the Hunter pet calling skill, for example.

This fixes the issue by adding the Quest-Specific skills to the bots for the various classes.

Unlike my other fixes, this is probably very Mangos-Zero specific.  If that's a problem, LMK or just delete this PR, but I needed this issue fixed, and this is what I came up with. :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/217)
<!-- Reviewable:end -->
