### PR TITLE
Hunterbot feign death clearing

### DIFF
--- a/src/modules/Bots/playerbot/strategy/hunter/DpsHunterStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/hunter/DpsHunterStrategy.cpp
@@ -108,6 +108,10 @@ void DpsAoeHunterStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "serpent sting on attacker",
         NextAction::array(0, new NextAction("serpent sting on attacker", 49.0f), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "has feign death",
+        NextAction::array(0, new NextAction("remove feign death", 53.0f), NULL)));
 }
 
 void DpsHunterDebuffStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
@@ -115,4 +119,8 @@ void DpsHunterDebuffStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "no stings",
         NextAction::array(0, new NextAction("serpent sting", 50.0f), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "has feign death",
+        NextAction::array(0, new NextAction("remove feign death", 53.0f), NULL)));
 }

--- a/src/modules/Bots/playerbot/strategy/hunter/GenericHunterNonCombatStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/hunter/GenericHunterNonCombatStrategy.cpp
@@ -64,4 +64,8 @@ void GenericHunterNonCombatStrategy::InitTriggers(std::list<TriggerNode*> &trigg
     triggers.push_back(new TriggerNode(
         "hunters pet low health",
         NextAction::array(0, new NextAction("mend pet", 60.0f), NULL)));
+
+    triggers.push_back(new TriggerNode(
+        "has feign death",
+        NextAction::array(0, new NextAction("remove feign death", 53.0f), NULL)));
 }

--- a/src/modules/Bots/playerbot/strategy/hunter/GenericHunterStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/hunter/GenericHunterStrategy.cpp
@@ -73,6 +73,10 @@ void GenericHunterStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         NextAction::array(0, new NextAction("feign death", 52.0f), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "has feign death",
+        NextAction::array(0, new NextAction("remove feign death", 53.0f), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "hunters pet low health",
         NextAction::array(0, new NextAction("mend pet", 60.0f), NULL)));
 

--- a/src/modules/Bots/playerbot/strategy/hunter/HunterActions.h
+++ b/src/modules/Bots/playerbot/strategy/hunter/HunterActions.h
@@ -103,6 +103,21 @@ namespace ai
         CastFeignDeathAction(PlayerbotAI* ai) : CastBuffSpellAction(ai, "feign death") {}
     };
 
+    class RemoveFeignDeathAction : public Action
+    {
+    public:
+        RemoveFeignDeathAction(PlayerbotAI* ai) : Action(ai, "remove feign death") {}
+        virtual bool Execute(Event event)
+        {
+            bot->RemoveSpellsCausingAura(SPELL_AURA_FEIGN_DEATH);
+            return true;
+        }
+        virtual bool isUseful()
+        {
+            return bot->hasUnitState(UNIT_STAT_DIED);
+        }
+    };
+
     class CastRapidFireAction : public CastBuffSpellAction
     {
     public:

--- a/src/modules/Bots/playerbot/strategy/hunter/HunterAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/hunter/HunterAiObjectContext.cpp
@@ -82,10 +82,12 @@ namespace ai
                 creators["aspect of the viper"] = &TriggerFactoryInternal::aspect_of_the_viper;
                 creators["trueshot aura"] = &TriggerFactoryInternal::trueshot_aura;
                 creators["serpent sting on attacker"] = &TriggerFactoryInternal::serpent_sting_on_attacker;
+                creators["has feign death"] = &TriggerFactoryInternal::has_feign_death;
             }
 
         private:
             static Trigger* serpent_sting_on_attacker(PlayerbotAI* ai) { return new SerpentStingOnAttackerTrigger(ai); }
+            static Trigger* has_feign_death(PlayerbotAI* ai) { return new FeignDeathTrigger(ai); }
             static Trigger* trueshot_aura(PlayerbotAI* ai) { return new TrueshotAuraTrigger(ai); }
             static Trigger* aspect_of_the_viper(PlayerbotAI* ai) { return new HunterAspectOfTheViperTrigger(ai); }
             static Trigger* black_arrow(PlayerbotAI* ai) { return new BlackArrowTrigger(ai); }
@@ -142,6 +144,7 @@ namespace ai
                 creators["aspect of the cheetah"] = &AiObjectContextInternal::aspect_of_the_cheetah;
                 creators["trueshot aura"] = &AiObjectContextInternal::trueshot_aura;
                 creators["feign death"] = &AiObjectContextInternal::feign_death;
+                creators["remove feign death"] = &AiObjectContextInternal::remove_feign_death;
                 creators["wing clip"] = &AiObjectContextInternal::wing_clip;
                 creators["disengage"] = &AiObjectContextInternal::disengage;
                 creators["immolation trap"] = &AiObjectContextInternal::immolation_trap;
@@ -157,6 +160,7 @@ namespace ai
 
         private:
             static Action* feign_death(PlayerbotAI* ai) { return new CastFeignDeathAction(ai); }
+            static Action* remove_feign_death(PlayerbotAI* ai) { return new RemoveFeignDeathAction(ai); }
             static Action* trueshot_aura(PlayerbotAI* ai) { return new CastTrueshotAuraAction(ai); }
             static Action* auto_shot(PlayerbotAI* ai) { return new CastAutoShotAction(ai); }
             static Action* aimed_shot(PlayerbotAI* ai) { return new CastAimedShotAction(ai); }

--- a/src/modules/Bots/playerbot/strategy/hunter/HunterTriggers.h
+++ b/src/modules/Bots/playerbot/strategy/hunter/HunterTriggers.h
@@ -90,4 +90,31 @@ namespace ai
         SerpentStingOnAttackerTrigger(PlayerbotAI* ai) : DebuffOnAttackerTrigger(ai, "serpent sting") {}
     };
 
+    class FeignDeathTrigger : public Trigger
+    {
+    public:
+        FeignDeathTrigger(PlayerbotAI* ai) : Trigger(ai, "has feign death", 1) {}
+        virtual bool IsActive()
+        {
+            if (!bot->hasUnitState(UNIT_STAT_DIED))
+                return false;
+
+            if (AI_VALUE(uint8, "attacker count") > 0)
+                return false;
+
+            Unit::AuraList const& auras = bot->GetAurasByType(SPELL_AURA_FEIGN_DEATH);
+            if (auras.empty())
+                return false;
+
+            Aura* aura = auras.front();
+            int32 maxDuration = aura->GetAuraMaxDuration();
+            int32 remaining = aura->GetAuraDuration();
+
+            if (maxDuration > 0)
+                return (maxDuration - remaining) >= 5000;
+
+            return true;
+        }
+    };
+
 }


### PR DESCRIPTION
Hunter Playerbots correctly used Feign Death to drop aggro, but were reluctant to ever get OUT of it, especially if combat ends soon after.  This puts a 5 second timer on Feign Death, reflecting how its normally used IRL.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/320)
<!-- Reviewable:end -->
