### PR TITLE
Bot leaving group causes un-follow

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/LeaveGroupAction.h
+++ b/src/modules/Bots/playerbot/strategy/actions/LeaveGroupAction.h
@@ -11,12 +11,10 @@ namespace ai
 
         virtual bool Execute(Event event)
         {
-            if (!bot->GetGroup())
+            if (bot->GetGroup())
             {
-                return false;
+                ai->TellMaster("Goodbye!", PLAYERBOT_SECURITY_TALK);
             }
-
-            ai->TellMaster("Goodbye!", PLAYERBOT_SECURITY_TALK);
 
             WorldPacket p;
             string member = bot->GetName();
@@ -31,6 +29,9 @@ namespace ai
             }
 
             ai->ResetStrategies();
+            ai->ChangeStrategy("-follow master", BOT_STATE_NON_COMBAT);
+            ai->ChangeStrategy("-follow master", BOT_STATE_DEAD);
+            ai->ChangeStrategy("-follow master", BOT_STATE_COMBAT);
             return true;
         }
     };


### PR DESCRIPTION
When Bots were kicked out of group, they retained their 'follow master' strategy, which caused downstream problems AND couldn't be fixed without re-grouping.  This change fixes this problem by forcing an "un-follow" when a random bot leaves a group.

(Technical notes: the changed code was called AFTER the system had removed the bot from the group, so the early exit had to be removed.  The other change was, of course, removing the follow strategies.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/235)
<!-- Reviewable:end -->
