### PR TITLE
Tweeks to make Warrior bots more Vanilla-capable

### DIFF
--- a/src/modules/Bots/playerbot/strategy/warrior/DpsWarriorStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/warrior/DpsWarriorStrategy.cpp
@@ -10,6 +10,8 @@ class DpsWarriorStrategyActionNodeFactory : public NamedObjectFactory<ActionNode
 public:
     DpsWarriorStrategyActionNodeFactory()
     {
+        creators["mortal strike"] = &mortal_strike;
+        creators["whirlwind"] = &whirlwind;
         creators["overpower"] = &overpower;
         creators["melee"] = &melee;
         creators["charge"] = &charge;
@@ -20,6 +22,20 @@ public:
         creators["execute"] = &execute;
     }
 private:
+    static ActionNode* mortal_strike(PlayerbotAI* ai)
+    {
+        return new ActionNode ("mortal strike",
+            /*P*/ NULL,
+            /*A*/ NextAction::array(0, new NextAction("bloodthirst"), NULL),
+            /*C*/ NULL);
+    }
+    static ActionNode* whirlwind(PlayerbotAI* ai)
+    {
+        return new ActionNode ("whirlwind",
+            /*P*/ NULL,
+            /*A*/ NextAction::array(0, new NextAction("cleave"), NULL),
+            /*C*/ NULL);
+    }
     static ActionNode* overpower(PlayerbotAI* ai)
     {
         return new ActionNode ("overpower",
@@ -65,14 +81,14 @@ private:
     static ActionNode* death_wish(PlayerbotAI* ai)
     {
         return new ActionNode ("death wish",
-            /*P*/ NULL,
+            /*P*/ NextAction::array(0, new NextAction("berserker stance"), NULL),
             /*A*/ NextAction::array(0, new NextAction("berserker rage"), NULL),
             /*C*/ NULL);
     }
     static ActionNode* execute(PlayerbotAI* ai)
     {
         return new ActionNode ("execute",
-            /*P*/ NextAction::array(0, new NextAction("battle stance"), NULL),
+            /*P*/ NULL,
             /*A*/ NextAction::array(0, new NextAction("heroic strike"), NULL),
             /*C*/ NULL);
     }
@@ -85,12 +101,16 @@ DpsWarriorStrategy::DpsWarriorStrategy(PlayerbotAI* ai) : GenericWarriorStrategy
 
 NextAction** DpsWarriorStrategy::getDefaultActions()
 {
-    return NextAction::array(0, new NextAction("bloodthirst", ACTION_NORMAL + 1), NULL);
+    return NextAction::array(0, new NextAction("mortal strike", ACTION_NORMAL + 1), NULL);
 }
 
 void DpsWarriorStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
     GenericWarriorStrategy::InitTriggers(triggers);
+
+    triggers.push_back(new TriggerNode(
+        "rend",
+        NextAction::array(0, new NextAction("rend", ACTION_NORMAL + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
         "enemy out of melee",
@@ -126,5 +146,5 @@ void DpsWarrirorAoeStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 
     triggers.push_back(new TriggerNode(
         "medium aoe",
-        NextAction::array(0, new NextAction("cleave", ACTION_HIGH + 3), NULL)));
+        NextAction::array(0, new NextAction("whirlwind", ACTION_HIGH + 4), new NextAction("cleave", ACTION_HIGH + 3), NULL)));
 }

--- a/src/modules/Bots/playerbot/strategy/warrior/GenericWarriorStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/warrior/GenericWarriorStrategy.cpp
@@ -52,10 +52,6 @@ void GenericWarriorStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         NextAction::array(0, new NextAction("battle shout", ACTION_HIGH + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "rend",
-        NextAction::array(0, new NextAction("rend", ACTION_NORMAL + 1), NULL)));
-
-    triggers.push_back(new TriggerNode(
         "bloodrage",
         NextAction::array(0, new NextAction("bloodrage", ACTION_HIGH + 1), NULL)));
 

--- a/src/modules/Bots/playerbot/strategy/warrior/TankWarriorStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/warrior/TankWarriorStrategy.cpp
@@ -12,7 +12,6 @@ public:
     {
         creators["melee"] = &melee;
         creators["shield wall"] = &shield_wall;
-        creators["rend"] = &rend;
         creators["revenge"] = &revenge;
         creators["devastate"] = &devastate;
         creators["shockwave"] = &shockwave;
@@ -31,13 +30,6 @@ private:
         return new ActionNode ("shield wall",
             /*P*/ NULL,
             /*A*/ NextAction::array(0, new NextAction("shield block"), NULL),
-            /*C*/ NULL);
-    }
-    static ActionNode* rend(PlayerbotAI* ai)
-    {
-        return new ActionNode ("rend",
-            /*P*/ NextAction::array(0, new NextAction("defensive stance"), NULL),
-            /*A*/ NULL,
             /*C*/ NULL);
     }
     static ActionNode* revenge(PlayerbotAI* ai)
@@ -110,7 +102,7 @@ void TankWarriorStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 
     triggers.push_back(new TriggerNode(
         "light aoe",
-        NextAction::array(0, new NextAction("thunder clap", ACTION_HIGH + 2), new NextAction("demoralizing shout", ACTION_HIGH + 2),  new NextAction("cleave", ACTION_HIGH + 1), NULL)));
+        NextAction::array(0, new NextAction("demoralizing shout", ACTION_HIGH + 2), new NextAction("cleave", ACTION_HIGH + 1), NULL)));
 
     triggers.push_back(new TriggerNode(
         "high aoe",

--- a/src/modules/Bots/playerbot/strategy/warrior/WarriorActions.h
+++ b/src/modules/Bots/playerbot/strategy/warrior/WarriorActions.h
@@ -176,6 +176,29 @@ namespace ai
         CastBerserkerRageAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "berserker rage") {}
     };
 
+    class CastBerserkerStanceAction : public CastBuffSpellAction {
+    public:
+        CastBerserkerStanceAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "berserker stance") {}
+    };
+
+    class CastVictoryRushAction : public CastMeleeSpellAction {
+    public:
+        CastVictoryRushAction(PlayerbotAI* ai) : CastMeleeSpellAction(ai, "victory rush") {}
+    };
+
+    class CastMortalStrikeAction : public CastBattleMeleeSpellAction {
+    public:
+        CastMortalStrikeAction(PlayerbotAI* ai) : CastBattleMeleeSpellAction(ai, "mortal strike") {}
+    };
+
+    class CastWhirlwindAction : public CastMeleeSpellAction {
+    public:
+        CastWhirlwindAction(PlayerbotAI* ai) : CastMeleeSpellAction(ai, "whirlwind") {}
+        virtual NextAction** getPrerequisites() {
+            return NextAction::merge(NextAction::array(0, new NextAction("berserker stance"), NULL), CastMeleeSpellAction::getPrerequisites());
+        }
+    };
+
     class CastLastStandAction : public CastBuffSpellAction {
     public:
         CastLastStandAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "last stand") {}

