### PR TITLE
Better mage food/drink conjure

### DIFF
--- a/src/modules/Bots/playerbot/strategy/ItemVisitors.h
+++ b/src/modules/Bots/playerbot/strategy/ItemVisitors.h
@@ -59,7 +59,6 @@ namespace ai
             {
                 return FindItemVisitor::Visit(item);
             }
-
             return true;
         }
 
@@ -286,6 +285,7 @@ namespace ai
     inline bool IsBuffFood(const ItemPrototype* proto)
     {
         if (proto->Class != ITEM_CLASS_CONSUMABLE ||
+            proto->SubClass == ITEM_SUBCLASS_BANDAGE ||
             proto->Spells[0].SpellCategory != SPELLCATEGORY_FOOD)
             return false;
         SpellEntry const* sp = sSpellStore.LookupEntry(proto->Spells[0].SpellId);
@@ -354,5 +354,21 @@ namespace ai
         }
     private:
         uint32 spellCategory;
+    };
+
+    class FindLikeItemVisitor : public FindItemVisitor
+    {
+    public:
+        FindLikeItemVisitor(Item *item) : FindItemVisitor()
+        {
+            this->itemId = item->GetProto()->ItemId;
+        }
+
+        virtual bool Accept(const ItemPrototype* proto)
+        {
+            return proto->ItemId == itemId;
+        }
+    private:
+        uint32 itemId;
     };
 }

--- a/src/modules/Bots/playerbot/strategy/actions/NonCombatActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/NonCombatActions.h
@@ -61,7 +61,11 @@ namespace ai
             if (!buffFoods.empty() && !HasFoodBuff(bot, buffFoods))
                 result = UseItemAuto(*buffFoods.begin());
             if (!result)
-                result = UseItemAction::Execute(event);
+            {
+                list<Item*> foods = AI_VALUE2(list<Item*>, "inventory items", "food");
+                if (!foods.empty())
+                    result = UseItemAuto(*foods.begin());
+            }
 
             if (result)
                 ai->SetEating();
@@ -70,7 +74,11 @@ namespace ai
 
         virtual bool isPossible()
         {
-            return ai->IsEating() || UseItemAction::isPossible();
+            if (ai->IsEating())
+                return true;
+            if(AI_VALUE2(list<Item*>, "inventory items", "food").empty())
+                return false;
+            return UseItemAction::isPossible();
         }
 
         virtual bool isUseful()

--- a/src/modules/Bots/playerbot/strategy/mage/GenericMageNonCombatStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/mage/GenericMageNonCombatStrategy.cpp
@@ -59,11 +59,11 @@ void GenericMageNonCombatStrategy::InitTriggers(std::list<TriggerNode*> &trigger
             NULL)));
 
     triggers.push_back(new TriggerNode(
-        "no drink",
+        "no conjured drink",
         NextAction::array(0, new NextAction("conjure water", 16.0f), NULL)));
 
     triggers.push_back(new TriggerNode(
-        "no food",
+        "no conjured food",
         NextAction::array(0, new NextAction("conjure food", 15.0f), NULL)));
 
     triggers.push_back(new TriggerNode(

--- a/src/modules/Bots/playerbot/strategy/mage/MageActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/mage/MageActions.cpp
@@ -9,7 +9,7 @@ Value<Unit*>* CastPolymorphAction::GetTargetValue()
     return context->GetValue<Unit*>("cc target", getName());
 }
 
-static Player* FindPartyMemberWithoutSustenance(Player* bot, bool food)
+static Player* FindPartyMemberWithoutSustenance(Player* bot, Item *item)
 {
     Group* group = bot->GetGroup();
     if (!group)
@@ -30,21 +30,17 @@ static Player* FindPartyMemberWithoutSustenance(Player* bot, bool food)
         {
             continue;
         }
-        if (!food && player->GetPowerType() != POWER_MANA)
+        if (bot->CanUseItem(item->GetProto()) != EQUIP_ERR_OK)
         {
             continue;
         }
-        bool hasItem;
-        if (food)
+        bool isWater = item->GetProto()->Spells[0].SpellCategory == SPELLCATEGORY_DRINK;
+        if (isWater && player->GetPowerType() != POWER_MANA)
         {
-            FindConjuredFoodVisitor foodVisitor(player, SPELLCATEGORY_FOOD);
-            hasItem = InventoryAction::FindPlayerItem(player, &foodVisitor) != NULL;
+            continue;
         }
-        else
-        {
-            FindConjuredFoodVisitor drinkVisitor(player, SPELLCATEGORY_DRINK);
-            hasItem = InventoryAction::FindPlayerItem(player, &drinkVisitor) != NULL;
-        }
+        FindLikeItemVisitor itemVisitor(item);
+        bool hasItem = InventoryAction::FindPlayerItem(player, &itemVisitor) != NULL;
         if (!hasItem)
             return player;
     }
@@ -71,7 +67,7 @@ bool GiveConjuredFoodAction::Execute(Event event)
     }
     Item* food = foods.front();
 
