### PR TITLE
hunter bots feed their pets

### DIFF
--- a/src/game/Server/SharedDefines.h
+++ b/src/game/Server/SharedDefines.h
@@ -2059,6 +2059,8 @@ enum CorpseDynFlags
 #define SPELL_ID_WEAPON_SWITCH_COOLDOWN_1_5s    6119
 #define SPELL_ID_WEAPON_SWITCH_COOLDOWN_1_0s    6123
 #define SPELL_ID_RECENTLY_BANDAGED              11196
+#define SPELL_ID_FEED_PET                       6991
+#define SPELL_ID_FEED_PET_EFFECT                1539
 
 enum WeatherType
 {

--- a/src/modules/Bots/playerbot/strategy/hunter/GenericHunterNonCombatStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/hunter/GenericHunterNonCombatStrategy.cpp
@@ -66,6 +66,10 @@ void GenericHunterNonCombatStrategy::InitTriggers(std::list<TriggerNode*> &trigg
         NextAction::array(0, new NextAction("mend pet", 60.0f), NULL)));
 
     triggers.push_back(new TriggerNode(
+        "hunters pet unhappy",
+        NextAction::array(0, new NextAction("feed pet", 60.0f), NULL)));
+
+    triggers.push_back(new TriggerNode(
         "has feign death",
         NextAction::array(0, new NextAction("remove feign death", 53.0f), NULL)));
 }

--- a/src/modules/Bots/playerbot/strategy/hunter/HunterActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/hunter/HunterActions.cpp
@@ -50,6 +50,20 @@ bool CastIntimidationAction::isUseful()
     return CastSpellAction::isUseful() && AI_VALUE(Unit*, "pet target") != NULL;
 }
 
+bool FeedPetAction::isUseful()
+{
+    Unit* pet = GetTarget();
+    if (!pet || !pet->IsAlive())
+        return false;
+
+    // Pet already has the Feed Pet Effect aura
+    if (pet->HasAura(SPELL_ID_FEED_PET_EFFECT))
+        return false;
+
+    uint32 spellId = AI_VALUE2(uint32, "spell id", "feed pet");
+    return spellId && AI_VALUE2(Item*, "item for spell", spellId);
+}
+
 bool HunterMeleeAction::isUseful()
 {
     // Only swing if enemy is already in our face AND targeting us.

--- a/src/modules/Bots/playerbot/strategy/hunter/HunterActions.h
+++ b/src/modules/Bots/playerbot/strategy/hunter/HunterActions.h
@@ -198,6 +198,14 @@ namespace ai
         virtual bool isUseful();
     };
 
