### PR TITLE
Creature position update fix

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -10090,7 +10090,10 @@ void Unit::InterruptMoving(bool forceSendStop /*=false*/)
     {
         Movement::Location loc = movespline->ComputePosition();
         movespline->_Interrupt();
-        Relocate(loc.x, loc.y, loc.z, loc.orientation);
+        if (GetTypeId() == TYPEID_PLAYER)
+            ((Player*)this)->SetPosition(loc.x, loc.y, loc.z, loc.orientation);
+        else
+            GetMap()->CreatureRelocation((Creature*)this, loc.x, loc.y, loc.z, loc.orientation);
         isMoving = true;
     }
 


### PR DESCRIPTION
This fixes InterruptMoving method to update the position correctly for non-players, just like it's done in all of the rest of the code.   Honestly, this was not fixing anything important:  the mistake would be noticed and corrected later anyway, but when this correction occurred, it logged it, and I just got curious about all those errors in my log and figured out what was going on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/274)
<!-- Reviewable:end -->
