### PR TITLE
Fix for 'A' heavy bot names

### DIFF
--- a/src/modules/Bots/playerbot/RandomPlayerbotFactory.cpp
+++ b/src/modules/Bots/playerbot/RandomPlayerbotFactory.cpp
@@ -163,7 +163,7 @@ string RandomPlayerbotFactory::CreateRandomBotName()
     // Query the database to get a random name that is not already used by a character
     result = CharacterDatabase.PQuery("SELECT `n`.`name` FROM `ai_playerbot_names` n "
             "LEFT OUTER JOIN `characters` e ON `e`.`name` = `n`.`name` "
-            "WHERE `e`.`guid` IS NULL AND `n`.`name_id` >= '%u' LIMIT 1", id);
+            "WHERE `e`.`guid` IS NULL AND `n`.`name_id` >= '%u' ORDER BY `n`.`name_id` LIMIT 1", id);
     if (!result)
     {
         // Log an error and return an empty string if no names are left


### PR DESCRIPTION
This fixes an issue where all of my Bots had names starting with A, which turns out to be because of how MySQL auto-orders results when you don't specify.  This change resulted in nice random names (well, maybe not nice, but definitely more random).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/227)
<!-- Reviewable:end -->
