### PR TITLE
Fix Holy Light triggered heal coefficient and downranking

### DIFF
--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -6407,7 +6407,7 @@ void Unit::EnergizeBySpell(Unit* pVictim, uint32 SpellID, uint32 Damage, Powers 
 }
 
 /**
- * \fn int32 Unit::SpellBonusWithCoeffs(Unit* pCaster, SpellEntry const* spellProto, int32 total, int32 benefit, int32 ap_benefit,  DamageEffectType damagetype, bool donePart)
+ * \fn int32 Unit::SpellBonusWithCoeffs(Unit* pCaster, SpellEntry const* spellProto, int32 total, int32 benefit, int32 ap_benefit,  DamageEffectType damagetype, bool donePart, Spell const* spell)
  * \brief This method is calculating the total amount of damage done including spell power.
  *
  * If benefit is 0, this function won't do anything. If pCaster isn't player, the default coefficient 1.0 will be used.
@@ -6427,7 +6427,7 @@ void Unit::EnergizeBySpell(Unit* pVictim, uint32 SpellID, uint32 Damage, Powers 
  *
  * \return int32 Total amount of damage including spell power bonuses.
  */
-int32 Unit::SpellBonusWithCoeffs(Unit* pCaster, SpellEntry const* spellProto, int32 total, int32 benefit, int32 ap_benefit,  DamageEffectType damagetype, bool donePart)
+int32 Unit::SpellBonusWithCoeffs(Unit* pCaster, SpellEntry const* spellProto, int32 total, int32 benefit, int32 ap_benefit,  DamageEffectType damagetype, bool donePart, Spell const* spell)
 {
     // Just don't waste time into this function if there's no benefit.
     if (!benefit)
@@ -6437,6 +6437,8 @@ int32 Unit::SpellBonusWithCoeffs(Unit* pCaster, SpellEntry const* spellProto, in
 
     // Distribute Damage over multiple effects, reduce by AoE
     float coeff = 1.0f;
+    SpellEntry const* levelPenaltySpell = spell ? spell->GetSpellBonusLevelPenaltySpell(spellProto) : spellProto;
+    bool const useTriggeredHealBonus = damagetype == HEAL && levelPenaltySpell != spellProto;
 
     // Not apply this to creature casted spells
     if (pCaster->GetTypeId() == TYPEID_UNIT && !((Creature*)this)->IsPet())
@@ -6450,6 +6452,13 @@ int32 Unit::SpellBonusWithCoeffs(Unit* pCaster, SpellEntry const* spellProto, in
         {
             case DOT:
                 coeff = bonus->dot_damage;
+                break;
+            case HEAL:
+                if (useTriggeredHealBonus)
+                {
+                    coeff = donePart ? (bonus->direct_damage_done ? bonus->direct_damage_done : bonus->direct_damage)
+                                     : (bonus->direct_damage_taken ? bonus->direct_damage_taken : bonus->direct_damage);
+                }
                 break;
             case SPELL_DIRECT_DAMAGE:
                 // Special check for bonus damage applying on spells depending on the equiped weapon.
@@ -6530,10 +6539,10 @@ int32 Unit::SpellBonusWithCoeffs(Unit* pCaster, SpellEntry const* spellProto, in
         coeff = CalculateDefaultCoefficient(spellProto, damagetype);
     }
 
-    float LvlPenalty = CalculateLevelPenalty(spellProto);
+    float LvlPenalty = CalculateLevelPenalty(levelPenaltySpell);
 
-    // Holy Light and Seal of Righteousness PROC and Flash of Light receive benefit from Spell Damage and Healing too low.
-    if (spellProto->SpellFamilyName == SPELLFAMILY_PALADIN && (spellProto->SpellIconID == 25 || spellProto->SpellIconID == 70 || spellProto->SpellIconID == 242))
+    // Seal of Righteousness PROC and Flash of Light receive benefit from Spell Damage and Healing too low.
+    if (spellProto->SpellFamilyName == SPELLFAMILY_PALADIN && (spellProto->SpellIconID == 25 || spellProto->SpellIconID == 242))
     {
         LvlPenalty = 1.0f;
     }
@@ -6911,13 +6920,13 @@ uint32 Unit::SpellCriticalHealingBonus(SpellEntry const* spellProto, uint32 dama
  * Calculates caster part of healing spell bonuses,
  * also includes different bonuses dependent from target auras
  */
-uint32 Unit::SpellHealingBonusDone(Unit* pVictim, SpellEntry const* spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack)
+uint32 Unit::SpellHealingBonusDone(Unit* pVictim, SpellEntry const* spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack, Spell const* spell)
 {
     // For totems get healing bonus from owner (statue isn't totem in fact)
     if (GetTypeId() == TYPEID_UNIT && ((Creature*)this)->IsTotem() && ((Totem*)this)->GetTotemType() != TOTEM_STATUE)
         if (Unit* owner = GetOwner())
         {
-            return owner->SpellHealingBonusDone(pVictim, spellProto, healamount, damagetype, stack);
+            return owner->SpellHealingBonusDone(pVictim, spellProto, healamount, damagetype, stack, spell);
         }
 
     // No heal amount for this class spells
@@ -6966,7 +6975,7 @@ uint32 Unit::SpellHealingBonusDone(Unit* pVictim, SpellEntry const* spellProto, 
     int32 DoneAdvertisedBenefit  = SpellBaseHealingBonusDone(GetSpellSchoolMask(spellProto));
 
     // apply ap bonus and benefit affected by spell power implicit coeffs and spell level penalties
-    DoneTotal = SpellBonusWithCoeffs(this, spellProto, DoneTotal, DoneAdvertisedBenefit, 0, damagetype, true);
+    DoneTotal = SpellBonusWithCoeffs(this, spellProto, DoneTotal, DoneAdvertisedBenefit, 0, damagetype, true, spell);
 
     // use float as more appropriate for negative values and percent applying
     float heal = (healamount + DoneTotal * int32(stack)) * DoneTotalMod;
@@ -6983,7 +6992,7 @@ uint32 Unit::SpellHealingBonusDone(Unit* pVictim, SpellEntry const* spellProto, 
  * Calculates target part of healing spell bonuses,
  * will be called on each tick for periodic damage over time auras
  */
-uint32 Unit::SpellHealingBonusTaken(Unit* pCaster, SpellEntry const* spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack)
+uint32 Unit::SpellHealingBonusTaken(Unit* pCaster, SpellEntry const* spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack, Spell const* spell)
 {
     float  TakenTotalMod = 1.0f;
 
@@ -7037,7 +7046,7 @@ uint32 Unit::SpellHealingBonusTaken(Unit* pCaster, SpellEntry const* spellProto,
     }
 
     // apply benefit affected by spell power implicit coeffs and spell level penalties
-    TakenTotal = SpellBonusWithCoeffs(pCaster, spellProto, TakenTotal, TakenAdvertisedBenefit, 0, damagetype, false);
+    TakenTotal = SpellBonusWithCoeffs(pCaster, spellProto, TakenTotal, TakenAdvertisedBenefit, 0, damagetype, false, spell);
 
     // Taken mods
     // Healing Wave cast

--- a/src/game/Object/Unit.h
+++ b/src/game/Object/Unit.h
@@ -3621,15 +3621,15 @@ class Unit : public WorldObject
         void UnsummonAllTotems();
         Unit* SelectMagnetTarget(Unit* victim, Spell* spell = NULL, SpellEffectIndex eff = EFFECT_INDEX_0);
 
-        int32 SpellBonusWithCoeffs(Unit* pCaster, SpellEntry const* spellProto, int32 total, int32 benefit, int32 ap_benefit, DamageEffectType damagetype, bool donePart);
+        int32 SpellBonusWithCoeffs(Unit* pCaster, SpellEntry const* spellProto, int32 total, int32 benefit, int32 ap_benefit, DamageEffectType damagetype, bool donePart, Spell const* spell = NULL);
         int32 SpellBaseDamageBonusDone(SpellSchoolMask schoolMask);
         int32 SpellBaseDamageBonusTaken(SpellSchoolMask schoolMask);
         uint32 SpellDamageBonusDone(Unit* pVictim, SpellEntry const* spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 stack = 1);
         uint32 SpellDamageBonusTaken(Unit* pCaster, SpellEntry const* spellProto, uint32 pdamage, DamageEffectType damagetype, uint32 stack = 1);
         int32 SpellBaseHealingBonusDone(SpellSchoolMask schoolMask);
         int32 SpellBaseHealingBonusTaken(SpellSchoolMask schoolMask);
-        uint32 SpellHealingBonusDone(Unit* pVictim, SpellEntry const* spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack = 1);
-        uint32 SpellHealingBonusTaken(Unit* pCaster, SpellEntry const* spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack = 1);
+        uint32 SpellHealingBonusDone(Unit* pVictim, SpellEntry const* spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack = 1, Spell const* spell = NULL);
+        uint32 SpellHealingBonusTaken(Unit* pCaster, SpellEntry const* spellProto, int32 healamount, DamageEffectType damagetype, uint32 stack = 1, Spell const* spell = NULL);
         uint32 MeleeDamageBonusDone(Unit* pVictim, uint32 damage, WeaponAttackType attType, SpellEntry const* spellProto = NULL, DamageEffectType damagetype = DIRECT_DAMAGE, uint32 stack = 1);
         uint32 MeleeDamageBonusTaken(Unit* pCaster, uint32 pdamage, WeaponAttackType attType, SpellEntry const* spellProto = NULL, DamageEffectType damagetype = DIRECT_DAMAGE, uint32 stack = 1);
 

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -419,6 +419,22 @@ Spell::~Spell()
 {
 }
 
+SpellEntry const* Spell::GetSpellBonusLevelPenaltySpell(SpellEntry const* spellProto) const
+{
+    if (!spellProto || !m_triggeredBySpellInfo)
+    {
+        return spellProto;
+    }
+
+    if (m_currentBasePoints[EFFECT_INDEX_1] == int32(m_triggeredBySpellInfo->Id) &&
+        sSpellMgr.GetSpellBonusData(spellProto->Id))
+    {
+        return m_triggeredBySpellInfo;
+    }
+
+    return spellProto;
+}
+
 template<typename T>
 WorldObject* Spell::FindCorpseUsing()
 {

--- a/src/game/WorldHandlers/Spell.h
+++ b/src/game/WorldHandlers/Spell.h
@@ -381,6 +381,8 @@ class Spell
         void HandleThreatSpells();
         // void HandleAddAura(Unit* Target);
 
+        SpellEntry const* GetSpellBonusLevelPenaltySpell(SpellEntry const* spellProto) const;
+
         SpellEntry const* m_spellInfo;
         SpellEntry const* m_triggeredBySpellInfo;
         int32 m_currentBasePoints[MAX_EFFECT_INDEX];        // cache SpellEntry::CalculateSimpleValue and use for set custom base points

--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -2098,8 +2098,8 @@ void Spell::EffectHeal(SpellEffectIndex /*eff_idx*/)
             addhealth += tickheal * tickcount;
         }
 
-        addhealth = caster->SpellHealingBonusDone(unitTarget, m_spellInfo, addhealth, HEAL);
-        addhealth = unitTarget->SpellHealingBonusTaken(caster, m_spellInfo, addhealth, HEAL);
+        addhealth = caster->SpellHealingBonusDone(unitTarget, m_spellInfo, addhealth, HEAL, 1, this);
+        addhealth = unitTarget->SpellHealingBonusTaken(caster, m_spellInfo, addhealth, HEAL, 1, this);
 
         m_healing += addhealth;
     }
@@ -4524,7 +4524,7 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
                 }
                 int32 heal = damage;
                 int32 spellid = m_spellInfo->Id;            // send main spell id as basepoints for not used effect
-                m_caster->CastCustomSpell(unitTarget, 19968, &heal, &spellid, NULL, true);
+                m_caster->CastCustomSpell(unitTarget, 19968, &heal, &spellid, NULL, true, NULL, NULL, ObjectGuid(), m_spellInfo);
             }
             // Flash of Light
             else if (m_spellInfo->SpellIconID  == 242)


### PR DESCRIPTION
## What changed

Holy Light uses spell `19968` as a triggered heal carrier. Because bonus calculation sees the triggered carrier instead of the original Holy Light rank, the spell power coefficient and low-rank penalty are calculated from the wrong spell.

This change fixes that by:

- passing the original Holy Light rank as `triggeredBy` when casting `19968`
- using the original triggered spell as the source for level penalty calculation
- applying `spell_bonus_data.direct_bonus` only for triggered heal carrier spells with original spell context
- keeping normal direct healing spells on the existing master behavior

The triggered spell `19968` remains instant for actual casting.

Companion database PR:
https://github.com/mangoszero/database/pull/141

Bug reference:
https://www.getmangos.eu/bug-tracker/mangos-zero/%5BPaladin%5D-Holy-Light---Downran-r274/

## Test

Tested on naked level 60 Paladin, no gear, no talents, no extra buffs.

Current master confirms the issue.

Holy Light Rank 4:

```text
without +1000 healing: 350 / 368 / 339
with +1000 healing: 780 / 773 / 777
```
The gain is about +424, matching the minimum 1.5 / 3.5 coefficient instead of Holy Light's expected 2.5 / 3.5.
Rank 1 is also affected. On current master, Holy Light Rank 1 gains about +428 from +1000 healing:
```text
without +1000 healing: 47 / 45
with +1000 healing: 476 / 473
```
That shows the low-rank penalty is not being calculated from the original Holy Light rank.
With the fix, Rank 4 gains about +714, matching:
```text
1000 * 2.5 / 3.5
```
Rank 1 uses the original rank for low-rank penalty, so the expected gain is about +205:
```text
1000 * 0.7143 * (1 - ((20 - 1) * 0.0375)) ~= 205
```
I also checked the regression risk around other healing spells. The final version only applies the custom HEAL coefficient to triggered carrier spells with original spell context, so normal heals such as Healing Wave, Flash Heal, Healing Touch, Regrowth, Holy Nova and Flash of Light keep the existing master behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/309)
<!-- Reviewable:end -->
