### PR TITLE
No packet spam for bots

### DIFF
--- a/src/game/WorldHandlers/Map.cpp
+++ b/src/game/WorldHandlers/Map.cpp
@@ -2174,6 +2174,11 @@ void Map::SendObjectUpdates()
     WorldPacket packet;                                     // here we allocate a std::vector with a size of 0x10000
     for (UpdateDataMapType::iterator iter = update_players.begin(); iter != update_players.end(); ++iter)
     {
+#ifdef ENABLE_PLAYERBOTS
+            // Don't waste CPU building packets for bots - they have no network client
+            if (iter->first->GetPlayerbotAI())
+                continue;
+#endif
         iter->second.BuildPacket(&packet);
         iter->first->GetSession()->SendPacket(&packet);
         packet.clear();                                     // clean the string


### PR DESCRIPTION
Get several hundred playerbots in your server, and clients become bogged down.  There are probably lots of tweeks that would help, but this one change made the difference between two minutes waiting for character list and instant play.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/221)
<!-- Reviewable:end -->
