### PR TITLE
Minor tweeks to Priest for Completeness

### DIFF
--- a/src/modules/Bots/playerbot/strategy/priest/GenericPriestStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/priest/GenericPriestStrategy.cpp
@@ -64,4 +64,8 @@ void GenericPriestStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         "medium threat",
         NextAction::array(0, new NextAction("psychic scream", 50.0f), NULL)));
 
+    triggers.push_back(new TriggerNode(
+        "power infusion",
+        NextAction::array(0, new NextAction("power infusion", 8.0f), NULL)));
+
 }

--- a/src/modules/Bots/playerbot/strategy/priest/GenericPriestStrategyActionNodeFactory.h
+++ b/src/modules/Bots/playerbot/strategy/priest/GenericPriestStrategyActionNodeFactory.h
@@ -25,6 +25,7 @@ namespace ai
             creators["lesser heal on party"] = &lesser_heal_on_party;
             creators["flash heal"] = &flash_heal;
             creators["flash heal on party"] = &flash_heal_on_party;
+            creators["circle of healing"] = &circle_of_healing;
             creators["psychic scream"] = &psychic_scream;
             creators["fade"] = &fade;
         }
@@ -153,6 +154,13 @@ namespace ai
             return new ActionNode ("flash heal on party",
                 /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
                 /*A*/ NextAction::array(0, new NextAction("greater heal on party"), NULL),
+                /*C*/ NULL);
+        }
+        static ActionNode* circle_of_healing(PlayerbotAI* ai)
+        {
+            return new ActionNode ("circle of healing",
+                /*P*/ NextAction::array(0, new NextAction("remove shadowform"), NULL),
+                /*A*/ NextAction::array(0, new NextAction("flash heal on party"), NULL),
                 /*C*/ NULL);
         }
         static ActionNode* psychic_scream(PlayerbotAI* ai)

--- a/src/modules/Bots/playerbot/strategy/priest/HealPriestStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/priest/HealPriestStrategy.cpp
@@ -33,4 +33,8 @@ void HealPriestStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "enemy too close for spell",
         NextAction::array(0, new NextAction("fade", 50.0f), new NextAction("flee", 49.0f), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "shackle undead",
+        NextAction::array(0, new NextAction("shackle undead", 18.0f), NULL)));
 }

--- a/src/modules/Bots/playerbot/strategy/priest/PriestActions.h
+++ b/src/modules/Bots/playerbot/strategy/priest/PriestActions.h
@@ -166,6 +166,9 @@ namespace ai
     BEGIN_DEBUFF_ACTION(CastDevouringPlagueAction, "devouring plague")
     END_SPELL_ACTION()
 
+    BEGIN_DEBUFF_ACTION(CastVampiricTouchAction, "vampiric touch")
+    END_SPELL_ACTION()
+
     BEGIN_RANGED_SPELL_ACTION(CastMindBlastAction, "mind blast")
     END_SPELL_ACTION()
 
@@ -225,5 +228,33 @@ namespace ai
     {
     public:
         CastPsychicScreamAction(PlayerbotAI* ai) : CastSpellAction(ai, "psychic scream") {}
+    };
+
+    class CastShackleUndeadAction : public CastDebuffSpellOnAttackerAction
+    {
+    public:
+        CastShackleUndeadAction(PlayerbotAI* ai) : CastDebuffSpellOnAttackerAction(ai, "shackle undead") {}
+        virtual bool isUseful()
+        {
+            Unit* target = GetTarget();
+            if (!target || target->GetCreatureType() != CREATURE_TYPE_UNDEAD)
+                return false;
+            return CastDebuffSpellOnAttackerAction::isUseful();
+        }
+        virtual string getName() { return "shackle undead"; }
+    };
+
+    class CastPowerInfusionAction : public BuffOnPartyAction
+    {
+    public:
+        CastPowerInfusionAction(PlayerbotAI* ai) : BuffOnPartyAction(ai, "power infusion") {}
+        virtual string getName() { return "power infusion"; }
+    };
+
+    class CastCircleOfHealingAction : public HealPartyMemberAction
+    {
+    public:
+        CastCircleOfHealingAction(PlayerbotAI* ai) : HealPartyMemberAction(ai, "circle of healing") {}
+        virtual string getName() { return "circle of healing"; }
     };
 }

--- a/src/modules/Bots/playerbot/strategy/priest/PriestAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/priest/PriestAiObjectContext.cpp
@@ -83,11 +83,14 @@ namespace ai
                 creators["vampiric touch"] = &TriggerFactoryInternal::vampiric_touch;
                 creators["shadowform"] = &TriggerFactoryInternal::shadowform;
                 creators["vampiric embrace"] = &TriggerFactoryInternal::vampiric_embrace;
-
+                creators["shackle undead"] = &TriggerFactoryInternal::shackle_undead;
+                creators["power infusion"] = &TriggerFactoryInternal::power_infusion;
             }
 
         private:
             static Trigger* vampiric_embrace(PlayerbotAI* ai) { return new VampiricEmbraceTrigger(ai); }
