### PR TITLE
Bot Role Strategies change

### DIFF
--- a/src/game/Object/Player.cpp
+++ b/src/game/Object/Player.cpp
@@ -21080,6 +21080,9 @@ void Player::SetGroup(Group* group, int8 subgroup)
         m_group.link(group, this);
         m_group.setSubGroup((uint8)subgroup);
     }
+
+    if (GetPlayerbotAI())
+        GetPlayerbotAI()->ResetStrategies();
 }
 
 /* Called by WorldSession::HandlePlayerLogin */

--- a/src/modules/Bots/playerbot/AiFactory.cpp
+++ b/src/modules/Bots/playerbot/AiFactory.cpp
@@ -128,11 +128,6 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
 
     engine->addStrategies("attack weak", "racials", "chat", "default", "aoe", "potions", "cast time", "conserve mana", "duel", "pvp", NULL);
 
-    if (sPlayerbotAIConfig.cautiousDefault)
-    {
-        engine->addStrategy("cautious");
-    }
-
     switch (player->getClass())
     {
         case CLASS_PRIEST:
@@ -248,7 +243,16 @@ void AiFactory::AddDefaultCombatStrategies(Player* player, PlayerbotAI* const fa
             break;
     }
 
-    if (sRandomPlayerbotMgr.IsRandomBot(player) && !player->GetGroup())
+    if (player->GetGroup())
+    {
+        if (engine->ContainsStrategy(STRATEGY_TYPE_TANK))
+            engine->ChangeStrategy(sPlayerbotAIConfig.botTankStrategies);
+        else if (engine->ContainsStrategy(STRATEGY_TYPE_HEAL))
+            engine->ChangeStrategy(sPlayerbotAIConfig.botHealStrategies);
+        else
+            engine->ChangeStrategy(sPlayerbotAIConfig.botDpsStrategies);
+    }
+    else if (sRandomPlayerbotMgr.IsRandomBot(player))
     {
         engine->ChangeStrategy(sPlayerbotAIConfig.randomBotCombatStrategies);
     }
@@ -263,11 +267,6 @@ Engine* AiFactory::createCombatEngine(Player* player, PlayerbotAI* const facade,
 void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const facade, Engine* nonCombatEngine)
 {
     int tab = GetPlayerSpecTab(player);
-
-    if (sPlayerbotAIConfig.cautiousDefault)
-    {
-        nonCombatEngine->addStrategy("cautious");
-    }
 
     switch (player->getClass()){
         case CLASS_PALADIN:
@@ -289,7 +288,11 @@ void AiFactory::AddDefaultNonCombatStrategies(Player* player, PlayerbotAI* const
     nonCombatEngine->addStrategies("nc", "attack weak", "food", "stay", "chat",
             "default", "quest", "loot", "gather", "duel", "emote", NULL);
 
-    if (sRandomPlayerbotMgr.IsRandomBot(player) && !player->GetGroup())
+    if (player->GetGroup())
+    {
+        nonCombatEngine->ChangeStrategy(sPlayerbotAIConfig.botGroupNonCombatStrategies);
+    }
+    else if (sRandomPlayerbotMgr.IsRandomBot(player))
     {
         nonCombatEngine->ChangeStrategy(sPlayerbotAIConfig.randomBotNonCombatStrategies);
     }

--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -1494,6 +1494,10 @@ void PlayerbotAI::WaitForSpellCast(uint32 spellId)
  */
 void PlayerbotAI::InterruptSpell()
 {
+    Spell* autoRepeat = bot->GetCurrentSpell(CURRENT_AUTOREPEAT_SPELL);
+    if (autoRepeat)
+        bot->InterruptSpell(CURRENT_AUTOREPEAT_SPELL);
+
     if (bot->GetCurrentSpell(CURRENT_CHANNELED_SPELL))
     {
         return;

--- a/src/modules/Bots/playerbot/PlayerbotAI.h
+++ b/src/modules/Bots/playerbot/PlayerbotAI.h
@@ -138,6 +138,7 @@ public:
     bool ContainsStrategy(StrategyType type);
     bool HasStrategy(string name, BotState type);
     bool HasStrategy(string name) { return HasStrategy(name, currentState); }
+    BotState GetState() const { return currentState; }
     void ResetStrategies();
     void ReInitCurrentEngine();
     void Reset();

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
@@ -68,7 +68,6 @@ PlayerbotAIConfig::PlayerbotAIConfig()
       logInGroupOnly(false),
       logValuesPerTick(false),
       fleeingEnabled(false),
-      cautiousDefault(false),
       randomBotMinLevel(0),
       randomBotMaxLevel(0),
       randomChangeMultiplier(0.0f),
@@ -185,7 +184,6 @@ bool PlayerbotAIConfig::Initialize()
     logInGroupOnly = config.GetBoolDefault("AiPlayerbot.LogInGroupOnly", true);
     logValuesPerTick = config.GetBoolDefault("AiPlayerbot.LogValuesPerTick", false);
     fleeingEnabled = config.GetBoolDefault("AiPlayerbot.FleeingEnabled", true);
-    cautiousDefault = config.GetBoolDefault("AiPlayerbot.Cautious", false);
     randomBotMinLevel = config.GetIntDefault("AiPlayerbot.RandomBotMinLevel", 1);
     randomBotMaxLevel = config.GetIntDefault("AiPlayerbot.RandomBotMaxLevel", 255);
     randomBotLoginAtStartup = config.GetBoolDefault("AiPlayerbot.RandomBotLoginAtStartup", true);
@@ -196,6 +194,10 @@ bool PlayerbotAIConfig::Initialize()
 
     randomBotCombatStrategies = config.GetStringDefault("AiPlayerbot.RandomBotCombatStrategies", "+dps,+attack weak");
     randomBotNonCombatStrategies = config.GetStringDefault("AiPlayerbot.RandomBotNonCombatStrategies", "+grind,+move random,+loot");
+    botTankStrategies = config.GetStringDefault("AiPlayerbot.BotTankStrategies", "+tank aoe");
+    botDpsStrategies = config.GetStringDefault("AiPlayerbot.BotDpsStrategies", "+dps assist");
+    botHealStrategies = config.GetStringDefault("AiPlayerbot.BotHealStrategies", "");
+    botGroupNonCombatStrategies = config.GetStringDefault("AiPlayerbot.BotGroupNonCombatStrategies", "+follow master,+loot");
 
     commandPrefix = config.GetStringDefault("AiPlayerbot.CommandPrefix", "");
 

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.h
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.h
@@ -72,8 +72,8 @@ public:
     uint32 randomBotTeleLevel; ///< The teleport level for random bots.
     bool logInGroupOnly, logValuesPerTick;
     bool fleeingEnabled; ///< Indicates if fleeing is enabled for bots.
-    bool cautiousDefault;
     std::string randomBotCombatStrategies, randomBotNonCombatStrategies;
+    std::string botTankStrategies, botDpsStrategies, botHealStrategies, botGroupNonCombatStrategies;
     uint32 randomBotMinLevel, randomBotMaxLevel;
     float randomChangeMultiplier;
     uint32 specProbability[MAX_CLASSES][3]; ///< Probability of class specs for random bots.

--- a/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
+++ b/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
@@ -88,9 +88,6 @@ AiPlayerbot.CommandPrefix = ~
 # Bot can flee for enemy
 #AiPlayerbot.FleeingEnabled = 1
 
-# Bot avoids pulling aggro during movement by default
-#AiPlayerbot.Cautious = 0
-
 # Health/Mana levels
 #AiPlayerbot.CriticalHealth = 25
 #AiPlayerbot.LowHealth = 45
@@ -107,6 +104,12 @@ AiPlayerbot.CommandPrefix = ~
 # Random bot default strategies (applied after defaults)
 #AiPlayerbot.RandomBotCombatStrategies = +dps,+attack weak
 #AiPlayerbot.RandomBotNonCombatStrategies = +grind,+move random,+loot
+
+# Group strategies (applied by role to all bots when in a group, replacing solo strategies)
+#AiPlayerbot.BotTankStrategies = +tank aoe
+#AiPlayerbot.BotDpsStrategies = +dps assist
+#AiPlayerbot.BotHealStrategies =
+#AiPlayerbot.BotGroupNonCombatStrategies = +follow master,+loot
 
 # Create random bot characters automatically
 #AiPlayerbot.RandomBotAutoCreate = 1

--- a/src/modules/Bots/playerbot/strategy/Engine.cpp
+++ b/src/modules/Bots/playerbot/strategy/Engine.cpp
@@ -581,8 +581,6 @@ void Engine::LogAction(const char* format, ...)
         {
             return;
         }
-
-        sLog.outDebug("%s %s", bot->GetName(), buf);
     }
 }
 
@@ -592,6 +590,8 @@ void Engine::ChangeStrategy(string &names)
     vector<string> splitted = split(names, ',');
     for (vector<string>::iterator i = splitted.begin(); i != splitted.end(); i++)
     {
+        i->erase(0, i->find_first_not_of(" \t"));
+        i->erase(i->find_last_not_of(" \t") + 1);
         const char* name = i->c_str();
         switch (name[0])
         {

--- a/src/modules/Bots/playerbot/strategy/warlock/TankWarlockStrategy.h
+++ b/src/modules/Bots/playerbot/strategy/warlock/TankWarlockStrategy.h
@@ -9,6 +9,7 @@ namespace ai
     public:
         TankWarlockStrategy(PlayerbotAI* ai);
         virtual string getName() { return "tank"; }
+        virtual int GetType() { return STRATEGY_TYPE_TANK | STRATEGY_TYPE_RANGED; }
 
     public:
         virtual void InitTriggers(std::list<TriggerNode*> &triggers);


### PR DESCRIPTION
This change makes it easier to manage your grouped bot strategies.

It creates 3 new aiplayerbot.conf entries for the three major group roles, each of which can be assigned the strategies you want those bots to use.  A 4th new entry allows you to assign group non-combat strategies also.

This eliminated the need for my "default cautious" flag, since I can now just add "cautious" to these groups, so the old flag was removed.

(PS there's a bonus bug fix for warlock tanks)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/308)
<!-- Reviewable:end -->
