### PR TITLE
transport vanishing fix

### DIFF
--- a/src/game/WorldHandlers/Transports.cpp
+++ b/src/game/WorldHandlers/Transports.cpp
@@ -599,7 +599,7 @@ bool GlobalTransport::GenerateWaypoints()
             cM = keyFrames[i + 1].node->mapid;
         }
 
-        pos = WayPoint(keyFrames[i + 1].node->mapid, keyFrames[i + 1].node->x, keyFrames[i + 1].node->y, keyFrames[i + 1].node->z, teleport);
+        pos = WayPoint(keyFrames[i + 1].node->mapid, keyFrames[i + 1].node->x, keyFrames[i + 1].node->y, keyFrames[i + 1].node->z, teleport, keyFrames[i + 1].node->delay > 0);
 
         //        sLog.outString("T: %d, x: %f, y: %f, z: %f, t:%d", t, pos.x, pos.y, pos.z, teleport);
 
@@ -711,6 +711,29 @@ void GlobalTransport::Update(uint32 /*update_diff*/, uint32 /*p_time*/)
         else
         {
             Relocate(m_curr->second.x, m_curr->second.y, m_curr->second.z);
+            if (m_curr->second.isStop)
+            {
+                uint32 zoneId = GetZoneId();
+                Map::PlayerList const& pl = GetMap()->GetPlayers();
+                UpdateData destroyData;
+                BuildOutOfRangeUpdateBlock(&destroyData);
+                WorldPacket destroyPacket;
+                destroyData.BuildPacket(&destroyPacket, true);
+                for (Map::PlayerList::const_iterator itr = pl.begin(); itr != pl.end(); ++itr)
+                {
+                    Player* player = itr->getSource();
+                    if (this == player->GetTransport())
+                        continue;
+                    if (player->GetZoneId() != zoneId)
+                        continue;
+                    player->SendDirectMessage(&destroyPacket);
+                    UpdateData transData;
+                    BuildCreateUpdateBlockForPlayer(&transData, player);
+                    WorldPacket packet;
+                    transData.BuildPacket(&packet, true);
+                    player->SendDirectMessage(&packet);
+                }
+            }
             UpdateCreaturePassengerPositions();
         }
 

--- a/src/game/WorldHandlers/Transports.h
+++ b/src/game/WorldHandlers/Transports.h
@@ -84,14 +84,15 @@ class GlobalTransport : public Transport
     private:
         struct WayPoint
         {
-            WayPoint() : mapid(0), x(0), y(0), z(0), teleport(false) {}
-            WayPoint(uint32 _mapid, float _x, float _y, float _z, bool _teleport) :
-                mapid(_mapid), x(_x), y(_y), z(_z), teleport(_teleport) {}
+            WayPoint() : mapid(0), x(0), y(0), z(0), teleport(false), isStop(false) {}
+            WayPoint(uint32 _mapid, float _x, float _y, float _z, bool _teleport, bool _isStop = false) :
+                mapid(_mapid), x(_x), y(_y), z(_z), teleport(_teleport), isStop(_isStop) {}
             uint32 mapid;
             float x;
             float y;
             float z;
             bool teleport;
+            bool isStop;
         };
 
         typedef std::map<uint32, WayPoint> WayPointMap;


### PR DESCRIPTION
Transports that travel within a single zone have a problem where the client will silently drop the transport object when it goes out of visible range, making it invisible to a player the next time it comes around to the same dock.  Presumably (because we are talking internal client logic here), this isn't a problem for Menethil harbor, etc style transports because they already send new Delete + Create packets whenever the transport crosses maps.

The proposed fix re-sends the delete + create packets for the transport to all in-zone players whenever the transport stops (docks).  It seems to fix the problem, though I'm still suspicious as to why it works as well as it does.

P.S. I tried sending only create messages, and I tried sending delete+create only for players entering the zone -- nothing seemed to work, which is why I suspect it's about visbility range on the client side.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/300)
<!-- Reviewable:end -->
