### PR TITLE
Bot trades accept white+ quality items with sell value

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/TradeStatusAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/TradeStatusAction.cpp
@@ -128,12 +128,13 @@ bool TradeStatusAction::CheckTrade()
         item = master->GetTradeData()->GetItem((TradeSlots)slot);
         if (item)
         {
-            ostringstream out; out << item->GetProto()->ItemId;
+            ItemPrototype const* proto = item->GetProto();
+            ostringstream out; out << proto->ItemId;
             ItemUsage usage = AI_VALUE2(ItemUsage, "item usage", out.str());
-            if (!auctionbot.GetBuyPrice(item->GetProto()) || usage == ITEM_USAGE_NONE)
+            if (usage == ITEM_USAGE_NONE || proto->Quality < ITEM_QUALITY_NORMAL || !proto->SellPrice)
             {
                 ostringstream out;
-                out << chat->formatItem(item->GetProto()) << " - I don't need this";
+                out << chat->formatItem(proto) << " - I don't need this";
                 ai->TellMaster(out);
                 return false;
             }


### PR DESCRIPTION
This loosens the restrictions on which items a bot will accept in a trade window.   I'll understand if yall don't like this one, but it fixes something that has annoyed me over and over and over again: player tries to share food, water, bandages, or whatever, and is rejected due to the 'value' being partially based on what the ahbot logic thinks.    I altered it to simply check if 1. it's not a grey item, and 2.  it is sellable (has a value > 0).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/283)
<!-- Reviewable:end -->