-    Player* target = FindPartyMemberWithoutSustenance(bot, true);
+    Player* target = FindPartyMemberWithoutSustenance(bot, food);
     if (!target)
     {
         return false;
@@ -81,7 +77,7 @@ bool GiveConjuredFoodAction::Execute(Event event)
     uint32 count = food->GetCount();
 
     Item* newItem = target->StoreNewItemInInventorySlot(itemId, count);
-    if (!newItem)
+    if (!newItem || target->CanUseItem(newItem->GetProto()) != EQUIP_ERR_OK)
         return false;
 
     bot->DestroyItem(food->GetBagSlot(), food->GetSlot(), true);
@@ -117,7 +113,7 @@ bool GiveConjuredWaterAction::Execute(Event event)
         return false;
     Item* water = drinks.front();
 
-    Player* target = FindPartyMemberWithoutSustenance(bot, false);
+    Player* target = FindPartyMemberWithoutSustenance(bot, water);
     if (!target)
         return false;
 
@@ -125,7 +121,7 @@ bool GiveConjuredWaterAction::Execute(Event event)
     uint32 count = water->GetCount();
 
     Item* newItem = target->StoreNewItemInInventorySlot(itemId, count);
-    if (!newItem)
+    if (!newItem || target->CanUseItem(newItem->GetProto()) != EQUIP_ERR_OK)
         return false;
 
     bot->DestroyItem(water->GetBagSlot(), water->GetSlot(), true);

--- a/src/modules/Bots/playerbot/strategy/triggers/GenericTriggers.h
+++ b/src/modules/Bots/playerbot/strategy/triggers/GenericTriggers.h
@@ -200,10 +200,22 @@ namespace ai
         virtual bool IsActive() { return AI_VALUE2(list<Item*>, "inventory items", "food").empty(); }
     };
 
+    class NoConjuredFoodTrigger : public Trigger {
+    public:
+        NoConjuredFoodTrigger(PlayerbotAI* ai) : Trigger(ai, "no conjured food trigger") {}
+        virtual bool IsActive() { return AI_VALUE2(list<Item*>, "inventory items", "conjured food").empty(); }
+    };
+
     class NoDrinkTrigger : public Trigger {
     public:
         NoDrinkTrigger(PlayerbotAI* ai) : Trigger(ai, "no drink trigger") {}
         virtual bool IsActive() { return AI_VALUE2(list<Item*>, "inventory items", "drink").empty(); }
+    };
+
+    class NoConjuredDrinkTrigger : public Trigger {
+    public:
+        NoConjuredDrinkTrigger(PlayerbotAI* ai) : Trigger(ai, "no conjured drink trigger") {}
+        virtual bool IsActive() { return AI_VALUE2(list<Item*>, "inventory items", "conjured drink").empty(); }
     };
 
     class LightAoeTrigger : public AoeTrigger

--- a/src/modules/Bots/playerbot/strategy/triggers/TriggerContext.h
+++ b/src/modules/Bots/playerbot/strategy/triggers/TriggerContext.h
@@ -76,7 +76,9 @@ namespace ai
             creators["no possible targets"] = &TriggerContext::no_possible_targets;
 
             creators["no drink"] = &TriggerContext::no_drink;
+            creators["no conjured drink"] = &TriggerContext::no_conjured_drink;
             creators["no food"] = &TriggerContext::no_food;
+            creators["no conjured food"] = &TriggerContext::no_conjured_food;
 
             creators["panic"] = &TriggerContext::panic;
             creators["behind target"] = &TriggerContext::behind_target;
@@ -110,7 +112,9 @@ namespace ai
         static Trigger* not_facing_target(PlayerbotAI* ai) { return new IsNotFacingTargetTrigger(ai); }
         static Trigger* panic(PlayerbotAI* ai) { return new PanicTrigger(ai); }
         static Trigger* no_drink(PlayerbotAI* ai) { return new NoDrinkTrigger(ai); }
+        static Trigger* no_conjured_drink(PlayerbotAI* ai) { return new NoConjuredDrinkTrigger(ai); }
         static Trigger* no_food(PlayerbotAI* ai) { return new NoFoodTrigger(ai); }
+        static Trigger* no_conjured_food(PlayerbotAI* ai) { return new NoConjuredFoodTrigger(ai); }
         static Trigger* LightAoe(PlayerbotAI* ai) { return new LightAoeTrigger(ai); }
         static Trigger* MediumAoe(PlayerbotAI* ai) { return new MediumAoeTrigger(ai); }
         static Trigger* HighAoe(PlayerbotAI* ai) { return new HighAoeTrigger(ai); }


### PR DESCRIPTION
Some tweeks to mage food/drink distribution (still one of my fav features) and consumption:
Mages always keep a supply of conjured food drink, so they have the good stuff to distribute, likewise, the mage isn't happy unless the party has the good stuff.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/299)
<!-- Reviewable:end -->
