### PR TITLE
Bot: Facing change after random move

### DIFF
--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
@@ -273,6 +273,7 @@ bool MovementAction::FollowOnTransport(Unit* target, Player* master)
         AI_VALUE(LastMovement&, "last movement").Set(target);
         return true;
     }
+    return false;
 }
 
 bool MovementAction::FollowOffTransport(Unit* target, Player* master)
@@ -527,6 +528,16 @@ bool RunAwayAction::Execute(Event event)
 
 bool MoveRandomAction::Execute(Event event)
 {
+    if (m_hasFaceTarget)
+    {
+        if (bot->IsStopped())
+        {
+            m_hasFaceTarget = false;
+            bot->SetFacingTo(bot->GetAngle(m_faceX, m_faceY));
+        }
+        return true;
+    }
+
     WorldObject* target = NULL;
 
     if (!(rand() % 3))
@@ -561,7 +572,14 @@ bool MoveRandomAction::Execute(Event event)
 
     if (target)
     {
-        return MoveNear(target);
+        bool moved = MoveNear(target);
+        if (moved)
+        {
+            m_faceX = target->GetPositionX();
+            m_faceY = target->GetPositionY();
+            m_hasFaceTarget = true;
+        }
+        return moved;
     }
 
     for (int i = 0; i < 10; ++i)

--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.h
@@ -62,14 +62,18 @@ namespace ai
     class MoveRandomAction : public MovementAction
     {
     public:
-        MoveRandomAction(PlayerbotAI* ai) : MovementAction(ai, "move random") {}
+        MoveRandomAction(PlayerbotAI* ai) : MovementAction(ai, "move random"), m_hasFaceTarget(false), m_faceX(0.0f), m_faceY(0.0f) {}
         virtual bool Execute(Event event);
         virtual bool isPossible()
         {
-            return MovementAction::isPossible() &&
+            return !bot->GetGroup() &&
+                    MovementAction::isPossible() &&
                     AI_VALUE2(uint8, "health", "self target") > sPlayerbotAIConfig.mediumHealth &&
                     (!AI_VALUE2(uint8, "mana", "self target") || AI_VALUE2(uint8, "mana", "self target") > sPlayerbotAIConfig.mediumMana);
         }
+    private:
+        bool m_hasFaceTarget;
+        float m_faceX, m_faceY;
     };
 
     class MoveToLootAction : public MovementAction


### PR DESCRIPTION
Purely cosmetic change:
After a Bot makes a random move, it will be forced to face the thing it moved to.  If you stare at random playerbots long enough, the previous behavior would bug you this much also.

Oh, also a random bug fix to add a missing return to FollowOnTransport.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/323)
<!-- Reviewable:end -->
