### PR TITLE
Bot Cautious Strategy

### DIFF
--- a/src/modules/Bots/playerbot/AiFactory.cpp
+++ b/src/modules/Bots/playerbot/AiFactory.cpp
@@ -122,6 +122,11 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
 
     engine->addStrategies("attack weak", "racials", "chat", "default", "aoe", "potions", "cast time", "conserve mana", "duel", "pvp", NULL);
 
+    if (sPlayerbotAIConfig.cautiousDefault)
+    {
+        engine->addStrategy("cautious");
+    }
+
     switch (player->getClass())
     {
         case CLASS_PRIEST:
@@ -253,6 +258,11 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
 {
     int tab = GetPlayerSpecTab(player);
 
+    if (sPlayerbotAIConfig.cautiousDefault)
+    {
+        nonCombatEngine->addStrategy("cautious");
+    }
+
     switch (player->getClass()){
         case CLASS_PALADIN:
         case CLASS_HUNTER:
@@ -277,7 +287,6 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
     {
         nonCombatEngine->ChangeStrategy(sPlayerbotAIConfig.randomBotNonCombatStrategies);
     }
-
 }
 
 Engine* AiFactory::createNonCombatEngine(Player* player, PlayerbotAI* const facade, AiObjectContext* AiObjectContext) {

--- a/src/modules/Bots/playerbot/PlayerbotAI.h
+++ b/src/modules/Bots/playerbot/PlayerbotAI.h
@@ -137,6 +137,7 @@ public:
     void ChangeStrategy(string name, BotState type);
     bool ContainsStrategy(StrategyType type);
     bool HasStrategy(string name, BotState type);
+    bool HasStrategy(string name) { return HasStrategy(name, currentState); }
     void ResetStrategies();
     void ReInitCurrentEngine();
     void Reset();

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
@@ -65,6 +65,7 @@ PlayerbotAIConfig::PlayerbotAIConfig()
       logInGroupOnly(false),
       logValuesPerTick(false),
       fleeingEnabled(false),
+      cautiousDefault(false),
       randomBotMinLevel(0),
       randomBotMaxLevel(0),
       randomChangeMultiplier(0.0f),
@@ -179,6 +180,7 @@ bool PlayerbotAIConfig::Initialize()
     logInGroupOnly = config.GetBoolDefault("AiPlayerbot.LogInGroupOnly", true);
     logValuesPerTick = config.GetBoolDefault("AiPlayerbot.LogValuesPerTick", false);
     fleeingEnabled = config.GetBoolDefault("AiPlayerbot.FleeingEnabled", true);
+    cautiousDefault = config.GetBoolDefault("AiPlayerbot.Cautious", false);
     randomBotMinLevel = config.GetIntDefault("AiPlayerbot.RandomBotMinLevel", 1);
     randomBotMaxLevel = config.GetIntDefault("AiPlayerbot.RandomBotMaxLevel", 255);
     randomBotLoginAtStartup = config.GetBoolDefault("AiPlayerbot.RandomBotLoginAtStartup", true);

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.h
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.h
@@ -71,6 +71,7 @@ public:
     uint32 randomBotTeleLevel; ///< The teleport level for random bots.
     bool logInGroupOnly, logValuesPerTick;
     bool fleeingEnabled; ///< Indicates if fleeing is enabled for bots.
+    bool cautiousDefault;
     std::string randomBotCombatStrategies, randomBotNonCombatStrategies;
     uint32 randomBotMinLevel, randomBotMaxLevel;
     float randomChangeMultiplier;

--- a/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
+++ b/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
@@ -88,6 +88,9 @@ AiPlayerbot.CommandPrefix = ~
 # Bot can flee for enemy
 #AiPlayerbot.FleeingEnabled = 1
 
+# Bot avoids pulling aggro during movement by default
+#AiPlayerbot.Cautious = 0
+
 # Health/Mana levels
 #AiPlayerbot.CriticalHealth = 25
 #AiPlayerbot.LowHealth = 45

--- a/src/modules/Bots/playerbot/strategy/StrategyContext.h
+++ b/src/modules/Bots/playerbot/strategy/StrategyContext.h
@@ -36,6 +36,7 @@
 #include "generic/TellTargetStrategy.h"
 #include "generic/AttackEnemyPlayersStrategy.h"
 #include "generic/MoveRandomStrategy.h"
+#include "generic/CautiousStrategy.h"
 
 namespace ai
 {
@@ -64,6 +65,7 @@ namespace ai
             creators["tell target"] = &StrategyContext::tell_target;
             creators["pvp"] = &StrategyContext::pvp;
             creators["move random"] = &StrategyContext::move_random;
+            creators["cautious"] = &StrategyContext::cautious;
         }
 
     private:
@@ -87,6 +89,7 @@ namespace ai
         static Strategy* ready_check(PlayerbotAI* ai) { return new ReadyCheckStrategy(ai); }
         static Strategy* pvp(PlayerbotAI* ai) { return new AttackEnemyPlayersStrategy(ai); }
         static Strategy* move_random(PlayerbotAI* ai) { return new MoveRandomStrategy(ai); }
+        static Strategy* cautious(PlayerbotAI* ai) { return new CautiousStrategy(ai); }
     };
 
     class MovementStrategyContext : public NamedObjectContext<Strategy>

--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
@@ -10,6 +10,7 @@
 #include "WorldHandlers/Transports.h"
 #include "movement/MoveSplineInit.h"
 #include "movement/MoveSpline.h"
+#include "Creature.h"
 
 using namespace ai;
 
@@ -33,7 +34,7 @@ bool MovementAction::MoveNear(WorldObject* target, float distance)
     {
         bool moved = MoveTo(target->GetMapId(),
             target->GetPositionX() + cos(angle) * distance,
-            target->GetPositionY()+ sin(angle) * distance,
+            target->GetPositionY() + sin(angle) * distance,
             target->GetPositionZ());
         if (moved)
         {
@@ -43,13 +44,16 @@ bool MovementAction::MoveNear(WorldObject* target, float distance)
     return false;
 }
 
-bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z)
+bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z, bool unsafe)
 {
     bot->UpdateGroundPositionZ(x, y, z);
     if (!IsMovingAllowed(mapId, x, y, z))
     {
         return false;
     }
+
+    if (!unsafe && ai->HasStrategy("cautious") && IsAggroPosition(x, y))
+        return false;
 
     float distance = bot->GetDistance(x, y, z);
     if (distance > sPlayerbotAIConfig.contactDistance)
@@ -77,7 +81,7 @@ bool MovementAction::MoveTo(uint32 mapId, float x, float y, float z)
         mm.Clear();
 
         float botZ = bot->GetPositionZ();
-            mm.MovePoint(mapId, x, y, z);
+        mm.MovePoint(mapId, x, y, z);
     }
 
     AI_VALUE(LastMovement&, "last movement").Set(x, y, z, bot->GetOrientation());
@@ -93,7 +97,6 @@ bool MovementAction::MoveTo(Unit* target, float distance)
 
     float bx = bot->GetPositionX();
     float by = bot->GetPositionY();
-    float bz = bot->GetPositionZ();
 
     float tx = target->GetPositionX();
     float ty = target->GetPositionY();
@@ -116,7 +119,20 @@ bool MovementAction::MoveTo(Unit* target, float distance)
     float dx = cos(angle) * needToGo + bx;
     float dy = sin(angle) * needToGo + by;
 
-    return MoveTo(target->GetMapId(), dx, dy, tz);
+    if (needToGo > 0)
+    {
+        float safeDist = CalculateAggroFreeDistance(bx, by, angle, needToGo);
+        if (safeDist < needToGo)
+        {
+            if(safeDist < sPlayerbotAIConfig.contactDistance)
+            {
+                return false;
+            }
+            dx = cos(angle) * safeDist + bx;
+            dy = sin(angle) * safeDist + by;
+        }
+    }
+    return MoveTo(target->GetMapId(), dx, dy, tz, true);
 }
 
 float MovementAction::GetFollowAngle()
