### PR TITLE
bot multi-hop taxi fix

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/RememberTaxiAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/RememberTaxiAction.cpp
@@ -34,7 +34,8 @@ bool RememberTaxiAction::Execute(Event event)
             uint32 node_count;
             try
             {
-                p >> guid >> node_count;
+                uint32 totalcost;
+                p >> guid >> totalcost >> node_count;
 
                 LastMovement& movement = context->GetValue<LastMovement&>("last movement")->Get();
                 movement.taxiNodes.clear();


### PR DESCRIPTION
Fixes bots ability to ride flight taxis across multiple hops.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/304)
<!-- Reviewable:end -->
