### PR TITLE
Console use guid lookup when player offline

### DIFF
--- a/src/game/WorldHandlers/Chat.cpp
+++ b/src/game/WorldHandlers/Chat.cpp
@@ -3526,15 +3526,42 @@ bool ChatHandler::ExtractPlayerTarget(char** args, Player** player /*= NULL*/, O
         {
             *player = pl;
         }
+
+        ObjectGuid guid = pl ? pl->GetObjectGuid() : ObjectGuid();
+
+        // Console with a selected player that is now offline: fall back to stored GUID
+        if (!pl && !m_session)
+        {
+            uint32 accountId = GetAccountId();
+            auto itr = m_consoleSelectedPlayers.find(accountId);
+            if (itr != m_consoleSelectedPlayers.end())
+                guid = itr->second;
+        }
+
         // if allowed player guid (if no then only online players allowed)
         if (player_guid)
         {
-            *player_guid = pl ? pl->GetObjectGuid() : ObjectGuid();
+            *player_guid = guid;
         }
 
         if (player_name)
         {
-            *player_name = pl ? pl->GetName() : "";
+            if (pl)
+                *player_name = pl->GetName();
+            else if (guid)
+            {
+                std::string name;
+                if (!sObjectMgr.GetPlayerNameByGUID(guid, name) || name.empty())
+                {
+                    if (player_guid)
+                        *player_guid = ObjectGuid();
+                    *player_name = "";
+                }
+                else
+                    *player_name = name;
+            }
+            else
+                *player_name = "";
         }
     }
 


### PR DESCRIPTION
This is a quality of life change for admin console commands that target players.  If you select an offline player and use a command that targets players, it will correctly resolve them so the command works.  See the commit message for more details, but that's the gist of it.

Not really an important change.  Just something that annoyed me exactly ONE time, and I was ornery enough at the time to change it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/266)
<!-- Reviewable:end -->
