### PR TITLE
Alternate skills bug fix

### DIFF
--- a/src/modules/Bots/playerbot/strategy/Action.h
+++ b/src/modules/Bots/playerbot/strategy/Action.h
@@ -95,9 +95,9 @@ namespace ai
         string getName() { return name; }
 
     public:
-        NextAction** getContinuers() { return NextAction::merge(NextAction::clone(continuers), action->getContinuers()); }
-        NextAction** getAlternatives() { return NextAction::merge(NextAction::clone(alternatives), action->getAlternatives()); }
-        NextAction** getPrerequisites() { return NextAction::merge(NextAction::clone(prerequisites), action->getPrerequisites()); }
+        NextAction** getContinuers() { return NextAction::merge(NextAction::clone(continuers), action ? action->getContinuers() : NULL); }
+        NextAction** getAlternatives() { return NextAction::merge(NextAction::clone(alternatives), action ? action->getAlternatives() : NULL); }
+        NextAction** getPrerequisites() { return NextAction::merge(NextAction::clone(prerequisites), action ? action->getPrerequisites() : NULL); }
 
     private:
         string name;

--- a/src/modules/Bots/playerbot/strategy/Engine.cpp
+++ b/src/modules/Bots/playerbot/strategy/Engine.cpp
@@ -150,6 +150,7 @@ bool Engine::DoNextAction(Unit* unit, int depth)
             if (!action)
             {
                 LogAction("A:%s - UNKNOWN", actionNode->getName().c_str());
+                MultiplyAndPush(actionNode->getAlternatives(), relevance + 0.03, false, event);
             }
             else if (action->isUseful())
             {


### PR DESCRIPTION
This fixes a very annoying issue where Playerbot actions that specify a Spell, and an Alternate Spell, would fail outright if the first Spell was not available, and never try the Alternate.

Explanation: Part of what makes playerbots code portable between Zero and the other versions is that, when later expansions add new spells, you can give those more updated versions as defaults for certain situations, but keep the old Zero spell as an alternative if you are running the Zero server.   Since I'm running the Zero server, I was seeing Playerbot failures to use those alternatives Constantly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/231)
<!-- Reviewable:end -->
