### PR TITLE
Playerbot Use Item Fixes

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/UseItemAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/UseItemAction.cpp
@@ -175,9 +175,11 @@ bool UseItemAction::UseItem(Item* item, ObjectGuid goGuid, Item* itemTarget)
     bot->clearUnitState( UNIT_STAT_CHASE );
     bot->clearUnitState( UNIT_STAT_FOLLOW );
 
-    if (bot->isMoving())
+    if (targetSelected)
     {
-        return false;
+        ai->TellMasterNoFacing(out.str());
+        bot->GetSession()->QueuePacket(packet);
+        return true;
     }
 
     for (int i=0; i<MAX_ITEM_PROTO_SPELLS; i++)

--- a/src/modules/Bots/playerbot/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -45,6 +45,10 @@ void ChatCommandHandlerStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         NextAction::array(0, new NextAction("use", relevance), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "use",
+        NextAction::array(0, new NextAction("use", relevance), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "c",
         NextAction::array(0, new NextAction("item count", relevance), NULL)));
 


### PR DESCRIPTION
Replace the broad isMoving() early-return in UseItemAction with a  !targetSelected guard on the spell loop, so item usage doesn't fail just because the bot has residual movement state.  I seriously consideried just a force-stop, but removing the check works fine.   Also add a "use" trigger alias alongside "u" in ChatCommandHandlerStrategy so the bot responds to the full command.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/315)
<!-- Reviewable:end -->
