### PR TITLE
Paladin bot for mangos zero

### DIFF
--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -4552,14 +4552,14 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
                 {
                     SpellEntry const* spellInfo = (*itr)->GetSpellProto();
 
-                    // search seal (all seals have judgement's aura dummy spell id in 2 effect
-                    if (!spellInfo || !IsSealSpell((*itr)->GetSpellProto()) || (*itr)->GetEffIndex() != 2)
+                    // the judgement spell id is stored in whatever effect index the seal's dummy aura occupies
+                    if (!spellInfo || !IsSealSpell((*itr)->GetSpellProto()))
                     {
                         continue;
                     }
 
                     // must be calculated base at raw base points in spell proto, GetModifier()->m_value for S.Righteousness modified by SPELLMOD_DAMAGE
-                    spellId2 = (*itr)->GetSpellProto()->CalculateSimpleValue(EFFECT_INDEX_2);
+                    spellId2 = (*itr)->GetSpellProto()->CalculateSimpleValue((SpellEffectIndex)(*itr)->GetEffIndex());
 
                     if (spellId2 <= 1)
                     {

--- a/src/modules/Bots/playerbot/strategy/paladin/DpsPaladinStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/paladin/DpsPaladinStrategy.cpp
@@ -10,6 +10,7 @@ class DpsPaladinStrategyActionNodeFactory : public NamedObjectFactory<ActionNode
 public:
     DpsPaladinStrategyActionNodeFactory()
     {
+        creators["seal of the crusader"] = &seal_of_the_crusader;
         creators["seal of vengeance"] = &seal_of_vengeance;
         creators["seal of command"] = &seal_of_command;
         creators["blessing of might"] = &blessing_of_might;
@@ -17,6 +18,13 @@ public:
     }
 
 private:
+    static ActionNode* seal_of_the_crusader(PlayerbotAI* ai)
+    {
+        return new ActionNode ("seal of the crusader",
+            /*P*/ NULL,
+            /*A*/ NextAction::array(0, new NextAction("seal of vengeance"), NULL),
+            /*C*/ NULL);
+    }
     static ActionNode* seal_of_vengeance(PlayerbotAI* ai)
     {
         return new ActionNode ("seal of vengeance",
@@ -28,7 +36,7 @@ private:
     {
         return new ActionNode ("seal of command",
             /*P*/ NULL,
-            /*A*/ NextAction::array(0, new NextAction("seal of wisdom"), NULL),
+            /*A*/ NextAction::array(0, new NextAction("seal of righteousness"), NULL),
             /*C*/ NULL);
     }
     static ActionNode* blessing_of_might(PlayerbotAI* ai)
@@ -70,7 +78,7 @@ void DpsPaladinStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         NextAction::array(0, new NextAction("judgement of wisdom", ACTION_NORMAL + 2), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "blessing",
+        "blessing of might",
         NextAction::array(0, new NextAction("blessing of might", ACTION_HIGH + 8), NULL)));
 
     triggers.push_back(new TriggerNode(

--- a/src/modules/Bots/playerbot/strategy/paladin/GenericPaladinNonCombatStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/paladin/GenericPaladinNonCombatStrategy.cpp
@@ -16,6 +16,10 @@ void GenericPaladinNonCombatStrategy::InitTriggers(std::list<TriggerNode*> &trig
     NonCombatStrategy::InitTriggers(triggers);
 
     triggers.push_back(new TriggerNode(
+        "aura",
+        NextAction::array(0, new NextAction("devotion aura", 8.0f), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "blessing of kings on party",
         NextAction::array(0, new NextAction("blessing of kings on party", 11.0f), NULL)));
 

--- a/src/modules/Bots/playerbot/strategy/paladin/GenericPaladinStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/paladin/GenericPaladinStrategy.cpp
@@ -74,4 +74,16 @@ void GenericPaladinStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "cleanse party member cure magic",
         NextAction::array(0, new NextAction("cleanse magic on party", ACTION_DISPEL + 1), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "holy wrath",
+        NextAction::array(0, new NextAction("holy wrath", ACTION_HIGH + 3), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "exorcism",
+        NextAction::array(0, new NextAction("exorcism", ACTION_HIGH + 2), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "blessing of freedom",
+        NextAction::array(0, new NextAction("blessing of freedom", ACTION_EMERGENCY), NULL)));
 }

--- a/src/modules/Bots/playerbot/strategy/paladin/GenericPaladinStrategyActionNodeFactory.h
+++ b/src/modules/Bots/playerbot/strategy/paladin/GenericPaladinStrategyActionNodeFactory.h
@@ -7,6 +7,7 @@ namespace ai
     public:
         GenericPaladinStrategyActionNodeFactory()
         {
+            creators["blessing of kings on party"] = &blessing_of_kings_on_party;
             creators["seal of light"] = &seal_of_light;
             creators["cleanse poison"] = &cleanse_poison;
             creators["cleanse disease"] = &cleanse_disease;
@@ -16,7 +17,9 @@ namespace ai
             creators["seal of wisdom"] = &seal_of_wisdom;
             creators["seal of justice"] = &seal_of_justice;
             creators["hand of reckoning"] = &hand_of_reckoning;
+            creators["judgement of justice"] = &judgement_of_justice;
             creators["judgement of wisdom"] = &judgement_of_wisdom;
+            creators["judgement of light"] = &judgement_of_light;
             creators["divine shield"] = &divine_shield;
             creators["flash of light"] = &flash_of_light;
             creators["flash of light on party"] = &flash_of_light_on_party;
@@ -25,6 +28,13 @@ namespace ai
             creators["lay on hands on party"] = &lay_on_hands_on_party;
         }
     private:
+        static ActionNode* blessing_of_kings_on_party(PlayerbotAI* ai)
+        {
+            return new ActionNode ("blessing of kings on party",
+                /*P*/ NULL,
+                /*A*/ NextAction::array(0, new NextAction("blessing of might on party"), NULL),
+                /*C*/ NULL);
+        }
         static ActionNode* lay_on_hands(PlayerbotAI* ai)
         {
             return new ActionNode ("lay on hands",
@@ -102,11 +112,25 @@ namespace ai
                 /*A*/ NextAction::array(0, new NextAction("judgement of justice"), NULL),
                 /*C*/ NULL);
         }
+        static ActionNode* judgement_of_justice(PlayerbotAI* ai)
+        {
+            return new ActionNode ("judgement of justice",
+                /*P*/ NULL,
+                /*A*/ NextAction::array(0, new NextAction("judgement"), NULL),
+                /*C*/ NULL);
+        }
         static ActionNode* judgement_of_wisdom(PlayerbotAI* ai)
         {
             return new ActionNode ("judgement of wisdom",
                 /*P*/ NULL,
                 /*A*/ NextAction::array(0, new NextAction("judgement of light"), NULL),
+                /*C*/ NULL);
+        }
+        static ActionNode* judgement_of_light(PlayerbotAI* ai)
+        {
+            return new ActionNode ("judgement of light",
+                /*P*/ NULL,
+                /*A*/ NextAction::array(0, new NextAction("judgement"), NULL),
                 /*C*/ NULL);
         }
         static ActionNode* divine_shield(PlayerbotAI* ai)

--- a/src/modules/Bots/playerbot/strategy/paladin/PaladinActions.h
+++ b/src/modules/Bots/playerbot/strategy/paladin/PaladinActions.h
@@ -3,22 +3,42 @@
 
 namespace ai
 {
-    class CastJudgementOfLightAction : public CastMeleeSpellAction
+    // Base for judgement actions that guards against judging with no active seal
+    class CastJudgementBaseAction : public CastMeleeSpellAction
     {
     public:
-        CastJudgementOfLightAction(PlayerbotAI* ai) : CastMeleeSpellAction(ai, "judgement of light") {}
+        CastJudgementBaseAction(PlayerbotAI* ai, string spell) : CastMeleeSpellAction(ai, spell) {}
+        virtual bool isPossible()
+        {
+            Unit* bot = ai->GetBot();
+            if (!ai->HasAura("seal of righteousness", bot) &&
+                !ai->HasAura("seal of the crusader", bot) &&
+                !ai->HasAura("seal of command", bot) &&
+                !ai->HasAura("seal of vengeance", bot) &&
+                !ai->HasAura("seal of justice", bot) &&
+                !ai->HasAura("seal of light", bot) &&
+                !ai->HasAura("seal of wisdom", bot))
+                return false;
+            return CastMeleeSpellAction::isPossible();
+        }
     };
 
-    class CastJudgementOfWisdomAction : public CastMeleeSpellAction
+    class CastJudgementOfLightAction : public CastJudgementBaseAction
     {
     public:
-        CastJudgementOfWisdomAction(PlayerbotAI* ai) : CastMeleeSpellAction(ai, "judgement of wisdom") {}
+        CastJudgementOfLightAction(PlayerbotAI* ai) : CastJudgementBaseAction(ai, "judgement of light") {}
     };
 
-    class CastJudgementOfJusticeAction : public CastMeleeSpellAction
+    class CastJudgementOfWisdomAction : public CastJudgementBaseAction
     {
     public:
-        CastJudgementOfJusticeAction(PlayerbotAI* ai) : CastMeleeSpellAction(ai, "judgement of justice") {}
+        CastJudgementOfWisdomAction(PlayerbotAI* ai) : CastJudgementBaseAction(ai, "judgement of wisdom") {}
+    };
+
+    class CastJudgementOfJusticeAction : public CastJudgementBaseAction
+    {
+    public:
+        CastJudgementOfJusticeAction(PlayerbotAI* ai) : CastJudgementBaseAction(ai, "judgement of justice") {}
     };
 
     class CastRighteousFuryAction : public CastBuffSpellAction
@@ -67,6 +87,25 @@ namespace ai
     {
     public:
         CastSealOfRighteousnessAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "seal of righteousness") {}
+    };
+
+    class CastSealOfTheCrusaderAction : public CastBuffSpellAction
+    {
+    public:
+        CastSealOfTheCrusaderAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "seal of the crusader") {}
+        virtual bool isPossible()
+        {
+            Unit* target = AI_VALUE(Unit*, "current target");
+            if (target && ai->HasAura("judgement of the crusader", target))
+                return false;
+            return CastBuffSpellAction::isPossible();
+        }
+    };
+
+    class CastJudgementAction : public CastJudgementBaseAction
+    {
+    public:
+        CastJudgementAction(PlayerbotAI* ai) : CastJudgementBaseAction(ai, "judgement") {}
     };
 
     class CastSealOfJusticeAction : public CastBuffSpellAction
@@ -304,6 +343,12 @@ namespace ai
 
     BEGIN_SPELL_ACTION(CastExorcismAction, "exorcism")
     END_SPELL_ACTION()
+
+    class CastBlessingOfFreedomAction : public CastBuffSpellAction
+    {
+    public:
+        CastBlessingOfFreedomAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "blessing of freedom") {}
+    };
 
     class CastHolyShieldAction : public CastBuffSpellAction
     {

--- a/src/modules/Bots/playerbot/strategy/paladin/PaladinAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/paladin/PaladinAiObjectContext.cpp
@@ -94,7 +94,9 @@ namespace ai
             {
                 creators["judgement of wisdom"] = &TriggerFactoryInternal::judgement_of_wisdom;
                 creators["judgement of light"] = &TriggerFactoryInternal::judgement_of_light;
+                creators["aura"] = &TriggerFactoryInternal::aura;
                 creators["blessing"] = &TriggerFactoryInternal::blessing;
+                creators["blessing of might"] = &TriggerFactoryInternal::blessing_of_might;
                 creators["seal"] = &TriggerFactoryInternal::seal;
                 creators["art of war"] = &TriggerFactoryInternal::art_of_war;
                 creators["blessing of kings on party"] = &TriggerFactoryInternal::blessing_of_kings_on_party;
@@ -115,6 +117,9 @@ namespace ai
                 creators["righteous fury"] = &TriggerFactoryInternal::righteous_fury;
                 creators["holy shield"] = &TriggerFactoryInternal::holy_shield;
                 creators["hammer of justice on enemy healer"] = &TriggerFactoryInternal::hammer_of_justice_on_enemy_target;
+                creators["holy wrath"] = &TriggerFactoryInternal::holy_wrath;
+                creators["exorcism"] = &TriggerFactoryInternal::exorcism;
+                creators["blessing of freedom"] = &TriggerFactoryInternal::blessing_of_freedom;
             }
 
         private:
@@ -122,7 +127,9 @@ namespace ai
             static Trigger* righteous_fury(PlayerbotAI* ai) { return new RighteousFuryTrigger(ai); }
             static Trigger* judgement_of_wisdom(PlayerbotAI* ai) { return new JudgementOfWisdomTrigger(ai); }
             static Trigger* judgement_of_light(PlayerbotAI* ai) { return new JudgementOfLightTrigger(ai); }
+            static Trigger* aura(PlayerbotAI* ai) { return new AuraTrigger(ai); }
             static Trigger* blessing(PlayerbotAI* ai) { return new BlessingTrigger(ai); }
+            static Trigger* blessing_of_might(PlayerbotAI* ai) { return new BlessingOfMightTrigger(ai); }
             static Trigger* seal(PlayerbotAI* ai) { return new SealTrigger(ai); }
             static Trigger* art_of_war(PlayerbotAI* ai) { return new ArtOfWarTrigger(ai); }
             static Trigger* blessing_of_kings_on_party(PlayerbotAI* ai) { return new BlessingOfKingsOnPartyTrigger(ai); }
@@ -141,6 +148,9 @@ namespace ai
             static Trigger* CleanseCureMagic(PlayerbotAI* ai) { return new CleanseCureMagicTrigger(ai); }
             static Trigger* CleanseCurePartyMemberMagic(PlayerbotAI* ai) { return new CleanseCurePartyMemberMagicTrigger(ai); }
             static Trigger* hammer_of_justice_on_enemy_target(PlayerbotAI* ai) { return new HammerOfJusticeEnemyHealerTrigger(ai); }
+            static Trigger* holy_wrath(PlayerbotAI* ai) { return new HolyWrathTrigger(ai); }
+            static Trigger* exorcism(PlayerbotAI* ai) { return new ExorcismTrigger(ai); }
+            static Trigger* blessing_of_freedom(PlayerbotAI* ai) { return new BlessingOfFreedomTrigger(ai); }
         };
     };
 };
@@ -156,12 +166,18 @@ namespace ai
         public:
             AiObjectContextInternal()
             {
+                creators["seal of the crusader"] = &AiObjectContextInternal::seal_of_the_crusader;
+                creators["judgement"] = &AiObjectContextInternal::judgement;
                 creators["seal of command"] = &AiObjectContextInternal::seal_of_command;
                 creators["blessing of might"] = &AiObjectContextInternal::blessing_of_might;
+                creators["blessing of might on party"] = &AiObjectContextInternal::blessing_of_might_on_party;
+                creators["blessing of wisdom"] = &AiObjectContextInternal::blessing_of_wisdom;
+                creators["blessing of wisdom on party"] = &AiObjectContextInternal::blessing_of_wisdom_on_party;
                 creators["blessing of kings on party"] = &AiObjectContextInternal::blessing_of_kings_on_party;
                 creators["redemption"] = &AiObjectContextInternal::redemption;
                 creators["seal of light"] = &AiObjectContextInternal::seal_of_light;
                 creators["devotion aura"] = &AiObjectContextInternal::devotion_aura;
+                creators["concentration aura"] = &AiObjectContextInternal::concentration_aura;
                 creators["holy wrath"] = &AiObjectContextInternal::holy_wrath;
                 creators["consecration"] = &AiObjectContextInternal::consecration;
                 creators["cleanse disease"] = &AiObjectContextInternal::cleanse_disease;
@@ -201,17 +217,24 @@ namespace ai
                 creators["righteous fury"] = &AiObjectContextInternal::righteous_fury;
                 creators["blessing of sanctuary"] = &AiObjectContextInternal::blessing_of_sanctuary;
                 creators["hammer of justice on enemy healer"] = &AiObjectContextInternal::hammer_of_justice_on_enemy_healer;
+                creators["blessing of freedom"] = &AiObjectContextInternal::blessing_of_freedom;
             }
 
         private:
             static Action* righteous_fury(PlayerbotAI* ai) { return new CastRighteousFuryAction(ai); }
             static Action* blessing_of_sanctuary(PlayerbotAI* ai) { return new CastBlessingOfSanctuaryAction(ai); }
+            static Action* seal_of_the_crusader(PlayerbotAI* ai) { return new CastSealOfTheCrusaderAction(ai); }
+            static Action* judgement(PlayerbotAI* ai) { return new CastJudgementAction(ai); }
             static Action* seal_of_command(PlayerbotAI* ai) { return new CastSealOfCommandAction(ai); }
             static Action* blessing_of_might(PlayerbotAI* ai) { return new CastBlessingOfMightAction(ai); }
+            static Action* blessing_of_might_on_party(PlayerbotAI* ai) { return new CastBlessingOfMightOnPartyAction(ai); }
+            static Action* blessing_of_wisdom(PlayerbotAI* ai) { return new CastBlessingOfWisdomAction(ai); }
+            static Action* blessing_of_wisdom_on_party(PlayerbotAI* ai) { return new CastBlessingOfWisdomOnPartyAction(ai); }
             static Action* blessing_of_kings_on_party(PlayerbotAI* ai) { return new CastBlessingOfKingsOnPartyAction(ai); }
             static Action* redemption(PlayerbotAI* ai) { return new CastRedemptionAction(ai); }
             static Action* seal_of_light(PlayerbotAI* ai) { return new CastSealOfLightAction(ai); }
             static Action* devotion_aura(PlayerbotAI* ai) { return new CastDevotionAuraAction(ai); }
+            static Action* concentration_aura(PlayerbotAI* ai) { return new CastConcentrationAuraAction(ai); }
             static Action* holy_wrath(PlayerbotAI* ai) { return new CastHolyWrathAction(ai); }
             static Action* consecration(PlayerbotAI* ai) { return new CastConsecrationAction(ai); }
             static Action* cleanse_poison(PlayerbotAI* ai) { return new CastCleansePoisonAction(ai); }
@@ -249,6 +272,7 @@ namespace ai
             static Action* frost_resistance_aura(PlayerbotAI* ai) { return new CastFrostResistanceAuraAction(ai); }
             static Action* fire_resistance_aura(PlayerbotAI* ai) { return new CastFireResistanceAuraAction(ai); }
             static Action* hammer_of_justice_on_enemy_healer(PlayerbotAI* ai) { return new CastHammerOfJusticeOnEnemyHealerAction(ai); }
+            static Action* blessing_of_freedom(PlayerbotAI* ai) { return new CastBlessingOfFreedomAction(ai); }
         };
     };
 };

