### PR TITLE
Bots ride all transport types (trams, lifts/elevators)

### DIFF
--- a/src/game/WorldHandlers/Map.h
+++ b/src/game/WorldHandlers/Map.h
@@ -305,6 +305,7 @@ class Map : public GridRefManager<NGridType>
         bool GetRandomPointUnderWater(float& x, float& y, float& z, float radius, GridMapLiquidData& liquid_status);
 
         void LoadLocalTransports();
+        std::set<Transport*> const& GetLocalTransports() const { return i_transports; }
 
 #ifdef ENABLE_ELUNA
         Eluna* GetEluna() const;

--- a/src/game/WorldHandlers/MovementHandler.cpp
+++ b/src/game/WorldHandlers/MovementHandler.cpp
@@ -627,6 +627,19 @@ void WorldSession::HandleMoverRelocation(MovementInfo& movementInfo)
                         break;
                     }
                 }
+                // also check local transports (lifts/elevators) which are per-map only
+                if (!plMover->m_transport)
+                {
+                    for (Transport* lt : plMover->GetMap()->GetLocalTransports())
+                    {
+                        if (lt->GetObjectGuid() == movementInfo.GetTransportGuid())
+                        {
+                            plMover->m_transport = lt;
+                            lt->AddPassenger(plMover);
+                            break;
+                        }
+                    }
+                }
             }
         }
         else if (plMover->m_transport)               // if we were on a transport, leave


### PR DESCRIPTION
This expands Bot ride support to trams and lifts.   I knew it would be easy -- I didn't realize it would be trivial.  As the longer commit message mentioned, it was just a matter of checking local transports.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/265)
<!-- Reviewable:end -->
