### PR TITLE
Bot gather fixed

### DIFF
--- a/src/modules/Bots/playerbot/LootObjectStack.cpp
+++ b/src/modules/Bots/playerbot/LootObjectStack.cpp
@@ -87,7 +87,7 @@ void LootObject::Refresh(Player* bot, ObjectGuid guid)
     }
 
     GameObject* go = ai->GetGameObject(guid);
-    if (go && go->isSpawned())
+    if (go && go->isSpawned() && go->getLootState() == GO_READY)
     {
         uint32 lockId = go->GetGOInfo()->GetLockId();
         LockEntry const *lockInfo = sLockStore.LookupEntry(lockId);

--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -179,9 +179,20 @@ void PlayerbotAI::UpdateAI(uint32 elapsed)
         }
     }
 
-    if (nextAICheckDelay > sPlayerbotAIConfig.maxWaitForMove && bot->IsInCombat() && !bot->GetCurrentSpell(CURRENT_CHANNELED_SPELL))
+    if (nextAICheckDelay > sPlayerbotAIConfig.maxWaitForMove &&
+        !bot->GetCurrentSpell(CURRENT_CHANNELED_SPELL))
     {
-        nextAICheckDelay = sPlayerbotAIConfig.maxWaitForMove;
+        if (bot->IsInCombat())
+            nextAICheckDelay = sPlayerbotAIConfig.maxWaitForMove;
+        else
+        {
+            Player* master = GetMaster();
+            if (master && master->IsInCombat())
+            {
+                InterruptSpell();
+                nextAICheckDelay = sPlayerbotAIConfig.maxWaitForMove;
+            }
+        }
     }
 
     PlayerbotAIBase::UpdateAI(elapsed);

--- a/src/modules/Bots/playerbot/strategy/actions/AddLootAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/AddLootAction.cpp
@@ -71,16 +71,27 @@ bool AddGatheringLootAction::AddLoot(ObjectGuid guid)
         return false;
     }
 
+    return AddAllLootAction::AddLoot(guid);
+}
+
+bool AddGatheringLootAction::isUseful()
+{
+    // Don't gather in dungeons or raids
+    if (bot->GetMap()->IsDungeon())
+    {
+        return false;
+    }
+
     // NC gathering is a problem if you are supposed to be following
     Player* master = ai->GetMaster();
-    if (master && ai->HasStrategy("follow master", BOT_STATE_NON_COMBAT))
+    if (master && bot->GetGroup())
     {
         float masterDist = bot->GetDistance(master);
-        if (masterDist > sPlayerbotAIConfig.reactDistance / 2)
+        if (masterDist > sPlayerbotAIConfig.reactDistance)
         {
             return false;
         }
     }
 
-    return AddAllLootAction::AddLoot(guid);
+    return AddAllLootAction::isUseful();
 }

--- a/src/modules/Bots/playerbot/strategy/actions/AddLootAction.h
+++ b/src/modules/Bots/playerbot/strategy/actions/AddLootAction.h
@@ -24,6 +24,7 @@ namespace ai
     class AddGatheringLootAction : public AddAllLootAction {
     public:
         AddGatheringLootAction(PlayerbotAI* ai) : AddAllLootAction(ai, "add gathering loot") {}
+        virtual bool isUseful();
 
     protected:
         virtual bool AddLoot(ObjectGuid guid);


### PR DESCRIPTION
I have fought and fought with bot gathering, and this is it-- three fixes that together make bot gathering actually work:
1. Bot skips nodes that aren't in ready state, fixing an infinite gather bug.
2. Cancel gathering channels when the master enters combat.  No more picking posies when your groupmates are dying.
3. Gate the gathering action behind dungeon/distance checks in isUseful() where it belongs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/267)
<!-- Reviewable:end -->