+    class FeedPetAction : public CastSpellAction
+    {
+    public:
+        FeedPetAction(PlayerbotAI* ai) : CastSpellAction(ai, "feed pet") {}
+        virtual string GetTargetName() { return "pet target"; }
+        virtual bool isUseful();
+    };
+
     class HunterMeleeAction : public Action
     {
     public:

--- a/src/modules/Bots/playerbot/strategy/hunter/HunterAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/hunter/HunterAiObjectContext.cpp
@@ -70,6 +70,7 @@ namespace ai
                 creators["no stings"] = &TriggerFactoryInternal::NoStings;
                 creators["hunters pet dead"] = &TriggerFactoryInternal::hunters_pet_dead;
                 creators["hunters pet low health"] = &TriggerFactoryInternal::hunters_pet_low_health;
+                creators["hunters pet unhappy"] = &TriggerFactoryInternal::hunters_pet_unhappy;
                 creators["hunter's mark"] = &TriggerFactoryInternal::hunters_mark;
                 creators["freezing trap"] = &TriggerFactoryInternal::freezing_trap;
                 creators["aspect of the pack"] = &TriggerFactoryInternal::aspect_of_the_pack;
@@ -92,6 +93,7 @@ namespace ai
             static Trigger* NoStings(PlayerbotAI* ai) { return new HunterNoStingsActiveTrigger(ai); }
             static Trigger* hunters_pet_dead(PlayerbotAI* ai) { return new HuntersPetDeadTrigger(ai); }
             static Trigger* hunters_pet_low_health(PlayerbotAI* ai) { return new HuntersPetLowHealthTrigger(ai); }
+            static Trigger* hunters_pet_unhappy(PlayerbotAI* ai) { return new HuntersPetUnhappyTrigger(ai); }
             static Trigger* hunters_mark(PlayerbotAI* ai) { return new HuntersMarkTrigger(ai); }
             static Trigger* freezing_trap(PlayerbotAI* ai) { return new FreezingTrapTrigger(ai); }
             static Trigger* aspect_of_the_pack(PlayerbotAI* ai) { return new HunterAspectOfThePackTrigger(ai); }
@@ -128,6 +130,7 @@ namespace ai
                 creators["viper sting"] = &AiObjectContextInternal::viper_sting;
                 creators["scorpid sting"] = &AiObjectContextInternal::scorpid_sting;
                 creators["hunter's mark"] = &AiObjectContextInternal::hunters_mark;
+                creators["feed pet"] = &AiObjectContextInternal::feed_pet;
                 creators["mend pet"] = &AiObjectContextInternal::mend_pet;
                 creators["revive pet"] = &AiObjectContextInternal::revive_pet;
                 creators["call pet"] = &AiObjectContextInternal::call_pet;
@@ -172,6 +175,7 @@ namespace ai
             static Action* viper_sting(PlayerbotAI* ai) { return new CastViperStingAction(ai); }
             static Action* scorpid_sting(PlayerbotAI* ai) { return new CastScorpidStingAction(ai); }
             static Action* hunters_mark(PlayerbotAI* ai) { return new CastHuntersMarkAction(ai); }
+            static Action* feed_pet(PlayerbotAI* ai) { return new FeedPetAction(ai); }
             static Action* mend_pet(PlayerbotAI* ai) { return new CastMendPetAction(ai); }
             static Action* revive_pet(PlayerbotAI* ai) { return new CastRevivePetAction(ai); }
             static Action* call_pet(PlayerbotAI* ai) { return new CastCallPetAction(ai); }

--- a/src/modules/Bots/playerbot/strategy/hunter/HunterTriggers.cpp
+++ b/src/modules/Bots/playerbot/strategy/hunter/HunterTriggers.cpp
@@ -34,3 +34,12 @@ bool HuntersPetLowHealthTrigger::IsActive()
     return pet && AI_VALUE2(uint8, "health", "pet target") < 40 &&
         !AI_VALUE2(bool, "dead", "pet target") && !AI_VALUE2(bool, "mounted", "self target");
 }
+
+bool HuntersPetUnhappyTrigger::IsActive()
+{
+    if (AI_VALUE2(bool, "mounted", "self target"))
+        return false;
+
+    Pet* pet = bot->GetPet();
+    return pet && pet->IsAlive() && pet->GetHappinessState() == UNHAPPY;
+}

--- a/src/modules/Bots/playerbot/strategy/hunter/HunterTriggers.h
+++ b/src/modules/Bots/playerbot/strategy/hunter/HunterTriggers.h
@@ -49,6 +49,14 @@ namespace ai
     BEGIN_TRIGGER(HuntersPetLowHealthTrigger, Trigger)
     END_TRIGGER()
 
+    class HuntersPetUnhappyTrigger : public Trigger
+    {
+    public:
+        HuntersPetUnhappyTrigger(PlayerbotAI* ai) : Trigger(ai, "hunters pet unhappy", 300) {}
+    public:
+        virtual bool IsActive();
+    };
+
     class BlackArrowTrigger : public DebuffTrigger
     {
     public:

--- a/src/modules/Bots/playerbot/strategy/values/ItemForSpellValue.cpp
+++ b/src/modules/Bots/playerbot/strategy/values/ItemForSpellValue.cpp
@@ -61,17 +61,74 @@ Item* ItemForSpellValue::Calculate()
         return NULL;
     }
 
