### PR TITLE
Improves the bot spawning and teleporting logic

### DIFF
--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
@@ -9,6 +9,9 @@
 #include "PlayerbotAI.h"
 #include "Player.h"
 #include "AiFactory.h"
+#include "GridDefines.h"
+#include "Map.h"
+#include "MapManager.h"
 
 INSTANTIATE_SINGLETON_1(RandomPlayerbotMgr);
 
@@ -216,6 +219,15 @@ bool RandomPlayerbotMgr::ProcessBot(uint32 bot)
         return true;
     }
 
+    if (!IsZoneSafeForBot(player, player->GetMapId(), player->GetPositionX(),
+                          player->GetPositionY(), player->GetPositionZ()))
+    {
+        sLog.outDetail("Bot %d is in unsafe zone, forcing teleport", bot);
+        RandomTeleportForLevel(player);
+        SetEventValue(bot, "teleport", 1, sPlayerbotAIConfig.maxRandomBotInWorldTime);
+        return true;
+    }
+
     uint32 teleport = GetEventValue(bot, "teleport");
     if (!teleport)
     {
@@ -298,8 +310,8 @@ void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
         "%u - (AVG(`t`.`maxlevel`) + AVG(`t`.`minlevel`)) / 2 `delta` FROM `creature` `c` "
     "INNER JOIN `creature_template` `t` ON `c`.`id` = `t`.`entry` GROUP BY `t`.`entry`) `q` "
         "WHERE `delta` >= 0 AND `delta` <= %u AND `map` IN (%s)",
-
         bot->getLevel(), sPlayerbotAIConfig.randomBotTeleLevel, sPlayerbotAIConfig.randomBotMapsAsString.c_str());
+
     if (results)
     {
         do
@@ -309,8 +321,11 @@ void RandomPlayerbotMgr::RandomTeleportForLevel(Player* bot)
             float x = fields[1].GetFloat();
             float y = fields[2].GetFloat();
             float z = fields[3].GetFloat();
-            WorldLocation loc(mapId, x, y, z, 0);
-            locs.push_back(loc);
+            if (IsZoneSafeForBot(bot, mapId, x, y, z))
+            {
+                WorldLocation loc(mapId, x, y, z, 0);
+                locs.push_back(loc);
+            }
         } while (results->NextRow());
         delete results;
     }
@@ -387,10 +402,15 @@ void RandomPlayerbotMgr::RandomizeFirst(Player* bot)
         for (GameTeleMap::const_iterator itr = teleMap.begin(); itr != teleMap.end(); ++itr)
         {
             GameTele const* tele = &itr->second;
-            if (tele->mapId == mapId)
+            if (( tele->mapId == mapId) &&
+               (IsZoneSafeForBot(bot, tele->mapId, tele->position_x, tele->position_y, tele->position_z)))
             {
                 locs.push_back(tele);
             }
+        }
+        if (locs.empty()) // no safe locations found, so try another map
+        {
+            continue;
         }
 
         index = urand(0, locs.size() - 1);
@@ -408,7 +428,8 @@ void RandomPlayerbotMgr::RandomizeFirst(Player* bot)
         level = min(level, maxLevel);
         if (!level) level = 1;
 
-        if (urand(0, 100) < 100 * sPlayerbotAIConfig.randomBotMaxLevelChance)
+        // only create a high level mob if they are in a high level zone
+        if ((urand(0, 100) < 100 * sPlayerbotAIConfig.randomBotMaxLevelChance) && level >= 40)
         {
             level = maxLevel;
         }
@@ -582,6 +603,62 @@ vector<uint32> RandomPlayerbotMgr::GetFreeBots(bool alliance)
     return guids;
 }
 
