### PR TITLE
Fix to melee dead-zone

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/AttackAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/AttackAction.cpp
@@ -57,8 +57,8 @@ bool AttackAction::Attack(Unit* target)
         if (verbose)
         {
             ai->TellMaster("I have no target");
-            return false;
         }
+        return false;
     }
 
     ostringstream msg;

--- a/src/modules/Bots/playerbot/strategy/actions/ReachTargetActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/ReachTargetActions.h
@@ -47,6 +47,11 @@ namespace ai
     {
     public:
         ReachMeleeAction(PlayerbotAI* ai) : ReachTargetAction(ai, "reach melee", sPlayerbotAIConfig.meleeDistance) {}
+
+        virtual bool isUseful()
+        {
+            return AI_VALUE2(float, "distance", "current target") > distance + sPlayerbotAIConfig.contactDistance + bot->GetObjectBoundingRadius();
+        }
     };
 
     class ReachSpellAction : public ReachTargetAction


### PR DESCRIPTION
Fix to return false from Attack when no target.  Pretty straightforward, that one.

The ReachMeleeAction for bots fixes a melee "dead zone" problem, and is more subtle, and needs explaining:

On the surface, it just looks like the code simply extends the melee range beyond the basic 1.5; and it does -- but it's not really the distance itself that was important, but the distance from the target "distance" (i.e. the difference).   

You see, when the bot is told to move less than a minimal distance from target, no movement actually occurs.  This is probably a great idea to prevent jittery micro-adjustments.  However, the side effect was this:  if you were 1.7 yards from your melee target, ReachMeleeAction would determine that you needed to move 0.2 yards and so prevent any other actions until you do so, which would then be rejected by the movement code for being too small.  This kept the bot Frozen 0.2 yards away from the position at which it would be allowed to attack.  So, by extending the difference between the target range and acceptable range to something larger than minimum, we guarantee it is either acceptable, or that the bot WILL move into range.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/275)
<!-- Reviewable:end -->