--- a/src/modules/Bots/playerbot/strategy/paladin/PaladinBuffStrategies.cpp
+++ b/src/modules/Bots/playerbot/strategy/paladin/PaladinBuffStrategies.cpp
@@ -30,7 +30,7 @@ void PaladinBuffDpsStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
     triggers.push_back(new TriggerNode(
         "seal",
-        NextAction::array(0, new NextAction("seal of vengeance", 89.0f), NULL)));
+        NextAction::array(0, new NextAction("seal of the crusader", 89.0f), NULL)));
 
     triggers.push_back(new TriggerNode(
         "retribution aura",

--- a/src/modules/Bots/playerbot/strategy/paladin/PaladinTriggers.cpp
+++ b/src/modules/Bots/playerbot/strategy/paladin/PaladinTriggers.cpp
@@ -13,11 +13,50 @@ bool SealTrigger::IsActive()
         !ai->HasAura("seal of vengeance", target) &&
         !ai->HasAura("seal of righteousness", target) &&
         !ai->HasAura("seal of light", target) &&
-        !ai->HasAura("seal of wisdom", target);
+        !ai->HasAura("seal of wisdom", target) &&
+        !ai->HasAura("seal of the crusader", target);
+}
+
+bool AuraTrigger::IsActive()
+{
+    Unit* target = GetTarget();
+    return !ai->HasAura("devotion aura", target) &&
+        !ai->HasAura("retribution aura", target) &&
+        !ai->HasAura("concentration aura", target) &&
+        !ai->HasAura("shadow resistance aura", target) &&
+        !ai->HasAura("frost resistance aura", target) &&
+        !ai->HasAura("fire resistance aura", target) &&
+        !ai->HasAura("crusader aura", target);
 }
 
 bool CrusaderAuraTrigger::IsActive()
 {
     Unit* target = GetTarget();
     return AI_VALUE2(bool, "mounted", "self target") && !ai->HasAura("crusader aura", target);
+}
+
+bool HolyWrathTrigger::IsActive()
+{
+    Unit* target = AI_VALUE(Unit*, "current target");
+    if (!target)
+        return false;
+    uint32 ctype = target->GetCreatureType();
+    if (ctype != CREATURE_TYPE_UNDEAD && ctype != CREATURE_TYPE_DEMON)
+        return false;
+    return AI_VALUE(uint8, "attacker count") >= 2;
+}
+
+bool ExorcismTrigger::IsActive()
+{
+    Unit* target = AI_VALUE(Unit*, "current target");
+    if (!target)
+        return false;
+    uint32 ctype = target->GetCreatureType();
+    return ctype == CREATURE_TYPE_UNDEAD || ctype == CREATURE_TYPE_DEMON;
+}
+
+bool BlessingOfFreedomTrigger::IsActive()
+{
+    Unit* bot = ai->GetBot();
+    return bot->IsInRoots() || bot->HasAuraType(SPELL_AURA_MOD_DECREASE_SPEED);
 }

--- a/src/modules/Bots/playerbot/strategy/paladin/PaladinTriggers.h
+++ b/src/modules/Bots/playerbot/strategy/paladin/PaladinTriggers.h
@@ -27,6 +27,14 @@ namespace ai
 
     BUFF_ON_PARTY_TRIGGER(BlessingOfKingsOnPartyTrigger, "blessing of kings", "blessing of kings on party")
     BUFF_TRIGGER(BlessingTrigger, "blessing of sanctuary", "blessing of sanctuary")
+    BUFF_TRIGGER(BlessingOfMightTrigger, "blessing of might", "blessing of might")
+
+    class AuraTrigger : public BuffTrigger
+    {
+    public:
+        AuraTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "devotion aura") {}
+        virtual bool IsActive();
+    };
 
     class HammerOfJusticeInterruptSpellTrigger : public InterruptSpellTrigger
     {
@@ -110,5 +118,27 @@ namespace ai
     {
     public:
         HammerOfJusticeEnemyHealerTrigger(PlayerbotAI* ai) : InterruptEnemyHealerTrigger(ai, "hammer of justice") {}
+    };
+
+    class HolyWrathTrigger : public SpellTrigger
+    {
+    public:
+        HolyWrathTrigger(PlayerbotAI* ai) : SpellTrigger(ai, "holy wrath") {}
+        virtual bool IsActive();
+    };
+
+    class ExorcismTrigger : public SpellTrigger
+    {
+    public:
+        ExorcismTrigger(PlayerbotAI* ai) : SpellTrigger(ai, "exorcism") {}
+        virtual bool IsActive();
+    };
+
+    // Fires when the bot itself is rooted — cast Blessing of Freedom on self.
+    class BlessingOfFreedomTrigger : public Trigger
+    {
+    public:
+        BlessingOfFreedomTrigger(PlayerbotAI* ai) : Trigger(ai, "blessing of freedom") {}
+        virtual bool IsActive();
     };
 }


### PR DESCRIPTION
Updates that make Paladin Bots do their Paladin things correctly in Zero, without losing any of the TBC+ work.
Fixes an issue that limited finding judgement spell ids at index 2 instead of wherever it happened to be.  
Put all the judgements under one base class that ensures there's a Seal to judge.
Limits on who Holy Wrath and Exorcism are used against.
Various new actions and triggers registered that were missing.
Several spells had vanilla fallbacks added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/285)
<!-- Reviewable:end -->
