### PR TITLE
Pet loiter and re-target fixes

### DIFF
--- a/src/game/Object/PetAI.cpp
+++ b/src/game/Object/PetAI.cpp
@@ -32,6 +32,9 @@
 #include "Creature.h"
 #include "World.h"
 #include "Util.h"
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
+#include "CellImpl.h"
 
 int PetAI::Permissible(const Creature* creature)
 {
@@ -43,7 +46,7 @@ int PetAI::Permissible(const Creature* creature)
     return PERMIT_BASE_NO;
 }
 
-PetAI::PetAI(Creature* c) : CreatureAI(c), i_tracker(TIME_INTERVAL_LOOK), inCombat(false)
+PetAI::PetAI(Creature* c) : CreatureAI(c), i_tracker(TIME_INTERVAL_LOOK), inCombat(false), m_loiterTimeout(0)
 {
     m_AllySet.clear();
     UpdateAllies();
@@ -121,21 +124,66 @@ bool PetAI::_needToStop() const
 
 void PetAI::_stopAttack()
 {
-    inCombat = false;
+    if (inCombat)
+    {
+        // simulate well known corpse loiter behavior by picking a loiter time
+        m_loiterTimeout = getMSTime() + urand(1000, 2500);
+        inCombat = false;
+    }
 
     Unit* owner = m_creature->GetCharmerOrOwner();
 
-    if (owner && m_creature->GetCharmInfo() && m_creature->GetCharmInfo()->HasCommandState(COMMAND_FOLLOW))
-    {
-        m_creature->GetMotionMaster()->MoveFollow(owner, PET_FOLLOW_DIST, PET_FOLLOW_ANGLE);
-        m_creature->UpdateSpeed(MOVE_RUN, false);
-    }
-    else
-    {
-        m_creature->GetMotionMaster()->Clear(false);
-        m_creature->GetMotionMaster()->MoveIdle();
-    }
+    m_creature->GetMotionMaster()->Clear(false);
+    m_creature->GetMotionMaster()->MoveIdle();
     m_creature->AttackStop();
+}
+
+void PetAI::SelectNextTarget(Unit* owner)
+{
+    if (!m_creature->GetCharmInfo()->HasReactState(REACT_PASSIVE) && !m_creature->GetCharmInfo()->HasCommandState(COMMAND_STAY))
+    {
+        std::list<Unit*> candidates;
+
+        if (m_creature->GetCharmInfo()->HasReactState(REACT_DEFENSIVE))
+        {
+            for (Unit* attacker : owner->getAttackers())
+                candidates.push_back(attacker);
+            for (Unit* attacker : m_creature->getAttackers())
+                candidates.push_back(attacker);
+        }
+        else if (m_creature->GetCharmInfo()->HasReactState(REACT_AGGRESSIVE))
+        {
+            float radius = m_creature->GetAttackDistance(m_creature);
+            MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck u_check(m_creature, radius);
+            MaNGOS::UnitListSearcher<MaNGOS::AnyUnfriendlyUnitInObjectRangeCheck>
+                searcher(candidates, u_check);
+            Cell::VisitAllObjects(m_creature, searcher, radius);
+        }
+
+        Unit* nextTarget = nullptr;
+        float closestDist = FLT_MAX;
+        for (Unit* candidate : candidates)
+        {
+            if (candidate->IsAlive() &&
+                candidate->IsTargetableForAttack() &&
+                candidate->isInAccessablePlaceFor(m_creature) &&
+                m_creature->IsWithinLOSInMap(candidate))
+            {
+                float dist = m_creature->GetDistance(candidate);
+                if (dist < closestDist)
+                {
+                    closestDist = dist;
+                    nextTarget = candidate;
+                }
+            }
+        }
+
+        if (nextTarget)
+        {
+            AttackStart(nextTarget);
+        }
+    }
+
 }
 
 void PetAI::UpdateAI(const uint32 diff)
@@ -206,9 +254,16 @@ void PetAI::UpdateAI(const uint32 diff)
             }
         }
     }
-    else if (owner && m_creature->GetCharmInfo())
+    else if (owner && m_creature->GetCharmInfo() && ((m_loiterTimeout == 0) || (getMSTime() > m_loiterTimeout)))
     {
-        if (owner->IsInCombat() && !(m_creature->GetCharmInfo()->HasReactState(REACT_PASSIVE) || m_creature->GetCharmInfo()->HasCommandState(COMMAND_STAY)))
+        // pets with dead enemies, after loiter, pick next target based on distance and stance
+        if (m_loiterTimeout > 0)
+        {
+            m_loiterTimeout = 0;
+            SelectNextTarget(owner);
+            // if nothing to do, loiter is extended 1 tick
+        }
+        else if (owner->IsInCombat() && !(m_creature->GetCharmInfo()->HasReactState(REACT_PASSIVE) || m_creature->GetCharmInfo()->HasCommandState(COMMAND_STAY)))
         {
             AttackStart(owner->getAttackerForHelper());
         }

--- a/src/game/Object/PetAI.cpp
+++ b/src/game/Object/PetAI.cpp
@@ -131,8 +131,6 @@ void PetAI::_stopAttack()
         inCombat = false;
     }
 
-    Unit* owner = m_creature->GetCharmerOrOwner();
-
     m_creature->GetMotionMaster()->Clear(false);
     m_creature->GetMotionMaster()->MoveIdle();
     m_creature->AttackStop();

--- a/src/game/Object/PetAI.h
+++ b/src/game/Object/PetAI.h
@@ -52,6 +52,7 @@ class PetAI : public CreatureAI
         bool _needToStop(void) const;
         void _stopAttack(void);
 
+        void SelectNextTarget(Unit*);
         void UpdateAllies();
 
         TimeTracker i_tracker;
@@ -59,5 +60,6 @@ class PetAI : public CreatureAI
 
         GuidSet m_AllySet;
         uint32 m_updateAlliesTimer;
+        uint32 m_loiterTimeout;
 };
 #endif

--- a/src/game/Object/PetAI.h
+++ b/src/game/Object/PetAI.h
@@ -60,6 +60,6 @@ class PetAI : public CreatureAI
 
         GuidSet m_AllySet;
         uint32 m_updateAlliesTimer;
-        uint32 m_loiterTimeout;
+        uint32 m_loiterUntilTime;
 };
 #endif


### PR DESCRIPTION
This change fixes the problem of Pets running back to their masters when their current fight ends, even if they are already also in combat with another nearby enemy.  

It also implements behavior I felt was missing, and vaguely remembered, but then confirmed via research as definitely being a thing in WoW:  The Pet "Corpse Loiter"; Pets spend a second or two just hanging out at corpses before making their next move.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/252)
<!-- Reviewable:end -->