+bool RandomPlayerbotMgr::IsZoneSafeForBot(Player* bot, uint32 mapId, float x, float y, float z)
+{
+    Map* map = sMapMgr.FindMap(mapId);
+    if (!map)
+        return false;
+    TerrainInfo const* terrain = map->GetTerrain();
+    if (!terrain)
+        return false;
+
+    CellPair cell_pair = MaNGOS::ComputeCellPair(x, y);
+    uint32 cell_id = (cell_pair.y_coord * TOTAL_NUMBER_OF_CELLS_PER_MAP) + cell_pair.x_coord;
+    std::pair<uint32, uint32> mapCell = std::make_pair(mapId, cell_id);
+
+    uint32 areaId = 0;
+    std::map<std::pair<uint32, uint32>, uint32>::iterator cacheItr = m_cellToAreaCache.find(mapCell);
+    if (cacheItr != m_cellToAreaCache.end())
+    {
+        areaId = cacheItr->second;
+    }
+    else
+    {
+        areaId = terrain->GetAreaId(x, y, z);
+        m_cellToAreaCache[mapCell] = areaId;
+    }
+
+    AreaTableEntry const* area = sAreaStore.LookupEntry(areaId);
+    if (!area)
+        return true;
+
+    if (area->team != AREATEAM_NONE)
+    {
+        bool botIsAlliance = IsAlliance(bot->getRace());
+        if (botIsAlliance && area->team != AREATEAM_ALLY)
+            return false;
+        if (!botIsAlliance && area->team != AREATEAM_HORDE)
+            return false;
+    }
+
+    if (m_areaCreatureStatsMap.empty()) // calculate stats if not done yet
+    {
+        const_cast<RandomPlayerbotMgr*>(this)->CalculateAreaCreatureStats();
+    }
+
+    std::map<uint32, AreaCreatureStats>::const_iterator statsItr = m_areaCreatureStatsMap.find(area->ID);
+    AreaCreatureStats const* stats = (statsItr != m_areaCreatureStatsMap.end()) ? &statsItr->second : nullptr;
+    if (stats && stats->creatureCount > 0)
+    {
+        uint8 botLevel = bot->getLevel();
+        uint8 tolerance = sPlayerbotAIConfig.randomBotTeleLevel;
+        if (botLevel < stats->minLevel - tolerance || botLevel > stats->maxLevel + tolerance)
+            return false;
+        return true;
+    }
+    return false;
+}
+
 uint32 RandomPlayerbotMgr::GetEventValue(uint32 bot, string event)
 {
     uint32 value = 0;
@@ -622,6 +699,80 @@ uint32 RandomPlayerbotMgr::SetEventValue(uint32 bot, string event, uint32 value,
 
     return value;
 }
+
+void RandomPlayerbotMgr::CalculateAreaCreatureStats()
+{
+    sLog.outString(">> [Playerbots] Calculating area creature statistics...");
+
+    std::map<std::pair<uint32, uint32>, uint32> cellToAreaCache; // (mapId, cellId) -> areaId
+    std::map<uint32, std::vector<uint8>> areaLevels;
+
+    uint32 getAreaIdCalls = 0;
+    uint32 totalCreatures = 0;
+
+    CreatureDataMap const* creatureDataMap = sObjectMgr.GetCreatureDataMap();
+    for (CreatureDataMap::const_iterator itr = creatureDataMap->begin(); itr != creatureDataMap->end(); ++itr)
+    {
+        CreatureData const& data = itr->second;
+        CreatureInfo const* cInfo = sObjectMgr.GetCreatureTemplate(data.id);
+
+        if (!cInfo || cInfo->NpcFlags != 0 || cInfo->UnitFlags & UNIT_FLAG_NON_ATTACKABLE)
+            continue;
+
+        totalCreatures++;
+
+        CellPair cell_pair = MaNGOS::ComputeCellPair(data.posX, data.posY);
+        uint32 cell_id = (cell_pair.y_coord * TOTAL_NUMBER_OF_CELLS_PER_MAP) + cell_pair.x_coord;
+        std::pair<uint32, uint32> mapCell = std::make_pair(data.mapid, cell_id);
+
+        uint32 areaId = 0;
+
+        std::map<std::pair<uint32, uint32>, uint32>::iterator cacheItr = cellToAreaCache.find(mapCell);
+        if (cacheItr != cellToAreaCache.end())
+        {
+            areaId = cacheItr->second;
+        }
+        else
+        {
+            Map* map = const_cast<Map*>(sMapMgr.FindMap(data.mapid));
+            if (!map || !map->GetTerrain())
+                continue;
+
+            areaId = map->GetTerrain()->GetAreaId(data.posX, data.posY, data.posZ);
+            cellToAreaCache[mapCell] = areaId; // Cache for future lookups
+            getAreaIdCalls++;
+        }
+
+        if (areaId == 0)
+            continue;
+
+        uint8 avgLevel = (cInfo->MinLevel + cInfo->MaxLevel) / 2;
+        areaLevels[areaId].push_back(avgLevel);
+    }
+
+    uint32 statsCount = 0;
+    for (std::map<uint32, std::vector<uint8>>::iterator itr = areaLevels.begin(); itr != areaLevels.end(); ++itr)
+    {
+        std::vector<uint8>& levels = itr->second;
+        if (levels.size() < 10) // need at least 10 creatures to have meaningful statistics
+            continue;
+
+        std::sort(levels.begin(), levels.end());
+
+        // to avoid outliers, use 25th and 75th percentiles
+        size_t p25 = levels.size() / 4;
+        size_t p75 = (levels.size() * 3) / 4;
+
+        AreaCreatureStats& stats = m_areaCreatureStatsMap[itr->first];
+        stats.minLevel = levels[p25];
+        stats.maxLevel = levels[p75];
+        stats.creatureCount = levels.size();
+        ++statsCount;
+    }
+
+    sLog.outString(">> [Playerbots] Calculated spawn stats for %u areas", statsCount);
+}
+
 
 bool ChatHandler::HandlePlayerbotConsoleCommand(char* args)
 {

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
@@ -12,7 +12,18 @@ class Object;
 class Item;
 
 using namespace std;
+/**
+* \struct AreaCreatureStats
+* \brief Entry representing creature levels within an area for playerbot spawning decisions
+*/
+struct AreaCreatureStats
+{
+    uint8   minLevel;
+    uint8   maxLevel;
+    uint16  creatureCount;
 
+    AreaCreatureStats() : minLevel(0), maxLevel(0), creatureCount(0) {}
+};
 class MANGOS_DLL_SPEC RandomPlayerbotMgr : public PlayerbotHolder
 {
     public:
@@ -58,10 +69,14 @@ class MANGOS_DLL_SPEC RandomPlayerbotMgr : public PlayerbotHolder
         void RandomTeleportForLevel(Player* bot);
         void RandomTeleport(Player* bot, vector<WorldLocation> &locs);
         uint32 GetZoneLevel(uint32 mapId, float teleX, float teleY, float teleZ);
+        bool IsZoneSafeForBot(Player* bot, uint32 mapId, float x, float y, float z);
+        void CalculateAreaCreatureStats();
 
     private:
         vector<Player*> players;
         int processTicks;
+        std::map<uint32, AreaCreatureStats> m_areaCreatureStatsMap;
+        std::map<std::pair<uint32, uint32>, uint32> m_cellToAreaCache;
 };
 
 #define sRandomPlayerbotMgr MaNGOS::Singleton<RandomPlayerbotMgr>::Instance()


### PR DESCRIPTION
(this one was inspired by getting tired of HL hoarde bots killing questgivers in low level areas).

Improves the bot spawning and teleporting logic in the following way:
* The creature min and max levels for all areas is calculated at boot time. 
* The AIPlayerBot will only spawn a bot in a zone that is their faction or neutral, and only if the creatures are in the level range specified in aiplayerbot.conf file. 
* Existing Bots found in illegal zones are teleported away. 

This has the following effects: 
1. Players can find bots in their level range to group with in appropriate zones. 
2. Players do not have to deal with high level other-faction bots killing the locals.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/219)
<!-- Reviewable:end -->
