### PR TITLE
Fix to threat system

### DIFF
--- a/src/game/Object/UnitEvents.h
+++ b/src/game/Object/UnitEvents.h
@@ -157,9 +157,8 @@ class ThreatRefStatusChangeEvent : public UnitBaseEvent
         ThreatRefStatusChangeEvent(uint32 pType, HostileReference* pHostileReference, float pValue) : UnitBaseEvent(pType)
         {
             iHostileReference = pHostileReference;
+            // ifValue in union, so don't alter other values
             iFValue = pValue;
-            iIValue = 0;
-            iBValue = false;
             iThreatManager = nullptr;
         }
 
@@ -173,8 +172,7 @@ class ThreatRefStatusChangeEvent : public UnitBaseEvent
         ThreatRefStatusChangeEvent(uint32 pType, HostileReference* pHostileReference, bool pValue) : UnitBaseEvent(pType)
         {
             iHostileReference = pHostileReference;
-            iFValue = 0.0f;
-            iIValue = 0;
+            // iBValue in union, so don't alter other values
             iBValue = pValue;
             iThreatManager = nullptr;
         }


### PR DESCRIPTION
The threat system was broken because the tracked values for threat were stored in a union where memory was overwritten the moment it was updated.  This should fix it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/220)
<!-- Reviewable:end -->
