### PR TITLE
Position follow bots in rear arc behind master

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
@@ -154,7 +154,8 @@ float MovementAction::GetFollowAngle()
 
         if ( ref->getSource() == bot)
         {
-            return 2 * M_PI / (group->GetMembersCount() -1) * index;
+            int botCount = (int)group->GetMembersCount() - 1;
+            return M_PI / 2.0f + M_PI * (index - 1) / std::max(botCount - 1, 1);
         }
 
         index++;


### PR DESCRIPTION
I love this change! So simple for what it does: it causes bots following a master to PREFER forming up in an arc BEHIND the master instead of all around him.  This gives an extra level of caution when leading them through dungeons and also looks cool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/294)
<!-- Reviewable:end -->
