### PR TITLE
fix for mysterious corrupt weapon def crash

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -2766,6 +2766,12 @@ uint32 Unit::CalculateDamage(WeaponAttackType attType, bool normalized)
         max_damage = 5.0f;
     }
 
+    if (min_damage < 0.0f)
+        min_damage = 0.0f;
+
+    if (max_damage < min_damage)
+        max_damage = min_damage;
+
     return urand((uint32)min_damage, (uint32)max_damage);
 }
 

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -2767,10 +2767,14 @@ uint32 Unit::CalculateDamage(WeaponAttackType attType, bool normalized)
     }
 
     if (min_damage < 0.0f)
+    {
         min_damage = 0.0f;
+    }
 
     if (max_damage < min_damage)
+    {
         max_damage = min_damage;
+    }
 
     return urand((uint32)min_damage, (uint32)max_damage);
 }


### PR DESCRIPTION
Fixes a server crash I experienced.  The ultimate cause is a corrupt weapon with negative damage, but I found nothing like that in my DB, and this is a one-off occurrence, so the chance of repro is low.  My solution therefore is to simply guard against the crash itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/301)
<!-- Reviewable:end -->
