### PR TITLE
Bot potential fix for perpetual looting

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
@@ -58,6 +58,12 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z)
             bot->SetStandState(UNIT_STAND_STATE_STAND);
         }
 
+        if (bot->GetLootGuid())
+        {
+            bot->SetLootGuid(ObjectGuid());
+            bot->RemoveFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_LOOTING);
+        }
+
         if (bot->IsNonMeleeSpellCasted(true))
         {
             bot->CastStop();


### PR DESCRIPTION
This causes a playerbot to cancel a looting action when they are commanded to move.  This was another fix to the perpetually gathering and looting bots whom I had grouped and instructed to follow me.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/228)
<!-- Reviewable:end -->
