### PR TITLE
Bots prefer buff food

### DIFF
--- a/src/modules/Bots/playerbot/strategy/ItemVisitors.h
+++ b/src/modules/Bots/playerbot/strategy/ItemVisitors.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "DBCStore.h"
+
 char * strstri (const char* str1, const char* str2);
 
 namespace ai
@@ -280,6 +282,15 @@ namespace ai
         map<uint32, int> count;
     };
 
+    inline bool IsBuffFood(const ItemPrototype* proto)
+    {
+        if (proto->Class != ITEM_CLASS_CONSUMABLE ||
+            proto->Spells[0].SpellCategory != SPELLCATEGORY_FOOD)
+            return false;
+        SpellEntry const* sp = sSpellStore.LookupEntry(proto->Spells[0].SpellId);
+        return sp && (sp->Effect[1] != 0 || sp->Effect[2] != 0);
+    }
+
     class FindFoodVisitor : public FindUsableItemVisitor
     {
     public:
@@ -296,6 +307,36 @@ namespace ai
     private:
         uint32 spellCategory;
     };
+
+    class FindBuffFoodVisitor : public FindUsableItemVisitor
+    {
+    public:
+        FindBuffFoodVisitor(Player* bot) : FindUsableItemVisitor(bot) {}
+
+        virtual bool Accept(const ItemPrototype* proto)
+        {
+            return IsBuffFood(proto);
+        }
+    };
+
+    inline bool HasFoodBuff(Player* bot, const list<Item*>& buffFoods)
+    {
+        for (Item* item : buffFoods)
+        {
+            SpellEntry const* sp = sSpellStore.LookupEntry(item->GetProto()->Spells[0].SpellId);
+            if (!sp)
+                continue;
+            if (bot->HasAura(sp->Id))
+                return true;
+            for (int i = 1; i < MAX_EFFECT_INDEX; ++i)
+            {
+                uint32 triggerSpell = sp->EffectTriggerSpell[i];
+                if (triggerSpell && bot->HasAura(triggerSpell))
+                    return true;
+            }
+        }
+        return false;
+    }
 
     class FindConjuredFoodVisitor : public FindUsableItemVisitor
     {

--- a/src/modules/Bots/playerbot/strategy/actions/InventoryAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/InventoryAction.cpp
@@ -278,6 +278,13 @@ list<Item*> InventoryAction::parseItems(string text)
         found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
     }
 
+    if (text == "buff food")
+    {
+        FindBuffFoodVisitor visitor(bot);
+        IterateItems(&visitor, ITERATE_ITEMS_IN_BAGS);
+        found.insert(visitor.GetResult().begin(), visitor.GetResult().end());
+    }
+
     if (text == "drink")
     {
         FindFoodVisitor visitor(bot, SPELLCATEGORY_DRINK);

--- a/src/modules/Bots/playerbot/strategy/actions/NonCombatActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/NonCombatActions.h
@@ -3,6 +3,7 @@
 #include "../Action.h"
 #include "UseItemAction.h"
 #include "../../PlayerbotAIConfig.h"
+#include "../ItemVisitors.h"
 
 namespace ai
 {
@@ -55,7 +56,13 @@ namespace ai
             if (ai->IsEating())
                 return true;
 
-            bool result = UseItemAction::Execute(event);
+            bool result = false;
+            list<Item*> buffFoods = AI_VALUE2(list<Item*>, "inventory items", "buff food");
+            if (!buffFoods.empty() && !HasFoodBuff(bot, buffFoods))
+                result = UseItemAuto(*buffFoods.begin());
+            if (!result)
+                result = UseItemAction::Execute(event);
+
             if (result)
                 ai->SetEating();
             return result;


### PR DESCRIPTION
Allows bots to prefer buff food when available, and regular food when not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/277)
<!-- Reviewable:end -->
