### PR TITLE
Bot taxi monitoring crash-bad packet

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/RememberTaxiAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/RememberTaxiAction.cpp
@@ -7,8 +7,6 @@ using namespace ai;
 
 bool RememberTaxiAction::Execute(Event event)
 {
-
-
     WorldPacket p(event.getPacket());
     p.rpos(0);
 
@@ -19,26 +17,41 @@ bool RememberTaxiAction::Execute(Event event)
             LastMovement& movement = context->GetValue<LastMovement&>("last movement")->Get();
             movement.taxiNodes.clear();
             movement.taxiNodes.resize(2);
-
-            p >> movement.taxiMaster >> movement.taxiNodes[0] >> movement.taxiNodes[1];
+            try
+            {
+                p >> movement.taxiMaster >> movement.taxiNodes[0] >> movement.taxiNodes[1];
+            }
+            catch(ByteBufferException&)
+            {
+                // Packet read failure that would cause server crash.
+                return false;
+            }
             return true;
         }
     case CMSG_ACTIVATETAXIEXPRESS:
         {
             ObjectGuid guid;
             uint32 node_count;
-            p >> guid >> node_count;
-
-            LastMovement& movement = context->GetValue<LastMovement&>("last movement")->Get();
-            movement.taxiNodes.clear();
-            for (uint32 i = 0; i < node_count; ++i)
+            try
             {
-                uint32 node;
-                p >> node;
-                movement.taxiNodes.push_back(node);
-            }
+                p >> guid >> node_count;
 
-            return true;
+                LastMovement& movement = context->GetValue<LastMovement&>("last movement")->Get();
+                movement.taxiNodes.clear();
+                for (uint32 i = 0; i < node_count; ++i)
+                {
+                    uint32 node;
+                    p >> node;
+                    movement.taxiNodes.push_back(node);
+                }
+
+                return true;
+            }
+            catch(ByteBufferException&)
+            {
+                // Packet read failure that would cause server crash.
+                return false;
+            }
         }
     }
 


### PR DESCRIPTION
I was seeing lots of crashes when boarding flight taxis when grouped playerbots  weren't able to follow.   While I admit I don't entirely understand what's going on, I added a try/catch around the critical crashing areas that seems to fix everything for me.  If you might know more about the root cause, please disregard this, but I submit it for your review anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/226)
<!-- Reviewable:end -->