+    // Feed Pet: search bags for food items instead of equipped items
+    if (!itemForSpell && spellid == SPELL_ID_FEED_PET)
+    {
+        Pet* pet = bot->GetPet();
+        if (pet && pet->IsAlive())
+        {
+            Item* bestFood = NULL;
+            uint32 lowestScore = 0x7fffffff;
+
+            // Main backpack
+            for (uint8 slot = INVENTORY_SLOT_ITEM_START; slot < INVENTORY_SLOT_ITEM_END; ++slot)
+            {
+                Item* item = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, slot);
+                uint32 itemScore = GetPetFoodScore(pet, item, spellInfo);
+                if(itemScore > 0 && itemScore < lowestScore)
+                {
+                    bestFood = item;
+                    lowestScore = itemScore;
+                }
+            }
+
+            // Bags
+            for (uint8 bag = INVENTORY_SLOT_BAG_START; bag < INVENTORY_SLOT_BAG_END; ++bag)
+            {
+                Bag* pBag = (Bag*)bot->GetItemByPos(INVENTORY_SLOT_BAG_0, bag);
+                if (!pBag) continue;
+                for (uint32 slot = 0; slot < pBag->GetBagSize(); ++slot)
+                {
+                    Item* item = pBag->GetItemByPos(slot);
+                    uint32 itemScore = GetPetFoodScore(pet, item, spellInfo);
+                    if(itemScore > 0 && itemScore < lowestScore)
+                    {
+                        bestFood = item;
+                        lowestScore = itemScore;
+                    }
+                }
+            }
+
+            if (bestFood)
+                return bestFood;
+        }
+    }
+
     for ( uint8 slot = EQUIPMENT_SLOT_START; slot < EQUIPMENT_SLOT_END; slot++ )
     {
-    {
         itemForSpell = GetItemFitsToSpellRequirements(slot, spellInfo);
-    }
         if (itemForSpell)
         {
             return itemForSpell;
         }
     }
+
     return NULL;
+}
+uint32 ItemForSpellValue::GetPetFoodScore(Pet *pet, Item *item, SpellEntry const *spellInfo)
+{
+    if (!item || !pet)
+    {
+        return 0;
+    }
+    ItemPrototype const* proto = item->GetProto();
+    if (!proto || !item->IsFitToSpellRequirements(spellInfo) ||
+        !pet->HaveInDiet(proto) ||
+        !pet->GetCurrentFoodBenefitLevel(proto->ItemLevel))
+    {
+        return 0;
+    }
+    return (proto->ItemLevel * 1000) + proto->BuyPrice;
 }
 
 Item* ItemForSpellValue::GetItemFitsToSpellRequirements(uint8 slot, SpellEntry const *spellInfo)
@@ -81,7 +138,6 @@ Item* ItemForSpellValue::GetItemFitsToSpellRequirements(uint8 slot, SpellEntry c
     {
         return NULL;
     }
-
     if (itemForSpell->IsFitToSpellRequirements(spellInfo))
     {
         return itemForSpell;

--- a/src/modules/Bots/playerbot/strategy/values/ItemForSpellValue.h
+++ b/src/modules/Bots/playerbot/strategy/values/ItemForSpellValue.h
@@ -15,6 +15,7 @@ namespace ai
 
     private:
         Item* GetItemFitsToSpellRequirements(uint8 slot, SpellEntry const *spellInfo);
+        uint32 GetPetFoodScore(Pet *pet, Item *item, SpellEntry const *spellInfo);
 
     };
 }


### PR DESCRIPTION
Gives hunterbots the ability to feed their pets when they become happy.  It selects food for appropriateness, but ranks it by feeding the pet lower level/cheaper food according to a formula, leaving the good stuff for the bot himself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/324)
<!-- Reviewable:end -->
