### PR TITLE
bot ai is frozen when no players in their zone

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -7492,6 +7492,10 @@ void Player::UpdateZone(uint32 newZone, uint32 newArea)
         sOutdoorPvPMgr.HandlePlayerLeaveZone(this, m_zoneUpdateId);
         sOutdoorPvPMgr.HandlePlayerEnterZone(this, newZone);
 
+#ifdef ENABLE_PLAYERBOTS
+        sRandomPlayerbotMgr.OnPlayerZoneChange(this, newZone);
+#endif
+
         SendInitWorldStates(newZone);                       // only if really enters to new zone, not just area change, works strange...
 
         if (sWorld.getConfig(CONFIG_BOOL_WEATHER))

--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -305,6 +305,15 @@ void PlayerbotAI::UpdateAI(uint32 elapsed)
         return;
     }
 
+    if (sPlayerbotAIConfig.randomBotActiveZoneOnly &&
+        !bot->GetGroup() && sRandomPlayerbotMgr.IsRandomBot(bot) &&
+        botOutgoingPacketHandlers.IsEmpty() &&
+        !sRandomPlayerbotMgr.HasRealPlayerInZone(bot->GetZoneId()))
+    {
+        SetNextCheckDelay(5000);
+        return;
+    }
+
     if (nextAICheckDelay > sPlayerbotAIConfig.globalCoolDown &&
             bot->IsNonMeleeSpellCasted(true, true, false) &&
             *GetAiObjectContext()->GetValue<bool>("invalid target", "current target"))

--- a/src/modules/Bots/playerbot/PlayerbotAI.h
+++ b/src/modules/Bots/playerbot/PlayerbotAI.h
@@ -82,6 +82,10 @@ public:
     void AddHandler(uint16 opcode, string handler);
     void Handle(ExternalEventHelper &helper);
     void AddPacket(const WorldPacket& packet);
+    bool IsEmpty()
+    {
+        return queue.size() == 0;
+    }
 
 private:
     map<uint16, string> handlers;

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
@@ -64,6 +64,7 @@ PlayerbotAIConfig::PlayerbotAIConfig()
       randomBotJoinLfg(false),
       randomBotLoginAtStartup(false),
       randomBotKeepGroups(false),
+      randomBotActiveZoneOnly(false),
       randomBotTeleLevel(0),
       logInGroupOnly(false),
       logValuesPerTick(false),
@@ -190,6 +191,7 @@ bool PlayerbotAIConfig::Initialize()
     randomBotMaxLevel = config.GetIntDefault("AiPlayerbot.RandomBotMaxLevel", 255);
     randomBotLoginAtStartup = config.GetBoolDefault("AiPlayerbot.RandomBotLoginAtStartup", true);
     randomBotKeepGroups = config.GetBoolDefault("AiPlayerbot.RandomBotKeepGroups", false);
+    randomBotActiveZoneOnly = config.GetBoolDefault("AiPlayerbot.RandomBotActiveZoneOnly", false);
     randomBotTeleLevel = config.GetIntDefault("AiPlayerbot.RandomBotTeleLevel", 3);
 
     randomChangeMultiplier = config.GetFloatDefault("AiPlayerbot.RandomChangeMultiplier", 1.0);

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.h
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.h
@@ -69,6 +69,7 @@ public:
     bool randomBotJoinLfg; ///< Indicates if random bots should join Looking For Group.
     bool randomBotLoginAtStartup; ///< Indicates if random bots should login at startup.
     bool randomBotKeepGroups; ///< Indicates if random bots should preserve groups across restarts.
+    bool randomBotActiveZoneOnly; ///< If true, ungrouped random bots only tick when a real player is in their zone.
     uint32 randomBotTeleLevel; ///< The teleport level for random bots.
     bool logInGroupOnly, logValuesPerTick;
     bool fleeingEnabled; ///< Indicates if fleeing is enabled for bots.

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
@@ -1004,6 +1004,16 @@ void RandomPlayerbotMgr::OnPlayerLogout(Player* player)
         {
             players.erase(i);
         }
