### PR TITLE
Caching AreaTable lookups

### DIFF
--- a/src/game/Server/DBCStores.cpp
+++ b/src/game/Server/DBCStores.cpp
@@ -153,11 +153,12 @@ bool IsAcceptableClientBuild(uint32 build)
 {
     int accepted_versions[] = EXPECTED_MANGOSD_CLIENT_BUILD;
     for (int i = 0; accepted_versions[i]; ++i)
+    {
         if (int(build) == accepted_versions[i])
         {
             return true;
         }
-
+    }
     return false;
 }
 
@@ -365,10 +366,12 @@ void LoadDBCStores(const std::string& dataPath)
             continue;
         }
         for (int j = 0; j < 5; ++j)
+        {
             if (talentInfo->RankID[j])
             {
                 sTalentSpellPosMap[talentInfo->RankID[j]] = TalentSpellPos(i, j);
             }
+        }
     }
 
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sTalentTabStore,           dbcPath, "TalentTab.dbc");
@@ -458,10 +461,12 @@ void LoadDBCStores(const std::string& dataPath)
 
     LoadDBC(availableDbcLocales, bar, bad_dbc_files, sTaxiPathStore,            dbcPath, "TaxiPath.dbc");
     for (uint32 i = 1; i < sTaxiPathStore.GetNumRows(); ++i)
+    {
         if (TaxiPathEntry const* entry = sTaxiPathStore.LookupEntry(i))
         {
             sTaxiPathSetBySource[entry->from][entry->to] = TaxiPathBySourceAndDestination(entry->ID, entry->price);
         }
+    }
     uint32 pathCount = sTaxiPathStore.GetNumRows();
 
     //## TaxiPathNode.dbc ## Loaded only for initialization different structures
@@ -470,6 +475,7 @@ void LoadDBCStores(const std::string& dataPath)
     std::vector<uint32> pathLength;
     pathLength.resize(pathCount);                           // 0 and some other indexes not used
     for (uint32 i = 1; i < sTaxiPathNodeStore.GetNumRows(); ++i)
+    {
         if (TaxiPathNodeEntry const* entry = sTaxiPathNodeStore.LookupEntry(i))
         {
             if (pathLength[entry->path] < entry->index + 1)
@@ -477,6 +483,7 @@ void LoadDBCStores(const std::string& dataPath)
                 pathLength[entry->path] = entry->index + 1;
             }
         }
+    }
     // Set path length
     sTaxiPathNodesByPath.resize(pathCount);                 // 0 and some other indexes not used
     for (uint32 i = 1; i < sTaxiPathNodesByPath.size(); ++i)
@@ -485,23 +492,30 @@ void LoadDBCStores(const std::string& dataPath)
     }
     // fill data (pointers to sTaxiPathNodeStore elements
     for (uint32 i = 1; i < sTaxiPathNodeStore.GetNumRows(); ++i)
+    {
         if (TaxiPathNodeEntry const* entry = sTaxiPathNodeStore.LookupEntry(i))
         {
             sTaxiPathNodesByPath[entry->path].set(entry->index, entry);
         }
+    }
 
     // Initialize global taxinodes mask
     // include existing nodes that have at least single not spell base (scripted) path
     {
         std::set<uint32> spellPaths;
         for (uint32 i = 1; i < sSpellStore.GetNumRows(); ++i)
+        {
             if (SpellEntry const* sInfo = sSpellStore.LookupEntry(i))
+            {
                 for (int j = 0; j < MAX_EFFECT_INDEX; ++j)
+                {
                     if (sInfo->Effect[j] == 123 /*SPELL_EFFECT_SEND_TAXI*/)
                     {
                         spellPaths.insert(sInfo->EffectMiscValue[j]);
                     }
-
+                }
+            }
+        }
         memset(sTaxiNodesMask, 0, sizeof(sTaxiNodesMask));
         for (uint32 i = 1; i < sTaxiNodesStore.GetNumRows(); ++i)
         {
@@ -668,8 +682,10 @@ AreaTableEntry const* GetAreaEntryByAreaFlagAndMap(uint32 area_flag, uint32 map_
     uint64 cacheKey = (static_cast<uint64>(area_flag) << 32) | static_cast<uint64>(map_id);
     auto it = cache.find(cacheKey);
     if (it != cache.end())
+    {
         return it->second;
-
+    }
+    
     AreaTableEntry const* aEntry = NULL;
     for (uint32 i = 0 ; i <= sAreaStore.GetNumRows() ; i++)
     {
@@ -781,9 +797,6 @@ ChatChannelsEntry const* GetChannelEntryFor(const std::string& name)
 
     return NULL;
 }
-
-
-
 
 bool Zone2MapCoordinates(float& x, float& y, uint32 zone)
 {

--- a/src/game/Server/DBCStores.cpp
+++ b/src/game/Server/DBCStores.cpp
@@ -685,7 +685,7 @@ AreaTableEntry const* GetAreaEntryByAreaFlagAndMap(uint32 area_flag, uint32 map_
     {
         return it->second;
     }
-    
+
     AreaTableEntry const* aEntry = NULL;
     for (uint32 i = 0 ; i <= sAreaStore.GetNumRows() ; i++)
     {

--- a/src/game/Server/DBCStores.cpp
+++ b/src/game/Server/DBCStores.cpp
@@ -664,6 +664,12 @@ AreaTableEntry const* GetAreaEntryByAreaID(uint32 area_id)
 AreaTableEntry const* GetAreaEntryByAreaFlagAndMap(uint32 area_flag, uint32 map_id)
 {
     // 1.12.1 areatable have duplicates for areaflag
+    static std::map<uint64, AreaTableEntry const*> cache;
+    uint64 cacheKey = (static_cast<uint64>(area_flag) << 32) | static_cast<uint64>(map_id);
+    auto it = cache.find(cacheKey);
+    if (it != cache.end())
+        return it->second;
+
     AreaTableEntry const* aEntry = NULL;
     for (uint32 i = 0 ; i <= sAreaStore.GetNumRows() ; i++)
     {
@@ -676,6 +682,7 @@ AreaTableEntry const* GetAreaEntryByAreaFlagAndMap(uint32 area_flag, uint32 map_
                     // area_flag found but it lets test map_id too
                     if (AreaEntry->mapid == map_id)
                     {
+                        cache[cacheKey] = AreaEntry;
                         return AreaEntry; // area_flag and map_id are ok so we can return value
                     }
                     // not same map_id so we store this entry and continue searching another better one
@@ -687,14 +694,18 @@ AreaTableEntry const* GetAreaEntryByAreaFlagAndMap(uint32 area_flag, uint32 map_
 
     if (aEntry)
     {
+        cache[cacheKey] = aEntry;
         return aEntry;  // return last entry found if exist (not same map_id but it seem ok in some places)
     }
 
     if (MapEntry const* mapEntry = sMapStore.LookupEntry(map_id))
     {
-        return GetAreaEntryByAreaID(mapEntry->linked_zone);
+        AreaTableEntry const* result = GetAreaEntryByAreaID(mapEntry->linked_zone);
+        cache[cacheKey] = result;
+        return result;
     }
 
+    cache[cacheKey] = NULL;
     return NULL;
 }
 


### PR DESCRIPTION
Adds a static cache for AreaTable lookups.  This was the tall nail when I looked at cpu usage with bots enabled, so I thought maybe we should hammer it down.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/310)
<!-- Reviewable:end -->
