### PR TITLE
fix for bot revive-from-corpse

### DIFF
--- a/src/modules/Bots/playerbot/strategy/generic/DeadStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/generic/DeadStrategy.cpp
@@ -9,8 +9,9 @@ void DeadStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 {
     PassTroughStrategy::InitTriggers(triggers);
 
+     // Trigger name changed from "dead" to "bot dead" because of collision with AI_VALUE2(bool, "dead", ...))
     triggers.push_back(new TriggerNode(
-        "dead",
+        "bot dead",
         NextAction::array(0, new NextAction("revive from corpse", relevance), NULL)));
 
     triggers.push_back(new TriggerNode(

--- a/src/modules/Bots/playerbot/strategy/triggers/HealthTriggers.h
+++ b/src/modules/Bots/playerbot/strategy/triggers/HealthTriggers.h
@@ -131,7 +131,7 @@ namespace ai
 
     class DeadTrigger : public Trigger {
     public:
-        DeadTrigger(PlayerbotAI* ai) : Trigger(ai, "dead", 10) {}
+        DeadTrigger(PlayerbotAI* ai) : Trigger(ai, "bot dead", 10) {}
         virtual string GetTargetName() { return "self target"; }
         virtual bool IsActive();
     };

--- a/src/modules/Bots/playerbot/strategy/triggers/TriggerContext.h
+++ b/src/modules/Bots/playerbot/strategy/triggers/TriggerContext.h
@@ -69,7 +69,7 @@ namespace ai
 
             creators["medium threat"] = &TriggerContext::MediumThreat;
 
-            creators["dead"] = &TriggerContext::Dead;
+            creators["bot dead"] = &TriggerContext::Dead;
             creators["party member dead"] = &TriggerContext::PartyMemberDead;
             creators["no pet"] = &TriggerContext::no_pet;
             creators["has attackers"] = &TriggerContext::has_attackers;


### PR DESCRIPTION
This fixes the problem with Bots not reviving when they are released and get back to their corpse.
The fix is to rename the "dead" trigger to "bot dead". 

The code was such that I can't prove it 100%, but I am really sure that the cause is that, when converting a trigger name to an object, it iterates through ALL named contexts for a match, which means that it could hit a "dead" value or "dead" action or whatever before hitting the correct "dead" trigger.  By making the name more unique, this doesn't happen.

Whether my causal theory is correct, the solution absolutely works and is otherwise harmless.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/306)
<!-- Reviewable:end -->
