### PR TITLE
Druid bot fixes for vanilla and TBC

### DIFF
--- a/src/modules/Bots/playerbot/strategy/druid/BearTankDruidStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/druid/BearTankDruidStrategy.cpp
@@ -22,6 +22,8 @@ public:
         creators["swipe"] = &swipe;
         creators["lacerate"] = &lacerate;
         creators["demoralizing roar"] = &demoralizing_roar;
+        creators["frenzied regeneration"] = &frenzied_regeneration;
+        creators["challenging roar"] = &challenging_roar;
     }
 private:
     static ActionNode* melee(PlayerbotAI* ai)
@@ -42,7 +44,7 @@ private:
     {
         return new ActionNode ("swipe (bear)",
             /*P*/ NULL,
-            /*A*/ NULL,
+            /*A*/ NextAction::array(0, new NextAction("swipe"), NULL),
             /*C*/ NULL);
     }
     static ActionNode* faerie_fire_feral(PlayerbotAI* ai)
@@ -115,6 +117,20 @@ private:
             /*A*/ NULL,
             /*C*/ NULL);
     }
+    static ActionNode* frenzied_regeneration(PlayerbotAI* ai)
+    {
+        return new ActionNode ("frenzied regeneration",
+            /*P*/ NULL,
+            /*A*/ NextAction::array(0, new NextAction("barkskin"), NULL),
+            /*C*/ NULL);
+    }
+    static ActionNode* challenging_roar(PlayerbotAI* ai)
+    {
+        return new ActionNode ("challenging roar",
+            /*P*/ NULL,
+            /*A*/ NULL,
+            /*C*/ NULL);
+    }
 };
 
 BearTankDruidStrategy::BearTankDruidStrategy(PlayerbotAI* ai) : FeralDruidStrategy(ai)
@@ -153,8 +169,12 @@ void BearTankDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         NextAction::array(0, new NextAction("growl", ACTION_HIGH + 8), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "low health",
+        NextAction::array(0, new NextAction("frenzied regeneration", ACTION_MEDIUM_HEAL + 3), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "medium aoe",
-        NextAction::array(0, new NextAction("demoralizing roar", ACTION_HIGH + 6), new NextAction("swipe (bear)", ACTION_HIGH + 6), NULL)));
+        NextAction::array(0, new NextAction("challenging roar", ACTION_HIGH + 7), new NextAction("demoralizing roar", ACTION_HIGH + 6), new NextAction("swipe (bear)", ACTION_HIGH + 6), NULL)));
 
     triggers.push_back(new TriggerNode(
         "light aoe",

--- a/src/modules/Bots/playerbot/strategy/druid/CatDpsDruidStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/druid/CatDpsDruidStrategy.cpp
@@ -19,6 +19,7 @@ public:
         creators["rake"] = &rake;
         creators["ferocious bite"] = &ferocious_bite;
         creators["rip"] = &rip;
+        creators["swipe (cat)"] = &swipe_cat;
     }
 private:
     static ActionNode* faerie_fire_feral(PlayerbotAI* ai)
@@ -84,6 +85,13 @@ private:
             /*A*/ NULL,
             /*C*/ NULL);
     }
+    static ActionNode* swipe_cat(PlayerbotAI* ai)
+    {
+        return new ActionNode ("swipe (cat)",
+            /*P*/ NULL,
+            /*A*/ NextAction::array(0, new NextAction("claw"), NULL),
+            /*C*/ NULL);
+    }
 };
 
 CatDpsDruidStrategy::CatDpsDruidStrategy(PlayerbotAI* ai) : FeralDruidStrategy(ai)
@@ -93,7 +101,9 @@ CatDpsDruidStrategy::CatDpsDruidStrategy(PlayerbotAI* ai) : FeralDruidStrategy(a
 
 NextAction** CatDpsDruidStrategy::getDefaultActions()
 {
-    return NextAction::array(0, new NextAction("mangle (cat)", ACTION_NORMAL + 1), NULL);
+    return NextAction::array(0,
+        new NextAction("mangle (cat)", ACTION_NORMAL + 1),
+        NULL);
 }
 
 void CatDpsDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)

--- a/src/modules/Bots/playerbot/strategy/druid/DruidActions.h
+++ b/src/modules/Bots/playerbot/strategy/druid/DruidActions.h
@@ -165,7 +165,19 @@ namespace ai
     class CastBarskinAction : public CastBuffSpellAction
     {
     public:
-        CastBarskinAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "barskin") {}
+        CastBarskinAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "barkskin") {}
+    };
+
+    class CastRemoveCurseAction : public CastCureSpellAction
+    {
+    public:
+        CastRemoveCurseAction(PlayerbotAI* ai) : CastCureSpellAction(ai, "remove curse") {}
+    };
+
+    class CastRemoveCurseOnPartyAction : public CurePartyMemberAction
+    {
+    public:
+        CastRemoveCurseOnPartyAction(PlayerbotAI* ai) : CurePartyMemberAction(ai, "remove curse", DISPEL_CURSE) {}
     };
 
     class CastInnervateAction : public CastSpellAction

