### PR TITLE
Bot Gathering suspended when following

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/AddLootAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/AddLootAction.cpp
@@ -3,6 +3,7 @@
 #include "AddLootAction.h"
 
 #include "../../LootObjectStack.h"
+#include "../../PlayerbotAIConfig.h"
 
 using namespace ai;
 
@@ -68,6 +69,17 @@ bool AddGatheringLootAction::AddLoot(ObjectGuid guid)
     if (!loot.IsLootPossible(bot))
     {
         return false;
+    }
+
+    // NC gathering is a problem if you are supposed to be following
+    Player* master = ai->GetMaster();
+    if (master && ai->HasStrategy("follow master", BOT_STATE_NON_COMBAT))
+    {
+        float masterDist = bot->GetDistance(master);
+        if (masterDist > sPlayerbotAIConfig.reactDistance / 2)
+        {
+            return false;
+        }
     }
 
     return AddAllLootAction::AddLoot(guid);


### PR DESCRIPTION
I noticed that playerbots, even those following a player, if distracted by their gathering skills, could get stuck in a looting state.  While there is probably a deeper fix to this issue, it seems safe enough to say that Follower bots falling behind should not be looting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/222)
<!-- Reviewable:end -->
