### PR TITLE
Add school-based interrupts

### DIFF
--- a/src/game/Object/Creature.cpp
+++ b/src/game/Object/Creature.cpp
@@ -2428,6 +2428,10 @@ SpellEntry const* Creature::ReachWithSpellAttack(Unit* pVictim)
         {
             continue;
         }
+        if (IsSchoolLockedOut(GetSpellSchoolMask(spellInfo)))
+        {
+            continue;
+        }
         if (spellInfo->PreventionType == SPELL_PREVENTION_TYPE_PACIFY && HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_PACIFIED))
         {
             continue;
@@ -2485,6 +2489,10 @@ SpellEntry const* Creature::ReachWithSpellCure(Unit* pVictim)
             continue;
         }
         if (spellInfo->PreventionType == SPELL_PREVENTION_TYPE_SILENCE && HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SILENCED))
+        {
+            continue;
+        }
+        if (IsSchoolLockedOut(GetSpellSchoolMask(spellInfo)))
         {
             continue;
         }

--- a/src/game/Object/CreatureAI.cpp
+++ b/src/game/Object/CreatureAI.cpp
@@ -26,6 +26,7 @@
 #include "Creature.h"
 #include "DBCStores.h"
 #include "Spell.h"
+#include "SpellMgr.h"
 #include "GridNotifiers.h"
 #include "GridNotifiersImpl.h"
 #include "CellImpl.h"
@@ -93,6 +94,11 @@ CanCastResult CreatureAI::CanCastSpell(Unit* pTarget, const SpellEntry* pSpell, 
         }
 
         if (pSpell->PreventionType == SPELL_PREVENTION_TYPE_SILENCE && m_creature->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_SILENCED))
+        {
+            return CAST_FAIL_SILENCED;
+        }
+
+        if (m_creature->IsSchoolLockedOut(GetSpellSchoolMask(pSpell)))
         {
             return CAST_FAIL_SILENCED;
         }

--- a/src/game/Object/Unit.cpp
+++ b/src/game/Object/Unit.cpp
@@ -197,7 +197,9 @@ Unit::Unit() :
     m_charmInfo(NULL),
     i_motionMaster(this),
     m_ThreatManager(this),
-    m_HostileRefManager(this)
+    m_HostileRefManager(this),
+    m_schoolLockoutMask(SPELL_SCHOOL_MASK_NONE),
+    m_schoolLockoutExpire(0)
 {
     m_objectType |= TYPEMASK_UNIT;
     m_objectTypeId = TYPEID_UNIT;
@@ -4036,6 +4038,26 @@ void Unit::InterruptSpell(CurrentSpellTypes spellType, bool withDelayed)
             m_currentSpells[spellType] = NULL;
         }
     }
+}
+
+void Unit::ProhibitSpellSchool(SpellSchoolMask idSchoolMask, uint32 unTimeMs)
+{
+    if (GetTypeId() == TYPEID_PLAYER || !unTimeMs)
+        return;
+
+    m_schoolLockoutMask = idSchoolMask;
+    m_schoolLockoutExpire = time(nullptr) + unTimeMs / IN_MILLISECONDS;
+}
+
+bool Unit::IsSchoolLockedOut(SpellSchoolMask schoolMask) const
+{
+    if (!m_schoolLockoutMask || !schoolMask)
+        return false;
+    if (!(m_schoolLockoutMask & schoolMask))
+        return false;
+    if (time(nullptr) >= m_schoolLockoutExpire)
+        return false;
+    return true;
 }
 
 /**

--- a/src/game/Object/Unit.h
+++ b/src/game/Object/Unit.h
@@ -3714,7 +3714,8 @@ class Unit : public WorldObject
         float GetCreateStat(Stats stat) const { return m_createStats[stat]; }
 
         void SetCurrentCastedSpell(Spell* pSpell);
-        virtual void ProhibitSpellSchool(SpellSchoolMask /*idSchoolMask*/, uint32 /*unTimeMs*/) {}
+        virtual void ProhibitSpellSchool(SpellSchoolMask idSchoolMask, uint32 unTimeMs);
+        bool IsSchoolLockedOut(SpellSchoolMask schoolMask) const;
         void InterruptSpell(CurrentSpellTypes spellType, bool withDelayed = true);
         void FinishSpell(CurrentSpellTypes spellType, bool ok = true);
 
@@ -3775,6 +3776,10 @@ class Unit : public WorldObject
 
         // Event handler
         EventProcessor m_Events;
+
+        // Per-school spell lockout (for non-Player units)
+        SpellSchoolMask m_schoolLockoutMask;
+        time_t m_schoolLockoutExpire;
 
         // stat system
         bool HandleStatModifier(UnitMods unitMod, UnitModifierType modifierType, float amount, bool apply);

--- a/src/game/WorldHandlers/Spell.cpp
+++ b/src/game/WorldHandlers/Spell.cpp
@@ -6877,6 +6877,9 @@ SpellCastResult Spell::CheckCasterAuras() const
         prevented_reason = SPELL_FAILED_PACIFIED;
     }
 
+    if (m_caster->IsSchoolLockedOut(GetSpellSchoolMask(m_spellInfo)))
+        prevented_reason = SPELL_FAILED_SILENCED;
+
     // Attr must make flag drop spell totally immune from all effects
     if (prevented_reason != SPELL_CAST_OK)
     {


### PR DESCRIPTION
Implements school-based spell interruption/lockout for creatures, which seemed to be a bug while playing before I realized that it wasn't implemented yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/325)
<!-- Reviewable:end -->
