### PR TITLE
Repeated spell actions aren't cancelled

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/GenericSpellActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/GenericSpellActions.cpp
@@ -15,7 +15,19 @@ bool CastSpellAction::isPossible()
     {
         return false;
     }
-
+    uint32 spellId = AI_VALUE2(uint32, "spell id", spell);
+    if (spellId)
+    {
+        const SpellEntry* spellInfo = sSpellStore.LookupEntry(spellId);
+        if (spellInfo && IsAutoRepeatRangedSpell(spellInfo))
+        {
+            Spell* currentAutoRepeat = bot->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL);
+            if (currentAutoRepeat && currentAutoRepeat->m_spellInfo->Id == spellId)
+            {
+                return false; // Already casting this autorepeat spell
+            }
+        }
+    }
     return ai->CanCastSpell(spell, GetTarget());
 }
 


### PR DESCRIPTION
This fixes an issue where a Playerbot with an auto-casting spell (wand use being the most common) would cancel their own wand use in the middle of using it in order to start another, leading to inaction.

If the Playerbot is using an auto-cast skill, they should wait until its done to start another.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/230)
<!-- Reviewable:end -->
