### PR TITLE
Expansions to the Playerbot jumping commands

### DIFF
--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -82,7 +82,7 @@ PlayerbotAI::PlayerbotAI() : PlayerbotAIBase(), bot(NULL), aiObjectContext(NULL)
     m_isJumping(false), m_jumpStartTime(0),
     m_jumpStartX(0.f), m_jumpStartY(0.f), m_jumpStartZ(0.f),
     m_jumpSinAngle(0.f), m_jumpCosAngle(1.f), m_jumpXYSpeed(0.f),
-    m_pendingJump(false), m_jumpRequestTime(0),
+    m_pendingJump(false), m_jumpHere(false), m_jumpRequestTime(0),
     m_jumpTargetX(0.f), m_jumpTargetY(0.f), m_jumpTargetZ(0.f), m_jumpTargetO(0.f)
 {
     for (int i = 0 ; i < BOT_STATE_MAX; i++)
@@ -101,7 +101,7 @@ PlayerbotAI::PlayerbotAI(Player* bot) :
     m_isJumping(false), m_jumpStartTime(0),
     m_jumpStartX(0.f), m_jumpStartY(0.f), m_jumpStartZ(0.f),
     m_jumpSinAngle(0.f), m_jumpCosAngle(1.f), m_jumpXYSpeed(0.f),
-    m_pendingJump(false), m_jumpRequestTime(0),
+    m_pendingJump(false), m_jumpHere(false), m_jumpRequestTime(0),
     m_jumpTargetX(0.f), m_jumpTargetY(0.f), m_jumpTargetZ(0.f), m_jumpTargetO(0.f)
 {
     this->bot = bot;
@@ -175,7 +175,7 @@ PlayerbotAI::~PlayerbotAI()
 static const float BOT_JUMP_VELOCITY = 7.9557f;
 static const float BOT_JUMP_GRAVITY  = 19.2911f;
 
-void PlayerbotAI::RequestJump()
+void PlayerbotAI::RequestJump(bool here)
 {
     if (m_pendingJump || m_isJumping)
         return;
@@ -189,6 +189,7 @@ void PlayerbotAI::RequestJump()
     m_jumpTargetZ = master->GetPositionZ();
     m_jumpTargetO = master->GetOrientation();
     m_pendingJump = true;
+    m_jumpHere = here;
     m_jumpRequestTime = getMSTime();
 }
 
@@ -243,7 +244,10 @@ void PlayerbotAI::UpdateJump()
             if (dist2d <= 0.5f)
             {
                 m_pendingJump = false;
-                StartJump(true, m_jumpTargetO);
+                if (m_jumpHere)
+                    StartJump(false);
+                else
+                    StartJump(true, m_jumpTargetO);
             }
             else
             {

--- a/src/modules/Bots/playerbot/PlayerbotAI.h
+++ b/src/modules/Bots/playerbot/PlayerbotAI.h
@@ -186,7 +186,7 @@ public:
     PlayerbotSecurity* GetSecurity() { return &security; }
 
     void StartJump(bool forward, float orientation = -1.f);
-    void RequestJump();
+    void RequestJump(bool here = false);
     bool IsJumping() const { return m_isJumping; }
     bool IsPendingJump() const { return m_pendingJump; }
 
@@ -229,6 +229,7 @@ protected:
     float  m_jumpStartX, m_jumpStartY, m_jumpStartZ;
     float  m_jumpSinAngle, m_jumpCosAngle, m_jumpXYSpeed;
     bool   m_pendingJump;
+    bool   m_jumpHere;
     uint32 m_jumpRequestTime;
     float  m_jumpTargetX, m_jumpTargetY, m_jumpTargetZ, m_jumpTargetO;
 

--- a/src/modules/Bots/playerbot/strategy/actions/ActionContext.h
+++ b/src/modules/Bots/playerbot/strategy/actions/ActionContext.h
@@ -68,7 +68,6 @@ namespace ai
             creators["attack duel opponent"] = &ActionContext::attack_duel_opponent;
             creators["drop target"] = &ActionContext::drop_target;
             creators["jump"] = &ActionContext::jump;
-            creators["jump up"] = &ActionContext::jump_up;
             creators["back off"] = &ActionContext::back_off;
         }
 
@@ -119,6 +118,6 @@ namespace ai
         static Action* move_out_of_enemy_contact(PlayerbotAI* ai) { return new MoveOutOfEnemyContactAction(ai); }
         static Action* set_facing(PlayerbotAI* ai) { return new SetFacingTargetAction(ai); }
         static Action* jump(PlayerbotAI* ai) { return new JumpAction(ai); }
-        static Action* jump_up(PlayerbotAI* ai) { return new JumpInPlaceAction(ai); }
+
     };
 };

