### PR TITLE
Console player teleportation and listing

### DIFF
--- a/src/game/ChatCommands/GMCommands.cpp
+++ b/src/game/ChatCommands/GMCommands.cpp
@@ -134,7 +134,27 @@ bool ChatHandler::HandlePInfoCommand(char* args)
     uint32 silv = (money % GOLD) / SILVER;
     uint32 copp = (money % GOLD) % SILVER;
     PSendSysMessage(LANG_PINFO_LEVEL, timeStr.c_str(), level, gold, silv, copp);
+    if (target)
+    {
+        uint32 mapId = target->GetMapId();
+        uint32 zoneId = target->GetZoneId();
+        float posX = target->GetPositionX();
+        float posY = target->GetPositionY();
+        float posZ = target->GetPositionZ();
+        float orientation = target->GetOrientation();
 
+        MapEntry const* mapEntry = sMapStore.LookupEntry(mapId);
+        AreaTableEntry const* zoneEntry = GetAreaEntryByAreaID(zoneId);
+
+        PSendSysMessage("Location: Map %u (%s), Zone %u (%s)",
+                        mapId,
+                        (mapEntry ? mapEntry->name[GetSessionDbcLocale()] : "<unknown>"),
+                        zoneId,
+                        (zoneEntry ? zoneEntry->area_name[GetSessionDbcLocale()] : "<unknown>"));
+
+        PSendSysMessage("Coordinates: X=%.2f Y=%.2f Z=%.2f O=%.2f",
+                        posX, posY, posZ, orientation);
+    }
     return true;
 }
 

--- a/src/game/ChatCommands/ListCommands.cpp
+++ b/src/game/ChatCommands/ListCommands.cpp
@@ -364,6 +364,45 @@ bool ChatHandler::HandleListItemCommand(char* args)
     return true;
 }
 
+bool ChatHandler::HandleListPlayersCommand(char* args)
+{
+    uint32 limit;
+    if (!ExtractOptUInt32(&args, limit, 100))
+    {
+        return false;
+    }
+
+    uint32 count = 0;
+
+    PSendSysMessage("Online Players (Limit %u):", limit);
+    PSendSysMessage("===========================================");
+
+    sObjectAccessor.DoForAllPlayers([&](Player* player)
+    {
+        if (count >= limit)
+        {
+            return;
+        }
+
+        uint32 mapId = player->GetMapId();
+        uint32 zoneId = player->GetZoneId();
+
+        MapEntry const* mapEntry = sMapStore.LookupEntry(mapId);
+        AreaTableEntry const* zoneEntry = GetAreaEntryByAreaID(zoneId);
+
+        PSendSysMessage("%-20s | Lvl %-2u | Map %u Zone %u (%s)",
+                       player->GetName(),
+                       player->getLevel(),
+                       mapId,
+                       zoneId,
+                       (zoneEntry ? zoneEntry->area_name[GetSessionDbcLocale()] : "Unknown"));
+
+        count++;
+    });
+
+    return true;
+}
+
 bool ChatHandler::HandleListObjectCommand(char* args)
 {
     // number or [name] Shift-click form |color|Hgameobject_entry:go_id|h[name]|h|r

--- a/src/game/ChatCommands/LookupCommands.cpp
+++ b/src/game/ChatCommands/LookupCommands.cpp
@@ -255,13 +255,6 @@ bool ChatHandler::HandleLookupAreaCommand(char* args)
 // Find tele in game_tele order by name
 bool ChatHandler::HandleLookupTeleCommand(char* args)
 {
-    if (!*args)
-    {
-        SendSysMessage(LANG_COMMAND_TELE_PARAMETER);
-        SetSentErrorMessage(true);
-        return false;
-    }
-
     std::string namepart = args;
     std::wstring wnamepart;
 

--- a/src/game/WorldHandlers/Chat.cpp
+++ b/src/game/WorldHandlers/Chat.cpp
@@ -338,7 +338,8 @@ ChatCommand* ChatHandler::getCommandTable()
         { "creature",       SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleListCreatureCommand,        "", NULL },
         { "item",           SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleListItemCommand,            "", NULL },
         { "object",         SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleListObjectCommand,          "", NULL },
-        { "talents",        SEC_ADMINISTRATOR,  false, &ChatHandler::HandleListTalentsCommand,         "", NULL },
+        { "talents",        SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleListTalentsCommand,         "", NULL },
+        { "players",        SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleListPlayersCommand,         "", NULL },
         { NULL,             0,                  false, NULL,                                           "", NULL }
     };
 

--- a/src/game/WorldHandlers/Chat.h
+++ b/src/game/WorldHandlers/Chat.h
@@ -380,6 +380,7 @@ class ChatHandler
         bool HandleListCreatureCommand(char* args);
         bool HandleListItemCommand(char* args);
         bool HandleListObjectCommand(char* args);
+        bool HandleListPlayersCommand(char* args);
         bool HandleListTalentsCommand(char* args);
 
         bool HandleLookupAccountEmailCommand(char* args);


### PR DESCRIPTION
Extension to the admin console/chat command system that allows:
1. Showing player locations in PINFO
2. Players to be listed with LIST PLAYERS <optional max>
3. LOOKUP TELE <no arg> to list ALL available teleportation destinations
4. TELE NAME <player> can now target mapid and coordinates instead of only the named destinations

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/225)
<!-- Reviewable:end -->
