### PR TITLE
Bot whisper level check

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/SuggestWhatToDoAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/SuggestWhatToDoAction.cpp
@@ -286,5 +286,8 @@ void SuggestWhatToDoAction::spam(string msg)
             (bot->GetMapId() != player->GetMapId() || bot->GetDistance(player) > sPlayerbotAIConfig.whisperDistance))
         return;
 
+    if ((int)bot->getLevel() - (int)player->getLevel() > 5)
+        return;
+
     bot->Whisper(msg, LANG_UNIVERSAL, player->GetObjectGuid());
 }


### PR DESCRIPTION
Another change to making those bot whispers actually usable by adding a simple level guard.  Many bot whispers will ask for a group invite, and if you DO try to invite them, they'll reject it due to being too high level compared to the player.  This fixes this issue by preventing the invite when the bot is too high level to want you.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/284)
<!-- Reviewable:end -->