+            static Trigger* shackle_undead(PlayerbotAI* ai) { return new ShackleUndeadTrigger(ai); }
+            static Trigger* power_infusion(PlayerbotAI* ai) { return new PowerInfusionTrigger(ai); }
             static Trigger* shadowform(PlayerbotAI* ai) { return new ShadowformTrigger(ai); }
             static Trigger* vampiric_touch(PlayerbotAI* ai) { return new VampiricTouchTrigger(ai); }
             static Trigger* devouring_plague(PlayerbotAI* ai) { return new DevouringPlagueTrigger(ai); }
@@ -157,10 +160,18 @@ namespace ai
                 creators["resurrection"] = &AiObjectContextInternal::resurrection;
                 creators["psychic scream"] = &AiObjectContextInternal::psychic_scream;
                 creators["vampiric embrace"] = &AiObjectContextInternal::vampiric_embrace;
+                creators["vampiric touch"] = &AiObjectContextInternal::vampiric_touch;
+                creators["shackle undead"] = &AiObjectContextInternal::shackle_undead;
+                creators["power infusion"] = &AiObjectContextInternal::power_infusion;
+                creators["circle of healing"] = &AiObjectContextInternal::circle_of_healing;
             }
 
         private:
             static Action* vampiric_embrace(PlayerbotAI* ai) { return new CastVampiricEmbraceAction(ai); }
+            static Action* vampiric_touch(PlayerbotAI* ai) { return new CastVampiricTouchAction(ai); }
+            static Action* shackle_undead(PlayerbotAI* ai) { return new CastShackleUndeadAction(ai); }
+            static Action* power_infusion(PlayerbotAI* ai) { return new CastPowerInfusionAction(ai); }
+            static Action* circle_of_healing(PlayerbotAI* ai) { return new CastCircleOfHealingAction(ai); }
             static Action* psychic_scream(PlayerbotAI* ai) { return new CastPsychicScreamAction(ai); }
             static Action* resurrection(PlayerbotAI* ai) { return new CastResurrectionAction(ai); }
             static Action* shadow_word_pain(PlayerbotAI* ai) { return new CastPowerWordPainAction(ai); }

--- a/src/modules/Bots/playerbot/strategy/priest/PriestNonCombatStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/priest/PriestNonCombatStrategy.cpp
@@ -79,4 +79,8 @@ void PriestNonCombatStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "party member cure disease",
         NextAction::array(0, new NextAction("abolish disease on party", 30.0f), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "power infusion",
+        NextAction::array(0, new NextAction("power infusion", 8.0f), NULL)));
 }

--- a/src/modules/Bots/playerbot/strategy/priest/PriestTriggers.h
+++ b/src/modules/Bots/playerbot/strategy/priest/PriestTriggers.h
@@ -51,4 +51,19 @@ namespace ai
         ShadowformTrigger(PlayerbotAI* ai) : BuffTrigger(ai, "shadowform") {}
         virtual bool IsActive() { return !ai->HasAura("shadowform", bot); }
     };
+
+    class ShackleUndeadTrigger : public DebuffOnAttackerTrigger
+    {
+    public:
+        ShackleUndeadTrigger(PlayerbotAI* ai) : DebuffOnAttackerTrigger(ai, "shackle undead") {}
+        virtual bool IsActive()
+        {
+            Unit* target = GetTargetValue()->Get();
+            if (!target || target->GetCreatureType() != CREATURE_TYPE_UNDEAD)
+                return false;
+            return DebuffTrigger::IsActive();
+        }
+    };
+
+    BUFF_ON_PARTY_TRIGGER(PowerInfusionTrigger, "power infusion", "power infusion")
 }

--- a/src/modules/Bots/playerbot/strategy/priest/ShadowPriestStrategyActionNodeFactory.h
+++ b/src/modules/Bots/playerbot/strategy/priest/ShadowPriestStrategyActionNodeFactory.h
@@ -7,11 +7,19 @@ namespace ai
     public:
         ShadowPriestStrategyActionNodeFactory()
         {
+            creators["vampiric touch"] = &vampiric_touch;
             creators["mind flay"] = &mind_flay;
             creators["mind blast"] = &mind_blast;
             creators["dispersion"] = &dispersion;
         }
     private:
+        static ActionNode* vampiric_touch(PlayerbotAI* ai)
+        {
+            return new ActionNode ("vampiric touch",
+                /*P*/ NULL,
+                /*A*/ NextAction::array(0, new NextAction("shadow word: pain"), NULL),
+                /*C*/ NULL);
+        }
         static ActionNode* mind_flay(PlayerbotAI* ai)
         {
             return new ActionNode ("mind flay",


### PR DESCRIPTION
The bot Priest now uses a few spells it was missing before. It will automatically shackle undead  enemies, cast Power Infusion on party members, and shadow priests will apply Vampiric Touch as a DoT.   Heal priests will use Circle of Healing on injured party members.  Circle of Healing and Vampiric Touch are TBC spells, but bot falls back to Vanilla equivalents of course.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/289)
<!-- Reviewable:end -->
