### PR TITLE
bot add all

### DIFF
--- a/src/modules/Bots/playerbot/PlayerbotMgr.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotMgr.cpp
@@ -344,6 +344,38 @@ list<string> PlayerbotHolder::HandlePlayerbotCommand(char* args, Player* master)
         }
     }
 
+    if (charnameStr == "all" && master && (cmdStr == "add" || cmdStr == "login"))
+    {
+        Group* group = master->GetGroup();
+        if (!group)
+        {
+            messages.push_back("you must be in group");
+            return messages;
+        }
+
+        Group::MemberSlotList slots = group->GetMemberSlots();
+        for (Group::member_citerator i = slots.begin(); i != slots.end(); i++)
+        {
+            ObjectGuid member = i->guid;
+
+            if (member == master->GetObjectGuid())
+            {
+                continue;
+            }
+
+            if (sObjectMgr.GetPlayer(member))
+            {
+                continue;
+            }
+
+            string botName;
+            if (sObjectMgr.GetPlayerNameByGUID(member, botName))
+            {
+                bots.insert(botName);
+            }
+        }
+    }
+
     if (charnameStr == "!" && master && master->GetSession()->GetSecurity() > SEC_GAMEMASTER)
     {
         for (PlayerBotMap::const_iterator i = GetPlayerBotsBegin(); i != GetPlayerBotsEnd(); ++i)


### PR DESCRIPTION
As the title says, adds the ability to use ".bot add all" syntax to automatically pull your entire group of bots back into the game at once, instead of having to do each of them by name.  I got tired of making macros when I swapped bots in and out, so this was just convenience.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/298)
<!-- Reviewable:end -->
