### PR TITLE
hunter bots move to closest shooting pos

### DIFF
--- a/src/modules/Bots/playerbot/strategy/hunter/HunterActions.h
+++ b/src/modules/Bots/playerbot/strategy/hunter/HunterActions.h
@@ -180,18 +180,25 @@ namespace ai
 
     class HunterEnsureRangedPositionAction : public MovementAction
     {
+    private:
+        const float minShootDistance = 10.0;
     public:
         HunterEnsureRangedPositionAction(PlayerbotAI* ai) : MovementAction(ai, "hunter ensure ranged position") {}
+
         virtual bool Execute(Event event)
         {
-            return MoveTo(AI_VALUE(Unit*, "current target"), sPlayerbotAIConfig.spellDistance);
+            Unit* target = AI_VALUE(Unit*, "current target");
+            if(bot->GetDistance(target) > sPlayerbotAIConfig.spellDistance)
+                return MoveTo(target, sPlayerbotAIConfig.spellDistance - 1.0);
+            else
+                return MoveTo(target, minShootDistance + 1.0);
         }
         virtual bool isUseful()
         {
             Unit* target = AI_VALUE(Unit*, "current target");
-            if (!target || !target->IsAlive()) return false;
-            return target->getVictim() != bot &&
-                   bot->GetDistance(target) < sPlayerbotAIConfig.spellDistance;
+            if (!target || !target->IsAlive() || (target->getVictim() == bot)) return false;
+            float distance = bot->GetDistance(target);
+            return distance < minShootDistance || distance > sPlayerbotAIConfig.spellDistance;
         }
     };
 }


### PR DESCRIPTION
Changes how hunters reach shooting range.  Previously they would always aim for maximum (spell) distance.  However, IRL, the hunter moves as little as necessary to reach shooting range, relying on traps, their pet, and other means to keep the target in place.  This change therefore has the hunter minimize their movement to reach shooting range.  

It also has the added benefit of, when leading a group of bots in the dungeon, the hunter won't always try to reach maximum distance, thereby increasing aggro opportunities.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/303)
<!-- Reviewable:end -->
