### PR TITLE
Fix for Bot Aura Checks

### DIFF
--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -1008,9 +1008,9 @@ bool PlayerbotAI::HasAura(string name, Unit* unit)
     }
 
     uint32 spellId = aiObjectContext->GetValue<uint32>("spell id", name)->Get();
-    if (spellId)
+    if (spellId && HasAura(spellId, unit))
     {
-        return HasAura(spellId, unit);
+        return true;
     }
 
     wstring wnamepart;


### PR DESCRIPTION
This fixes a bug where the code wants to know if a spell has already been cast on someone, but doesn't consider that many buffs come in multiple ranks with different ids.  The fix is to fall back to the spells string name, which will cover all the ranks.

In particular, this fixed an infinite buffing contest between two mage playerbots with different ranks of Intellect.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/272)
<!-- Reviewable:end -->
