### PR TITLE
debug logging on packets

### DIFF
--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -901,6 +901,11 @@ int WorldSocket::iSendPacket(const WorldPacket& pct)
         return -1;
     }
 
+    if (sLog.HasLogLevelOrHigher(LOG_LVL_DEBUG))   // allow server packet logging
+    {
+        sLog.outWorldPacketDump(uint32(get_handle()), pct.GetOpcode(), pct.GetOpcodeName(), &pct, false);
+    }
+
     ServerPktHeader header;
 
     header.cmd = pct.GetOpcode();


### PR DESCRIPTION
Small tweek that adds Server->Client packet logging to world-packets.log, but ONLY when the LogLevel is 3.  I completely understand how much noise this creates in high activity servers, which is why it's behind high log level.  I also understand it's been really helping me understand problems with getting bots and pets on boats.

So I humbly submit it for your consideration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/224)
<!-- Reviewable:end -->
