### PR TITLE
Fix to bot spell casting

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/CastCustomSpellAction.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/CastCustomSpellAction.cpp
@@ -22,6 +22,10 @@ bool CastCustomSpellAction::Execute(Event event)
     string text = event.getParam();
 
     uint32 spell = chat->parseSpell(text);
+    if(!spell)
+    {
+        spell = AI_VALUE2(uint32, "spell id", text);
+    }
 
     ostringstream msg;
     if (!ai->CanCastSpell(spell, target))


### PR DESCRIPTION
The ~cast chat command for bots only seems to work for links and not actual spell names.  Sometimes you just need a playerbot to cast a spell by name, and this fixes that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/317)
<!-- Reviewable:end -->