--- a/src/modules/Bots/playerbot/strategy/druid/DruidAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/druid/DruidAiObjectContext.cpp
@@ -90,6 +90,8 @@ namespace ai
                 creators["eclipse (solar)"] = &TriggerFactoryInternal::eclipse_solar;
                 creators["eclipse (lunar)"] = &TriggerFactoryInternal::eclipse_lunar;
                 creators["bash on enemy healer"] = &TriggerFactoryInternal::bash_on_enemy_healer;
+                creators["remove curse"] = &TriggerFactoryInternal::remove_curse;
+                creators["remove curse on party"] = &TriggerFactoryInternal::remove_curse_on_party;
             }
 
         private:
@@ -113,6 +115,8 @@ namespace ai
             static Trigger* cat_form(PlayerbotAI* ai) { return new CatFormTrigger(ai); }
             static Trigger* tree_form(PlayerbotAI* ai) { return new TreeFormTrigger(ai); }
             static Trigger* bash_on_enemy_healer(PlayerbotAI* ai) { return new BashInterruptEnemyHealerSpellTrigger(ai); }
+            static Trigger* remove_curse(PlayerbotAI* ai) { return new RemoveCurseTrigger(ai); }
+            static Trigger* remove_curse_on_party(PlayerbotAI* ai) { return new PartyMemberRemoveCurseTrigger(ai); }
         };
     };
 };
@@ -176,12 +180,16 @@ namespace ai
                 creators["rejuvenation on party"] = &AiObjectContextInternal::rejuvenation_on_party;
                 creators["healing touch on party"] = &AiObjectContextInternal::healing_touch_on_party;
                 creators["rebirth"] = &AiObjectContextInternal::rebirth;
-                creators["barskin"] = &AiObjectContextInternal::barskin;
+                creators["barkskin"] = &AiObjectContextInternal::barskin;
                 creators["lacerate"] = &AiObjectContextInternal::lacerate;
                 creators["hurricane"] = &AiObjectContextInternal::hurricane;
                 creators["innervate"] = &AiObjectContextInternal::innervate;
                 creators["tranquility"] = &AiObjectContextInternal::tranquility;
                 creators["bash on enemy healer"] = &AiObjectContextInternal::bash_on_enemy_healer;
+                creators["remove curse"] = &AiObjectContextInternal::remove_curse;
+                creators["remove curse on party"] = &AiObjectContextInternal::remove_curse_on_party;
+                creators["frenzied regeneration"] = &AiObjectContextInternal::frenzied_regeneration;
+                creators["challenging roar"] = &AiObjectContextInternal::challenging_roar;
             }
 
         private:
@@ -239,6 +247,10 @@ namespace ai
             static Action* hurricane(PlayerbotAI* ai) { return new CastHurricaneAction(ai); }
             static Action* innervate(PlayerbotAI* ai) { return new CastInnervateAction(ai); }
             static Action* bash_on_enemy_healer(PlayerbotAI* ai) { return new CastBashOnEnemyHealerAction(ai); }
+            static Action* remove_curse(PlayerbotAI* ai) { return new CastRemoveCurseAction(ai); }
+            static Action* remove_curse_on_party(PlayerbotAI* ai) { return new CastRemoveCurseOnPartyAction(ai); }
+            static Action* frenzied_regeneration(PlayerbotAI* ai) { return new CastFrenziedRegenerationAction(ai); }
+            static Action* challenging_roar(PlayerbotAI* ai) { return new CastChallengingRoarAction(ai); }
         };
     };
 };

--- a/src/modules/Bots/playerbot/strategy/druid/DruidBearActions.h
+++ b/src/modules/Bots/playerbot/strategy/druid/DruidBearActions.h
@@ -61,4 +61,16 @@ namespace ai {
     public:
         CastBashOnEnemyHealerAction(PlayerbotAI* ai) : CastSpellOnEnemyHealerAction(ai, "bash") {}
     };
+
+    class CastFrenziedRegenerationAction : public CastSpellAction
+    {
+    public:
+        CastFrenziedRegenerationAction(PlayerbotAI* ai) : CastSpellAction(ai, "frenzied regeneration") {}
+    };
+
+    class CastChallengingRoarAction : public CastSpellAction
+    {
+    public:
+        CastChallengingRoarAction(PlayerbotAI* ai) : CastSpellAction(ai, "challenging roar") {}
+    };
 }

--- a/src/modules/Bots/playerbot/strategy/druid/DruidCatActions.h
+++ b/src/modules/Bots/playerbot/strategy/druid/DruidCatActions.h
@@ -64,6 +64,4 @@ namespace ai {
         CastRipAction(PlayerbotAI* ai) : CastMeleeSpellAction(ai, "rip") {}
     };
 
-
-
 }

