### PR TITLE
Bot spell target reach

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/ActionContext.h
+++ b/src/modules/Bots/playerbot/strategy/actions/ActionContext.h
@@ -69,6 +69,7 @@ namespace ai
             creators["drop target"] = &ActionContext::drop_target;
             creators["jump"] = &ActionContext::jump;
             creators["jump up"] = &ActionContext::jump_up;
+            creators["back off"] = &ActionContext::back_off;
         }
 
     private:
@@ -82,6 +83,7 @@ namespace ai
         static Action* melee(PlayerbotAI* ai) { return new MeleeAction(ai); }
         static Action* ReachSpell(PlayerbotAI* ai) { return new ReachSpellAction(ai); }
         static Action* ReachMelee(PlayerbotAI* ai) { return new ReachMeleeAction(ai); }
+        static Action* back_off(PlayerbotAI* ai) { return new BackOffAction(ai); }
         static Action* flee(PlayerbotAI* ai) { return new FleeAction(ai); }
         static Action* gift_of_the_naaru(PlayerbotAI* ai) { return new CastGiftOfTheNaaruAction(ai); }
         static Action* lifeblood(PlayerbotAI* ai) { return new CastLifeBloodAction(ai); }

--- a/src/modules/Bots/playerbot/strategy/actions/GenericSpellActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/GenericSpellActions.h
@@ -77,33 +77,25 @@ namespace ai
 
         virtual NextAction** getPrerequisites()
         {
-            float currentDistance = AI_VALUE2(float, "distance", GetTargetName());
-
-            if (currentDistance <= range)
+            if (range > ATTACK_DISTANCE)
             {
-                if (range > ATTACK_DISTANCE)
+                float currentDistance = AI_VALUE2(float, "distance", GetTargetName());
+                if (currentDistance <= range)
                 {
                     return Action::getPrerequisites();
                 }
                 else
                 {
-                    return NextAction::merge(NextAction::array(0, new NextAction("reach melee"), NULL), Action::getPrerequisites());
+                    context->GetValue<float>("reach spell distance")->Set(range);
+                    return NextAction::merge( NextAction::array(0, new NextAction("reach spell"), NULL), Action::getPrerequisites());
                 }
-            }
-
-            if (range > sPlayerbotAIConfig.spellDistance)
-            {
-                return NULL;
-            }
-            else if (range > ATTACK_DISTANCE)
-            {
-                return NextAction::merge( NextAction::array(0, new NextAction("reach spell"), NULL), Action::getPrerequisites());
             }
             else
             {
                 return NextAction::merge( NextAction::array(0, new NextAction("reach melee"), NULL), Action::getPrerequisites());
             }
         }
+
 
     protected:
         string spell;

--- a/src/modules/Bots/playerbot/strategy/actions/ReachTargetActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/ReachTargetActions.h
@@ -54,9 +54,30 @@ namespace ai
         }
     };
 
+    class BackOffAction : public ReachTargetAction
+    {
+    public:
+        BackOffAction(PlayerbotAI* ai) : ReachTargetAction(ai, "back off", sPlayerbotAIConfig.meleeDistance) {}
+
+        virtual bool isUseful()
+        {
+            return AI_VALUE2(float, "distance", "current target") < distance + sPlayerbotAIConfig.contactDistance + bot->GetObjectBoundingRadius();
+        }
+    };
+
     class ReachSpellAction : public ReachTargetAction
     {
     public:
-        ReachSpellAction(PlayerbotAI* ai, float distance = sPlayerbotAIConfig.spellDistance) : ReachTargetAction(ai, "reach spell", distance) {}
+        ReachSpellAction(PlayerbotAI* ai) : ReachTargetAction(ai, "reach spell", sPlayerbotAIConfig.spellDistance) {}
+        virtual bool Execute(Event event)
+        {
+            distance = AI_VALUE(float, "reach spell distance");
+            return ReachTargetAction::Execute(event);
+        }
+        virtual bool isUseful()
+        {
+            distance = AI_VALUE(float, "reach spell distance");
+            return ReachTargetAction::isUseful();
+        }
     };
 }

--- a/src/modules/Bots/playerbot/strategy/values/ValueContext.h
+++ b/src/modules/Bots/playerbot/strategy/values/ValueContext.h
@@ -139,10 +139,12 @@ namespace ai
             creators["bag space"] = &ValueContext::bag_space;
             creators["enemy healer target"] = &ValueContext::enemy_healer_target;
             creators["item usage"] = &ValueContext::item_usage;
+            creators["reach spell distance"] = &ValueContext::reach_spell_distance;
         }
 
     private:
         static UntypedValue* item_usage(PlayerbotAI* ai) { return new ItemUsageValue(ai); }
+        static UntypedValue* reach_spell_distance(PlayerbotAI* ai) { return new ManualSetValue<float>(ai, sPlayerbotAIConfig.spellDistance, "reach spell distance"); }
         static UntypedValue* mana_save_level(PlayerbotAI* ai) { return new ManaSaveLevelValue(ai); }
         static UntypedValue* invalid_target(PlayerbotAI* ai) { return new InvalidTargetValue(ai); }
         static UntypedValue* balance(PlayerbotAI* ai) { return new BalancePercentValue(ai); }


### PR DESCRIPTION
This implements a suggestion that Copilot made in a long ago previous change to how bots determine range.  I was still relying mostly on the config spell distance instead of the Actual spell distance from the DBC file.  This fixes that, while still having the config spellDistance as a last-resort fallback.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/296)
<!-- Reviewable:end -->
