### PR TITLE
Mage Bot Strat tweeks (and many TBC additions)

### DIFF
--- a/src/modules/Bots/playerbot/strategy/mage/FrostMageStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/mage/FrostMageStrategy.cpp
@@ -29,4 +29,8 @@ void FrostMageAoeStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "high aoe",
         NextAction::array(0, new NextAction("blizzard", 40.0f), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "medium aoe",
+        NextAction::array(0, new NextAction("cone of cold", 30.0f), NULL)));
 }

--- a/src/modules/Bots/playerbot/strategy/mage/GenericMageNonCombatStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/mage/GenericMageNonCombatStrategy.cpp
@@ -53,7 +53,10 @@ void GenericMageNonCombatStrategy::InitTriggers(std::list<TriggerNode*> &trigger
 
     triggers.push_back(new TriggerNode(
         "arcane intellect on party",
-        NextAction::array(0, new NextAction("arcane intellect on party", 20.0f), NULL)));
+        NextAction::array(0,
+            new NextAction("arcane brilliance", 21.0f),
+            new NextAction("arcane intellect on party", 20.0f),
+            NULL)));
 
     triggers.push_back(new TriggerNode(
         "no drink",

--- a/src/modules/Bots/playerbot/strategy/mage/GenericMageStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/mage/GenericMageStrategy.cpp
@@ -19,6 +19,7 @@ public:
         creators["evocation"] = &evocation;
         creators["dragon's breath"] = &dragons_breath;
         creators["blast wave"] = &blast_wave;
+        creators["ice block"] = &ice_block;
     }
 private:
     static ActionNode* frostbolt(PlayerbotAI* ai)
@@ -83,6 +84,13 @@ private:
             /*P*/ NULL,
             /*A*/ NextAction::array(0, new NextAction("frost nova"), NULL),
             /*C*/ NextAction::array(0, new NextAction("flamestrike", 71.0f), NULL));
+    }
+    static ActionNode* ice_block(PlayerbotAI* ai)
+    {
+        return new ActionNode ("ice block",
+            /*P*/ NULL,
+            /*A*/ NextAction::array(0, new NextAction("cold snap"), NULL),
+            /*C*/ NULL);
     }
 };
 

--- a/src/modules/Bots/playerbot/strategy/mage/MageActions.h
+++ b/src/modules/Bots/playerbot/strategy/mage/MageActions.h
@@ -173,6 +173,60 @@ namespace ai
         CastCounterspellOnEnemyHealerAction(PlayerbotAI* ai) : CastSpellOnEnemyHealerAction(ai, "counterspell") {}
     };
 
+    class CastLivingBombAction : public CastSpellAction
+    {
+    public:
+        CastLivingBombAction(PlayerbotAI* ai) : CastSpellAction(ai, "living bomb") {}
+    };
+
+    class CastIcyVeinsAction : public CastBuffSpellAction
+    {
+    public:
+        CastIcyVeinsAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "icy veins") {}
+    };
+
+    class CastSpellstealAction : public CastSpellAction
+    {
+    public:
+        CastSpellstealAction(PlayerbotAI* ai) : CastSpellAction(ai, "spellsteal") {}
+    };
+
+    class CastDragonsBreathAction : public CastSpellAction
+    {
+    public:
+        CastDragonsBreathAction(PlayerbotAI* ai) : CastSpellAction(ai, "dragon's breath") {}
+    };
+
+    class CastArcaneBlastAction : public CastSpellAction
+    {
+    public:
+        CastArcaneBlastAction(PlayerbotAI* ai) : CastSpellAction(ai, "arcane blast") {}
+    };
+
+    class CastArcaneBarrageAction : public CastSpellAction
+    {
+    public:
+        CastArcaneBarrageAction(PlayerbotAI* ai) : CastSpellAction(ai, "arcane barrage") {}
+    };
+
+    class CastConeOfColdAction : public CastSpellAction
+    {
+    public:
+        CastConeOfColdAction(PlayerbotAI* ai) : CastSpellAction(ai, "cone of cold") {}
+    };
+
+    class CastColdSnapAction : public CastSpellAction
+    {
+    public:
+        CastColdSnapAction(PlayerbotAI* ai) : CastSpellAction(ai, "cold snap") {}
+        virtual string GetTargetName() { return "self target"; }
+    };
+
+    class CastArcaneBrillianceAction : public CastBuffSpellAction
+    {
+    public:
+        CastArcaneBrillianceAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "arcane brilliance") {}
+    };
 
     class GiveConjuredFoodAction : public InventoryAction
     {

--- a/src/modules/Bots/playerbot/strategy/mage/MageAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/mage/MageAiObjectContext.cpp
@@ -170,6 +170,15 @@ namespace ai
                 creators["evocation"] = &AiObjectContextInternal::evocation;
                 creators["arcane missiles"] = &AiObjectContextInternal::arcane_missiles;
                 creators["counterspell on enemy healer"] = &AiObjectContextInternal::counterspell_on_enemy_healer;
+                creators["living bomb"] = &AiObjectContextInternal::living_bomb;
+                creators["icy veins"] = &AiObjectContextInternal::icy_veins;
+                creators["spellsteal"] = &AiObjectContextInternal::spellsteal;
+                creators["dragon's breath"] = &AiObjectContextInternal::dragons_breath;
+                creators["arcane blast"] = &AiObjectContextInternal::arcane_blast;
+                creators["arcane barrage"] = &AiObjectContextInternal::arcane_barrage;
+                creators["cone of cold"] = &AiObjectContextInternal::cone_of_cold;
+                creators["cold snap"] = &AiObjectContextInternal::cold_snap;
+                creators["arcane brilliance"] = &AiObjectContextInternal::arcane_brilliance;
             }
 
         private:
@@ -201,6 +210,15 @@ namespace ai
             static Action* blast_wave(PlayerbotAI* ai) { return new CastBlastWaveAction(ai); }
             static Action* evocation(PlayerbotAI* ai) { return new CastEvocationAction(ai); }
             static Action* counterspell_on_enemy_healer(PlayerbotAI* ai) { return new CastCounterspellOnEnemyHealerAction(ai); }
+            static Action* living_bomb(PlayerbotAI* ai) { return new CastLivingBombAction(ai); }
+            static Action* icy_veins(PlayerbotAI* ai) { return new CastIcyVeinsAction(ai); }
+            static Action* spellsteal(PlayerbotAI* ai) { return new CastSpellstealAction(ai); }
+            static Action* dragons_breath(PlayerbotAI* ai) { return new CastDragonsBreathAction(ai); }
+            static Action* arcane_blast(PlayerbotAI* ai) { return new CastArcaneBlastAction(ai); }
+            static Action* arcane_barrage(PlayerbotAI* ai) { return new CastArcaneBarrageAction(ai); }
+            static Action* cone_of_cold(PlayerbotAI* ai) { return new CastConeOfColdAction(ai); }
+            static Action* cold_snap(PlayerbotAI* ai) { return new CastColdSnapAction(ai); }
+            static Action* arcane_brilliance(PlayerbotAI* ai) { return new CastArcaneBrillianceAction(ai); }
         };
     };
 };


### PR DESCRIPTION
Looks like a lot, but isn't much.
Adds icy veins as an alternative to ice block, arcane brilliance as an intellect alternative, and cone of cold as an aoe spell.
Most of this is just wiring up TBC spells for adding to strategies later, since it was pretty obvious this code is shared with TBC.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/286)
<!-- Reviewable:end -->