--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
@@ -630,15 +630,37 @@ bool SetFacingTargetAction::isUseful()
 
 bool JumpAction::Execute(Event event)
 {
-    if (ai->IsJumping() || ai->IsPendingJump())
-        return false;
+    string const param = event.getParam();
 
-    ai->RequestJump();
-    return ai->IsPendingJump();
-}
+    if (param == "forward")
+    {
+        if (ai->IsJumping())
+            return false;
+        ai->StartJump(true);
+        return true;
+    }
 
-bool JumpInPlaceAction::Execute(Event event)
-{
+    if (param == "master")
+    {
+        if (ai->IsJumping())
+            return false;
+        Player* master = ai->GetMaster();
+        if (!master)
+            return false;
+        float angle = bot->GetAngle(master);
+        bot->SetFacingTo(angle);
+        ai->StartJump(true, angle);
+        return true;
+    }
+
+    if (param == "here")
+    {
+        if (ai->IsJumping() || ai->IsPendingJump())
+            return false;
+        ai->RequestJump();
+        return ai->IsPendingJump();
+    }
+
     if (ai->IsJumping())
         return false;
 

--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.h
@@ -102,11 +102,4 @@ namespace ai
         virtual bool Execute(Event event);
     };
 
-    class JumpInPlaceAction : public MovementAction
-    {
-    public:
-        JumpInPlaceAction(PlayerbotAI* ai) : MovementAction(ai, "jump up") {}
-        virtual bool Execute(Event event);
-    };
-
 }

--- a/src/modules/Bots/playerbot/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -135,10 +135,6 @@ void ChatCommandHandlerStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
     triggers.push_back(new TriggerNode(
         "jump",
         NextAction::array(0, new NextAction("jump", relevance), NULL)));
-
-    triggers.push_back(new TriggerNode(
-        "jump up",
-        NextAction::array(0, new NextAction("jump up", relevance), NULL)));
 }
 
 
@@ -182,5 +178,7 @@ ChatCommandHandlerStrategy::ChatCommandHandlerStrategy(PlayerbotAI* ai) : PassTr
     supported.push_back("who");
     supported.push_back("save mana");
     supported.push_back("jump");
-    supported.push_back("jump up");
+    supported.push_back("jump here");
+    supported.push_back("jump forward");
+    supported.push_back("jump master");
 }

--- a/src/modules/Bots/playerbot/strategy/triggers/ChatTriggerContext.h
+++ b/src/modules/Bots/playerbot/strategy/triggers/ChatTriggerContext.h
@@ -72,13 +72,11 @@ namespace ai
             creators["max dps"] = &ChatTriggerContext::max_dps;
             creators["attackers"] = &ChatTriggerContext::attackers;
             creators["jump"] = &ChatTriggerContext::jump;
-            creators["jump up"] = &ChatTriggerContext::jump_up;
         }
 
     private:
         static Trigger* attackers(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "attackers"); }
         static Trigger* jump(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "jump"); }
-        static Trigger* jump_up(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "jump up"); }
         static Trigger* max_dps(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "max dps"); }
         static Trigger* save_mana(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "save mana"); }
         static Trigger* who(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "who"); }


### PR DESCRIPTION
Expands the chat commands for making playerbots jump.  Gives the follow new commands and changes to old ones:
1. JUMP UP - jump in place
2. JUMP FORWARD - jumps forward at their current place and orientation
3. JUMP MASTER - orients the bot to the master and THEN jumps forward
4. JUMP HERE - bots path to master, orient as master, and then jump forward
5. JUMP * - anything else acts as JUMP UP

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/321)
<!-- Reviewable:end -->
