### PR TITLE
Fix for Pet passive mode

### DIFF
--- a/src/game/WorldHandlers/PetHandler.cpp
+++ b/src/game/WorldHandlers/PetHandler.cpp
@@ -193,6 +193,11 @@ void WorldSession::HandlePetAction(WorldPacket& recv_data)
             switch (spellid)
             {
                 case REACT_PASSIVE:                         // passive
+                    if (pet->getVictim())
+                    {
+                        pet->AttackStop();
+                    }
+                    pet->GetMotionMaster()->MoveFollow(_player, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
                 case REACT_DEFENSIVE:                       // recovery
                 case REACT_AGGRESSIVE:                      // activete
                     charmInfo->SetReactState(ReactStates(spellid));


### PR DESCRIPTION
When using a Pet with a class that supports them, the Passive mode button should immediately disengage the pet from combat if they are currently fighting.  This change adds that normal WOW feature to the passive button.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/232)
<!-- Reviewable:end -->