--- a/src/modules/Bots/playerbot/strategy/warrior/WarriorAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/warrior/WarriorAiObjectContext.cpp
@@ -105,6 +105,10 @@ namespace ai
         public:
             AiObjectContextInternal()
             {
+                creators["berserker stance"] = &AiObjectContextInternal::berserker_stance;
+                creators["victory rush"] = &AiObjectContextInternal::victory_rush;
+                creators["mortal strike"] = &AiObjectContextInternal::mortal_strike;
+                creators["whirlwind"] = &AiObjectContextInternal::whirlwind;
                 creators["overpower"] = &AiObjectContextInternal::overpower;
                 creators["charge"] = &AiObjectContextInternal::charge;
                 creators["bloodthirst"] = &AiObjectContextInternal::bloodthirst;
@@ -140,6 +144,10 @@ namespace ai
             }
 
         private:
+            static Action* berserker_stance(PlayerbotAI* ai) { return new CastBerserkerStanceAction(ai); }
+            static Action* victory_rush(PlayerbotAI* ai) { return new CastVictoryRushAction(ai); }
+            static Action* mortal_strike(PlayerbotAI* ai) { return new CastMortalStrikeAction(ai); }
+            static Action* whirlwind(PlayerbotAI* ai) { return new CastWhirlwindAction(ai); }
             static Action* last_stand(PlayerbotAI* ai) { return new CastLastStandAction(ai); }
             static Action* cleave(PlayerbotAI* ai) { return new CastCleaveAction(ai); }
             static Action* concussion_blow(PlayerbotAI* ai) { return new CastConcussionBlowAction(ai); }


### PR DESCRIPTION
Added correct stances for Death Wish and Whirlwind before they are cast.   
For the Tank strategy, rend and thunder-clap are removed, the former because waste of rage, and the later because of the slow stance dance. 
Mortal Strike added for DPS warrior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/291)
<!-- Reviewable:end -->
