### PR TITLE
Admin console die/damage command support

### DIFF
--- a/src/game/WorldHandlers/Chat.cpp
+++ b/src/game/WorldHandlers/Chat.cpp
@@ -685,7 +685,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "delete",         SEC_ADMINISTRATOR,  true,  &ChatHandler::HandleTicketDeleteCommand,         "", NULL },
         { "info",           SEC_GAMEMASTER,     true,  &ChatHandler::HandleTicketInfoCommand,           "", NULL },
         { "list",           SEC_GAMEMASTER,     true,  &ChatHandler::HandleTicketListCommand,           "", NULL },
-        { "meaccept",       SEC_GAMEMASTER,     true,  &ChatHandler::HandleTicketMeAcceptCommand,       "", NULL },
+        { "meaccept",       SEC_GAMEMASTER,     false, &ChatHandler::HandleTicketMeAcceptCommand,       "", NULL },
         { "onlinelist",     SEC_GAMEMASTER,     true,  &ChatHandler::HandleTicketOnlineListCommand,     "", NULL },
         { "respond",        SEC_GAMEMASTER,     true,  &ChatHandler::HandleTicketRespondCommand,        "", NULL },
         { "show",           SEC_GAMEMASTER,     true,  &ChatHandler::HandleTicketShowCommand,           "", NULL },


### PR DESCRIPTION
This allows the admin console DIE and DAMAGE command to work correctly with the SELECT PLAYER command, allowing you to kill or damage players from the admin console.

This was important to helping me troubleshoot Priest revive behavior, and is just a fun thing to be able to do to your friends.

Oh -- PS: there is also a one line change that removes the ticket meaccept command from admin-console-ability, as it uses m_session and therefore wouldn't work from the admin console anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/234)
<!-- Reviewable:end -->