@@ -360,6 +376,11 @@ bool MovementAction::Follow(Unit* target, float distance, float angle)
         ai->InterruptSpell();
     }
 
+    float followX = target->GetPositionX() + cos(angle) * distance;
+    float followY = target->GetPositionY() + sin(angle) * distance;
+    if (IsAggroPosition(followX, followY))
+        return false;
+
     mm.MoveFollow(target, distance, angle);
 
     AI_VALUE(LastMovement&, "last movement").Set(target);
@@ -417,6 +438,74 @@ bool MovementAction::Flee(Unit *target)
     }
 
     return MoveTo(target->GetMapId(), rx, ry, rz);
+}
+
+/*
+ * Returns the farthest distance along the beeline from (bx,by) at the
+ * given angle that doesn't enter any hostile creature's aggro zone.
+ * Returns maxDist if the entire path is clear.
+ */
+float MovementAction::CalculateAggroFreeDistance(float bx, float by,
+                                                  float angle, float maxDist)
+{
+    if( !ai->HasStrategy("cautious"))
+    {
+        return maxDist;
+    }
+    float cosA = cos(angle);
+    float sinA = sin(angle);
+    float safeDist = maxDist;
+
+    list<ObjectGuid> targets = AI_VALUE(list<ObjectGuid>, "possible targets");
+    for (list<ObjectGuid>::iterator i = targets.begin(); i != targets.end(); ++i)
+    {
+        Unit* unit = ai->GetUnit(*i);
+        if (!unit || !unit->IsAlive() || unit->IsInCombat() || !unit->IsHostileTo(bot) || unit == bot->getVictim())
+            continue;
+
+        Creature* creature = dynamic_cast<Creature*>(unit);
+        if (!creature || !creature->CanInitiateAttack())
+            continue;
+
+        float aggroRange = creature->GetAttackDistance(bot);
+        float ex = bx - creature->GetPositionX();
+        float ey = by - creature->GetPositionY();
+        float b = ex * cosA + ey * sinA;
+        float c = ex * ex + ey * ey - aggroRange * aggroRange;
+
+        float disc = b * b - c;
+        if (disc < 0)
+            continue;
+
+        float sqrtDisc = sqrt(disc);
+        float tEntry = -b - sqrtDisc;
+        if (tEntry < 0)
+        {
+            continue;
+        }
+
+        if (tEntry < safeDist)
+        {
+            safeDist = std::max(0.0f, tEntry - 2.0f);
+        }
+    }
+
+    return safeDist;
+}
+
+bool MovementAction::IsAggroPosition(float x, float y)
+{
+    float bx = bot->GetPositionX();
+    float by = bot->GetPositionY();
+
+    float dx = x - bx;
+    float dy = y - by;
+    float dist = sqrt(dx * dx + dy * dy);
+    if (dist < 0.1f)
+        return false;
+
+    float angle = atan2(dy, dx);
+    return CalculateAggroFreeDistance(bx, by, angle, dist) < dist;
 }
 
 bool FleeAction::Execute(Event event)

