### PR TITLE
bots dont complain about vendors

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/QuestAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/QuestAction.cpp
@@ -39,6 +39,8 @@ bool QuestAction::ProcessQuests(ObjectGuid questGiver)
     Creature* creature = ai->GetCreature(questGiver);
     if (creature)
     {
+        if (!creature->isQuestGiver())
+            return false;
         return ProcessQuests(creature);
     }
 


### PR DESCRIPTION
Prevents the silly "I can't talk to Quest Giver" message from your bot group members when you interact with a vendor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/307)
<!-- Reviewable:end -->