--- a/src/modules/Bots/playerbot/strategy/druid/DruidShapeshiftActions.h
+++ b/src/modules/Bots/playerbot/strategy/druid/DruidShapeshiftActions.h
@@ -30,6 +30,10 @@ namespace ai {
     class CastTreeFormAction : public CastBuffSpellAction {
     public:
         CastTreeFormAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "tree of life") {}
+
+        virtual bool isUseful() {
+            return AI_VALUE2(uint32, "spell id", "tree of life") != 0 && CastBuffSpellAction::isUseful();
+        }
     };
 
     class CastMoonkinFormAction : public CastBuffSpellAction {

--- a/src/modules/Bots/playerbot/strategy/druid/DruidTriggers.h
+++ b/src/modules/Bots/playerbot/strategy/druid/DruidTriggers.h
@@ -124,4 +124,16 @@ namespace ai {
     public:
         BashInterruptEnemyHealerSpellTrigger(PlayerbotAI* ai) : InterruptEnemyHealerTrigger(ai, "bash") {}
     };
+
+    class RemoveCurseTrigger : public NeedCureTrigger
+    {
+    public:
+        RemoveCurseTrigger(PlayerbotAI* ai) : NeedCureTrigger(ai, "remove curse", DISPEL_CURSE) {}
+    };
+
+    class PartyMemberRemoveCurseTrigger : public PartyMemberNeedCureTrigger
+    {
+    public:
+        PartyMemberRemoveCurseTrigger(PlayerbotAI* ai) : PartyMemberNeedCureTrigger(ai, "remove curse", DISPEL_CURSE) {}
+    };
 }

--- a/src/modules/Bots/playerbot/strategy/druid/FeralDruidStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/druid/FeralDruidStrategy.cpp
@@ -21,7 +21,7 @@ private:
     {
         return new ActionNode ("survival instincts",
             /*P*/ NULL,
-            /*A*/ NextAction::array(0, new NextAction("barskin"), NULL),
+            /*A*/ NextAction::array(0, new NextAction("barkskin"), NULL),
             /*C*/ NULL);
     }
     static ActionNode* thorns(PlayerbotAI* ai)

--- a/src/modules/Bots/playerbot/strategy/druid/GenericDruidNonCombatStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/druid/GenericDruidNonCombatStrategy.cpp
@@ -64,6 +64,14 @@ void GenericDruidNonCombatStrategy::InitTriggers(std::list<TriggerNode*> &trigge
         NextAction::array(0, new NextAction("abolish poison on party", 20.0f), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "remove curse",
+        NextAction::array(0, new NextAction("remove curse", ACTION_DISPEL + 2), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "remove curse on party",
+        NextAction::array(0, new NextAction("remove curse on party", ACTION_DISPEL + 1), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "party member dead",
         NextAction::array(0, new NextAction("revive", 22.0f), NULL)));
 

--- a/src/modules/Bots/playerbot/strategy/druid/GenericDruidStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/druid/GenericDruidStrategy.cpp
@@ -19,6 +19,8 @@ public:
         creators["rebirth"] = &rebirth;
         creators["entangling roots on cc"] = &entangling_roots_on_cc;
         creators["innervate"] = &innervate;
+        creators["remove curse"] = &remove_curse;
+        creators["remove curse on party"] = &remove_curse_on_party;
     }
 
 private:
@@ -85,6 +87,20 @@ private:
             /*A*/ NextAction::array(0, new NextAction("mana potion"), NULL),
             /*C*/ NULL);
     }
+    static ActionNode* remove_curse(PlayerbotAI* ai)
+    {
+        return new ActionNode ("remove curse",
+            /*P*/ NextAction::array(0, new NextAction("caster form"), NULL),
+            /*A*/ NULL,
+            /*C*/ NULL);
+    }
+    static ActionNode* remove_curse_on_party(PlayerbotAI* ai)
+    {
+        return new ActionNode ("remove curse on party",
+            /*P*/ NextAction::array(0, new NextAction("caster form"), NULL),
+            /*A*/ NULL,
+            /*C*/ NULL);
+    }
 };
 
 GenericDruidStrategy::GenericDruidStrategy(PlayerbotAI* ai) : CombatStrategy(ai)
@@ -121,6 +137,14 @@ void GenericDruidStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "party member cure poison",
         NextAction::array(0, new NextAction("abolish poison on party", ACTION_DISPEL + 1), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "remove curse",
+        NextAction::array(0, new NextAction("remove curse", ACTION_DISPEL + 2), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "remove curse on party",
+        NextAction::array(0, new NextAction("remove curse on party", ACTION_DISPEL + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
         "party member dead",


### PR DESCRIPTION
Unlike Mage, this one does quite a bit for Druid bots, esp Zero bots:
swipe (bear) and swipe (cat), both TBC spells, will fallback to swipe (vanilla).
At low health, frenzied regeneration is preferred to barkskin (oh, and barkskin actually spelled right now)
Challenging Roar added for druid tanks.
Remove Curse added for targeted or party cures.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/287)
<!-- Reviewable:end -->
