### PR TITLE
Fix to teleport name location

### DIFF
--- a/src/game/ChatCommands/TeleportationAndPositionCommands.cpp
+++ b/src/game/ChatCommands/TeleportationAndPositionCommands.cpp
@@ -1509,6 +1509,7 @@ bool ChatHandler::HandleTeleNameCommand(char* args)
     Player* target;
     ObjectGuid target_guid;
     std::string target_name;
+    char* locationArgs = args;
     if (!ExtractPlayerTarget(&nameStr, &target, &target_guid, &target_name))
     {
         return false;
@@ -1587,6 +1588,7 @@ bool ChatHandler::HandleTeleNameCommand(char* args)
             }
         }
     }
+    args = locationArgs;
 
     // Not coordinates, restore args pointer and try as saved location name
     GameTele const* tele = ExtractGameTeleFromLink(&args);


### PR DESCRIPTION
The fixes a bug I introduced in the admin console tele name command.  I accidentally broke the old behavior of being able to teleport to Named places when I added the ability to also target coordinates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/233)
<!-- Reviewable:end -->
