### PR TITLE
bot hunter wingclip fix

### DIFF
--- a/src/modules/Bots/playerbot/strategy/hunter/GenericHunterStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/hunter/GenericHunterStrategy.cpp
@@ -14,6 +14,7 @@ public:
         creators["boost"] = &rapid_fire;
         creators["aspect of the pack"] = &aspect_of_the_pack;
         creators["feign death"] = &feign_death;
+        creators["wing clip"] = &wing_clip;
     }
 private:
     static ActionNode* rapid_fire(PlayerbotAI* ai)
@@ -35,6 +36,13 @@ private:
         return new ActionNode ("feign death",
             /*P*/ NULL,
             /*A*/ NextAction::array(0, new NextAction("flee"), NULL),
+            /*C*/ NULL);
+    }
+    static ActionNode* wing_clip(PlayerbotAI* ai)
+    {
+        return new ActionNode ("wing clip",
+            /*P*/ NULL,
+            /*A*/ NULL,
             /*C*/ NULL);
     }
 };

--- a/src/modules/Bots/playerbot/strategy/hunter/HunterActions.h
+++ b/src/modules/Bots/playerbot/strategy/hunter/HunterActions.h
@@ -123,7 +123,7 @@ namespace ai
         virtual bool isUseful()
         {
             Unit* target = GetTarget();
-            return target && target->IsAlive() && CastMeleeSpellAction::isUseful() && !ai->HasAura(spell, target);
+            return target && target->IsAlive() && CastMeleeSpellAction::isUseful() && !ai->HasAura(spell, target) && target->getVictim() == bot;
         }
     };
 


### PR DESCRIPTION
Allows a hunter bot to use Wing Clip when in melee and being targeted, as this is a common strat for moving out to shooting range.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/302)
<!-- Reviewable:end -->
