### PR TITLE
Bot follow state survives teleport and instances

### DIFF
--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -229,6 +229,13 @@ void PlayerbotAI::HandleTeleportAck()
     {
         bot->GetSession()->HandleMoveWorldportAckOpcode();
     }
+
+    LastMovement& movement = aiObjectContext->GetValue<LastMovement&>("last movement")->Get();
+    if (movement.lastFollowState)
+    {
+        ChangeStrategy("+follow master,-stay", BOT_STATE_NON_COMBAT);
+        movement.lastFollowState = false;
+    }
 }
 
 /**

--- a/src/modules/Bots/playerbot/strategy/actions/AreaTriggerAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/AreaTriggerAction.cpp
@@ -42,7 +42,8 @@ bool ReachAreaTriggerAction::Execute(Event event)
         return true;
     }
 
-    ai->ChangeStrategy("-follow,+stay", BOT_STATE_NON_COMBAT);
+    bool wasFollowing = ai->HasStrategy("follow master", BOT_STATE_NON_COMBAT);
+    ai->ChangeStrategy("-follow master,+stay", BOT_STATE_NON_COMBAT);
 
     MotionMaster &mm = *bot->GetMotionMaster();
     mm.Clear();
@@ -52,7 +53,7 @@ bool ReachAreaTriggerAction::Execute(Event event)
     ai->TellMaster("Wait for me");
     ai->SetNextCheckDelay(delay);
     context->GetValue<LastMovement&>("last movement")->Get().lastAreaTrigger = triggerId;
-
+    context->GetValue<LastMovement&>("last movement")->Get().lastFollowState = wasFollowing;
     return true;
 }
 
@@ -77,7 +78,7 @@ bool AreaTriggerAction::Execute(Event event)
         return true;
     }
 
-    ai->ChangeStrategy("-follow,+stay", BOT_STATE_NON_COMBAT);
+    ai->ChangeStrategy("-follow master,+stay", BOT_STATE_NON_COMBAT);
 
     MotionMaster &mm = *bot->GetMotionMaster();
     mm.Clear();
@@ -86,7 +87,6 @@ bool AreaTriggerAction::Execute(Event event)
     p << triggerId;
     p.rpos(0);
     bot->GetSession()->HandleAreaTriggerOpcode(p);
-
     ai->TellMaster("Hello");
     return true;
 }

--- a/src/modules/Bots/playerbot/strategy/actions/TeleportAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/TeleportAction.cpp
@@ -29,10 +29,12 @@ bool TeleportAction::Execute(Event event)
             continue;
         }
 
+        LastMovement& movement = context->GetValue<LastMovement&>("last movement")->Get();
+        movement.lastFollowState = ai->HasStrategy("follow master", BOT_STATE_NON_COMBAT);
         ostringstream out; out << "Teleporting using " << goInfo->name;
         ai->TellMasterNoFacing(out.str());
 
-        ai->ChangeStrategy("-follow,+stay", BOT_STATE_NON_COMBAT);
+        ai->ChangeStrategy("-follow master,+stay", BOT_STATE_NON_COMBAT);
 
         Spell *spell = new Spell(bot, pSpellInfo, false);
         SpellCastTargets targets;

--- a/src/modules/Bots/playerbot/strategy/values/LastMovementValue.h
+++ b/src/modules/Bots/playerbot/strategy/values/LastMovementValue.h
@@ -16,6 +16,7 @@ namespace ai
             lastMoveToOri = 0;
             lastFollow = NULL;
             lastAreaTrigger = 0; // Initialize lastAreaTrigger
+            lastFollowState = false;
         }
 
         // Copy constructor to copy movement details from another LastMovement object
@@ -29,6 +30,7 @@ namespace ai
             lastMoveToY = other.lastMoveToY;
             lastMoveToZ = other.lastMoveToZ;
             lastMoveToOri = other.lastMoveToOri;
+            lastFollowState = other.lastFollowState;
         }
 
         // Set the last follow unit and reset movement coordinates
@@ -53,6 +55,7 @@ namespace ai
         ObjectGuid taxiMaster; // GUID of the taxi master
         Unit* lastFollow; // Pointer to the last followed unit
         uint32 lastAreaTrigger; // ID of the last area trigger
+        bool lastFollowState; // whether follow was removed temprarily
         float lastMoveToX, lastMoveToY, lastMoveToZ, lastMoveToOri; // Last movement coordinates and orientation
     };
 


### PR DESCRIPTION
This fixes a super annoying thing with bots where they lose their +follow master strategy when being teleported, such as when entering an instance.  This happened because the follow strategy was intentionally removed before such teleports, which I suspect fixes some other, more serious problem.  The fix, therefore, imho, was to "save" the follow state of a bot before they are teleported, and then restore the follow state afterwards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/236)
<!-- Reviewable:end -->