--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.h
@@ -15,7 +15,7 @@ namespace ai
 
     protected:
         bool MoveNear(uint32 mapId, float x, float y, float z, float distance = sPlayerbotAIConfig.followDistance);
-        bool MoveTo(uint32 mapId, float x, float y, float z);
+        bool MoveTo(uint32 mapId, float x, float y, float z, bool unsafe = false);
         bool MoveTo(Unit* target, float distance = 0.0f);
         bool MoveNear(WorldObject* target, float distance = sPlayerbotAIConfig.followDistance);
         float GetFollowAngle();
@@ -28,6 +28,8 @@ namespace ai
         bool IsMovingAllowed(uint32 mapId, float x, float y, float z);
         bool IsMovingAllowed();
         bool Flee(Unit *target);
+        float CalculateAggroFreeDistance(float bx, float by, float angle, float maxDist);
+        bool IsAggroPosition(float x, float y);
 
     protected:
         Player* bot;

--- a/src/modules/Bots/playerbot/strategy/actions/PositionAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/PositionAction.cpp
@@ -36,7 +36,11 @@ bool MoveToPositionAction::Execute(Event event)
         ai->TellMaster(out);
         return false;
     }
-
-    return MoveTo(bot->GetMapId(), pos.x, pos.y, pos.z);
+    if (IsAggroPosition(pos.x, pos.y))
+    {
+        ai->TellMaster("Warning: that position is near hostile creatures.");
+    }
+    return MoveTo(bot->GetMapId(), pos.x, pos.y, pos.z, true);
 }
+
 

--- a/src/modules/Bots/playerbot/strategy/generic/CautiousStrategy.h
+++ b/src/modules/Bots/playerbot/strategy/generic/CautiousStrategy.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace ai
+{
+    class CautiousStrategy : public Strategy
+    {
+    public:
+        CautiousStrategy(PlayerbotAI* ai) : Strategy(ai) {}
+        virtual string getName() { return "cautious"; }
+    };
+}


### PR DESCRIPTION
Adds an optional strategy called "Cautious" that can be auto-applied to bots from a new configuration option, OR applied manually as desired.

The purpose of the strategy is to prevent bots from wiping their groups in dungeons with careless behavior that aggros new mobs.  This behavior was rampant.   The change makes the Bot "Cautious", checking every move to ensure it won't create new aggro where it did not already exist, without impacting the ability to be directed into combat by a player, or entering combat itself. 

It *does* allow a bot to get as close as possible to new aggro, however, which is often enough to get into range for what it must do in a fight.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/270)
<!-- Reviewable:end -->
