### PR TITLE
Un-AFK msg fix

### DIFF
--- a/src/game/WorldHandlers/ChatHandler.cpp
+++ b/src/game/WorldHandlers/ChatHandler.cpp
@@ -105,12 +105,15 @@ void WorldSession::HandleMessagechatOpcode(WorldPacket& recv_data)
         return;
     }
 
-    //prevent cheating, by sending LANG_UNIVERSAL
-    if ((langDesc->lang_id == LANG_UNIVERSAL && !sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHAT) && GetSecurity() == SEC_PLAYER) ||
-         (langDesc->skill_id != 0 && !_player->HasSkill(langDesc->skill_id)))
+    if (type != CHAT_MSG_AFK && type != CHAT_MSG_DND)
     {
-        SendNotification(LANG_NOT_LEARNED_LANGUAGE);
-        return;
+        //prevent cheating, by sending LANG_UNIVERSAL
+        if ((langDesc->lang_id == LANG_UNIVERSAL && !sWorld.getConfig(CONFIG_BOOL_ALLOW_TWO_SIDE_INTERACTION_CHAT) && GetSecurity() == SEC_PLAYER) ||
+             (langDesc->skill_id != 0 && !_player->HasSkill(langDesc->skill_id)))
+        {
+            SendNotification(LANG_NOT_LEARNED_LANGUAGE);
+            return;
+        }
     }
 
     if (lang == LANG_ADDON)


### PR DESCRIPTION
This fixes a minor annoyance for me.  Whenever I went AFK, and then came out of it, I'd get a weird "You don't know that language" message on the client screen.  Turns out it was because some anti-cheat (?) code was generating it when the AFK message came through.  I found other places where CHAT_MSG_AFK  and CHAT_MSG_DND are treated as special cases, and so I routed those around the "universal language" message and it fixed my issue.

I hope I did good.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/238)
<!-- Reviewable:end -->
