### PR TITLE
Bot Cautious Path improvement

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
@@ -119,18 +119,31 @@ bool MovementAction::MoveTo(Unit* target, float distance)
     float dx = cos(angle) * needToGo + bx;
     float dy = sin(angle) * needToGo + by;
 
-    if (needToGo > 0)
+    if (needToGo != 0)
     {
-        float safeDist = CalculateAggroFreeDistance(bx, by, angle, needToGo);
-        if (safeDist < needToGo)
+        float travelAngle = needToGo > 0 ? angle : angle + M_PI;
+        float travelDist  = fabs(needToGo);
+
+        static const float deltas[] = { 0.0f, M_PI/6, -M_PI/6, M_PI/3, -M_PI/3, M_PI/2, -M_PI/2 };
+        float bestSafeDist = 0.0f;
+        float bestAngle    = travelAngle;
+        for (float delta : deltas)
         {
-            if(safeDist < sPlayerbotAIConfig.contactDistance)
+            float safe = CalculateAggroFreeDistance(bx, by, travelAngle + delta, travelDist);
+            if (safe > bestSafeDist)
             {
-                return false;
+                bestSafeDist = safe;
+                bestAngle    = travelAngle + delta;
             }
-            dx = cos(angle) * safeDist + bx;
-            dy = sin(angle) * safeDist + by;
+            if (bestSafeDist >= travelDist)
+                break;
         }
+
+        float moveDist = std::min(bestSafeDist, travelDist);
+        if (moveDist < sPlayerbotAIConfig.contactDistance)
+            return false;
+        dx = cos(bestAngle) * moveDist + bx;
+        dy = sin(bestAngle) * moveDist + by;
     }
     return MoveTo(target->GetMapId(), dx, dy, tz, true);
 }


### PR DESCRIPTION
Improves the cautious strategy's pathfinding by trying multiple offset angles when moving toward or away from a target, instead of only checking the direct line of travel. If the straight path would aggro a nearby mob, the bot now searches  off the desired heading for the safest route.   Also extends aggro-free distance checking to backward movement, whereas previously only forward movement was checked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/316)
<!-- Reviewable:end -->