+
+        uint32 zone = player->GetZoneId();
+        std::unordered_map<uint32, uint32>::iterator zi = m_playerZoneCounts.find(zone);
+        if (zi != m_playerZoneCounts.end())
+        {
+            if (zi->second <= 1)
+                m_playerZoneCounts.erase(zi);
+            else
+                zi->second--;
+        }
     }
 }
 
@@ -1041,8 +1051,38 @@ void RandomPlayerbotMgr::OnPlayerLogin(Player* player)
     if (!player->GetPlayerbotAI())
     {
         players.push_back(player);
-        sLog.outDebug("Including non-random bot player %s into random bot update", player->GetName());
+        // do not add to m_playerZoneCounts, as OnPlayerZoneChange is called anyway
     }
+}
+
+void RandomPlayerbotMgr::OnPlayerZoneChange(Player* player, uint32 newZone)
+{
+    if (player->GetPlayerbotAI() ||
+        player->GetSession()->GetRemoteAddress() == "bot")
+    {
+        // PlayerbotAI is not set before calling this on entry, so remote address chk
+        return;
+    }
+
+    uint32 oldZone = player->GetCachedZoneId();
+    if (oldZone == newZone)
+        return;
+
+    std::unordered_map<uint32, uint32>::iterator zi = m_playerZoneCounts.find(oldZone);
+    if (zi != m_playerZoneCounts.end())
+    {
+        if (zi->second <= 1)
+            m_playerZoneCounts.erase(zi);
+        else
+            zi->second--;
+    }
+    m_playerZoneCounts[newZone]++;
+}
+
+bool RandomPlayerbotMgr::HasRealPlayerInZone(uint32 zoneId) const
+{
+    std::unordered_map<uint32, uint32>::const_iterator zi = m_playerZoneCounts.find(zoneId);
+    return zi != m_playerZoneCounts.end() && zi->second > 0;
 }
 
 Player* RandomPlayerbotMgr::GetRandomPlayer()

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
@@ -5,6 +5,7 @@
 #include "PlayerbotAIBase.h"
 #include "PlayerbotMgr.h"
 #include <set>
+#include <unordered_map>
 
 class WorldPacket;
 class Player;
@@ -98,6 +99,9 @@ class RandomPlayerbotMgr : public PlayerbotHolder
          * @param player Pointer to the player.
          */
         void OnPlayerLogin(Player* player);
+
+        void OnPlayerZoneChange(Player* player, uint32 newZone);
+        bool HasRealPlayerInZone(uint32 zoneId) const;
 
         /**
          * @brief Gets a random player.
@@ -235,6 +239,7 @@ class RandomPlayerbotMgr : public PlayerbotHolder
         set<uint32> m_groupedBots; ///< Cached set of bot GUIDs currently in a group, refreshed each update cycle.
         std::map<uint32, AreaCreatureStats> m_areaCreatureStatsMap;
         std::map<std::pair<uint32, uint32>, uint32> m_cellToAreaCache;
+        std::unordered_map<uint32, uint32> m_playerZoneCounts; ///< zone_id -> real player count, for O(1) bot tick gating.
 };
 
 #define sRandomPlayerbotMgr MaNGOS::Singleton<RandomPlayerbotMgr>::Instance()

--- a/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
+++ b/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
@@ -164,6 +164,10 @@ AiPlayerbot.RandomBotTeleLevel = 3
 # Preserve bot group assignments across server restarts
 #AiPlayerbot.RandomBotKeepGroups = 0
 
+# Only tick ungrouped random bots when a real player is in their zone.
+# Reduces CPU load on empty zones at the cost of bots being frozen there.
+#AiPlayerbot.RandomBotActiveZoneOnly = 0
+
 # How far random bots are teleported after death
 #AiPlayerbot.RandomBotTeleportDistance = 1000
 


### PR DESCRIPTION
Adds a new aiplayerbot.conf option that will forbid thread time to bots unless they are 1. grouped OR 2. in the same zone as a real Player.

This has a huge impact on CPU time, not driving hundreds of bots on another continent while you are running a dungeon somewhere.  And besides, if a Treant falls to a playerbot in a forest, and no one is around to see it, did it really need to happen?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/305)
<!-- Reviewable:end -->
