### PR TITLE
DPS Assist fix and DPS Tanks target

### DIFF
--- a/src/modules/Bots/CMakeLists.txt
+++ b/src/modules/Bots/CMakeLists.txt
@@ -254,6 +254,8 @@ set(BOT_SRCS
     playerbot/strategy/generic/DpsAoeStrategy.h
     playerbot/strategy/generic/DpsAssistStrategy.cpp
     playerbot/strategy/generic/DpsAssistStrategy.h
+    playerbot/strategy/generic/DpsTanksTargetStrategy.cpp
+    playerbot/strategy/generic/DpsTanksTargetStrategy.h
     playerbot/strategy/generic/DuelStrategy.cpp
     playerbot/strategy/generic/DuelStrategy.h
     playerbot/strategy/generic/EmoteStrategy.cpp
@@ -475,6 +477,7 @@ set(BOT_SRCS
     playerbot/strategy/values/DistanceValue.h
     playerbot/strategy/values/DpsTargetValue.cpp
     playerbot/strategy/values/DpsTargetValue.h
+    playerbot/strategy/values/DpsTanksTargetValue.h
     playerbot/strategy/values/DuelTargetValue.cpp
     playerbot/strategy/values/DuelTargetValue.h
     playerbot/strategy/values/EnemyHealerTargetValue.cpp

--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -907,6 +907,30 @@ bool PlayerbotAI::IsTank(Player* player)
  * @param player The player to check.
  * @return True if the player is a healer class, false otherwise.
  */
+Player* PlayerbotAI::GetGroupTank(Player* except)
+{
+    Group* group = except->GetGroup();
+    if (!group)
+        return nullptr;
+
+    Group::MemberSlotList const& slots = group->GetMemberSlots();
+    if (slots.size() < 5)
+        return nullptr;
+
+    for (Group::member_citerator itr = slots.begin(); itr != slots.end(); ++itr)
+    {
+        Player* member = sObjectMgr.GetPlayer(itr->guid);
+        if (member && member != except && IsTank(member))
+            return member;
+    }
+    return nullptr;
+}
+
+/**
+ * Checks if the player is a healer class.
+ * @param player The player to check.
+ * @return True if the player is a healer class, false otherwise.
+ */
 bool PlayerbotAI::IsHeal(Player* player)
 {
     PlayerbotAI* botAi = player->GetPlayerbotAI();

--- a/src/modules/Bots/playerbot/PlayerbotAI.h
+++ b/src/modules/Bots/playerbot/PlayerbotAI.h
@@ -159,6 +159,7 @@ public:
     void ReInitCurrentEngine();
     void Reset();
     bool IsTank(Player* player);
+    Player* GetGroupTank(Player* except);
     bool IsHeal(Player* player);
     bool IsRanged(Player* player);
     Creature* GetCreature(ObjectGuid guid);

--- a/src/modules/Bots/playerbot/strategy/StrategyContext.h
+++ b/src/modules/Bots/playerbot/strategy/StrategyContext.h
@@ -37,6 +37,7 @@
 #include "generic/AttackEnemyPlayersStrategy.h"
 #include "generic/MoveRandomStrategy.h"
 #include "generic/CautiousStrategy.h"
+#include "generic/DpsTanksTargetStrategy.h"
 
 namespace ai
 {
@@ -131,6 +132,7 @@ namespace ai
         {
             creators["dps assist"] = &AssistStrategyContext::dps_assist;
             creators["dps aoe"] = &AssistStrategyContext::dps_aoe;
+            creators["dps tanks"] = &AssistStrategyContext::dps_tanks_target;
             creators["tank assist"] = &AssistStrategyContext::tank_assist;
             creators["tank aoe"] = &AssistStrategyContext::tank_aoe;
             creators["attack weak"] = &AssistStrategyContext::attack_weak;
@@ -146,6 +148,7 @@ namespace ai
         static Strategy* attack_weak(PlayerbotAI* ai) { return new AttackWeakStrategy(ai); }
         static Strategy* grind(PlayerbotAI* ai) { return new GrindingStrategy(ai); }
         static Strategy* attack_rti(PlayerbotAI* ai) { return new AttackRtiStrategy(ai); }
+        static Strategy* dps_tanks_target(PlayerbotAI* ai) { return new DpsTanksTargetStrategy(ai); }
     };
 
     class QuestStrategyContext : public NamedObjectContext<Strategy>

--- a/src/modules/Bots/playerbot/strategy/actions/ActionContext.h
+++ b/src/modules/Bots/playerbot/strategy/actions/ActionContext.h
@@ -56,6 +56,7 @@ namespace ai
             creators["stay combat"] = &ActionContext::stay_combat;
             creators["attack anything"] = &ActionContext::attack_anything;
             creators["attack least hp target"] = &ActionContext::attack_least_hp_target;
+            creators["attack tanks target"] = &ActionContext::attack_tanks_target;
             creators["attack enemy player"] = &ActionContext::enemy_player_target;
             creators["emote"] = &ActionContext::emote;
             creators["suggest what to do"] = &ActionContext::suggest_what_to_do;
@@ -93,6 +94,7 @@ namespace ai
         static Action* suggest_what_to_do(PlayerbotAI* ai) { return new SuggestWhatToDoAction(ai); }
         static Action* attack_anything(PlayerbotAI* ai) { return new AttackAnythingAction(ai); }
         static Action* attack_least_hp_target(PlayerbotAI* ai) { return new AttackLeastHpTargetAction(ai); }
+        static Action* attack_tanks_target(PlayerbotAI* ai) { return new AttackTanksTargetAction(ai); }
         static Action* enemy_player_target(PlayerbotAI* ai) { return new AttackEnemyPlayerAction(ai); }
         static Action* stay_combat(PlayerbotAI* ai) { return new StayCombatAction(ai); }
         static Action* stay_line(PlayerbotAI* ai) { return new StayLineAction(ai); }

--- a/src/modules/Bots/playerbot/strategy/actions/ChooseTargetActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/ChooseTargetActions.h
@@ -64,6 +64,20 @@ namespace ai
         }
     };
 
+    class AttackTanksTargetAction : public AttackAction
+    {
+    public:
+        AttackTanksTargetAction(PlayerbotAI* ai) : AttackAction(ai, "attack tanks target") {}
+
+        virtual string GetTargetName()
+        {
+            Player* tank = ai->GetGroupTank(bot);
+            if (!tank)
+                return "least hp target";
+            return "dps tanks target";
+        }
+    };
+
     class AttackEnemyPlayerAction : public AttackAction
     {
     public:

--- a/src/modules/Bots/playerbot/strategy/generic/DpsAssistStrategy.h
+++ b/src/modules/Bots/playerbot/strategy/generic/DpsAssistStrategy.h
@@ -1,5 +1,5 @@
-#include "../generic/NonCombatStrategy.h"
 #pragma once
+#include "../generic/NonCombatStrategy.h"
 
 namespace ai
 {

--- a/src/modules/Bots/playerbot/strategy/generic/DpsTanksTargetStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/generic/DpsTanksTargetStrategy.cpp
@@ -1,0 +1,13 @@
+#include "botpch.h"
+#include "../../playerbot.h"
+#include "DpsTanksTargetStrategy.h"
+
+using namespace ai;
+
+void DpsTanksTargetStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
+{
+    triggers.push_back(new TriggerNode(
+        "no tanks target active",
+        NextAction::array(0, new NextAction("attack tanks target", 50.0f), NULL)));
+}
+

--- a/src/modules/Bots/playerbot/strategy/generic/DpsTanksTargetStrategy.h
+++ b/src/modules/Bots/playerbot/strategy/generic/DpsTanksTargetStrategy.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "../generic/NonCombatStrategy.h"
+
+namespace ai
+{
+    class DpsTanksTargetStrategy : public NonCombatStrategy
+    {
+    public:
+        DpsTanksTargetStrategy(PlayerbotAI* ai) : NonCombatStrategy(ai) {}
+        virtual string getName() { return "dps tanks"; }
+        virtual int GetType() { return STRATEGY_TYPE_DPS; }
+        virtual void InitTriggers(std::list<TriggerNode*> &triggers);
+    };
+
+}

--- a/src/modules/Bots/playerbot/strategy/triggers/GenericTriggers.cpp
+++ b/src/modules/Bots/playerbot/strategy/triggers/GenericTriggers.cpp
@@ -214,6 +214,13 @@ bool NotLeastHpTargetActiveTrigger::IsActive()
     return leastHp && target != leastHp;
 }
 
+bool NoTanksTargetActiveTrigger::IsActive()
+{
+    Unit* tanksTarget = AI_VALUE(Unit*, "dps tanks target");
+    Unit* target = AI_VALUE(Unit*, "current target");
+    return tanksTarget && target != tanksTarget;
+}
+
 bool EnemyPlayerIsAttacking::IsActive()
 {
     Unit* enemyPlayer = AI_VALUE(Unit*, "enemy player target");

--- a/src/modules/Bots/playerbot/strategy/triggers/GenericTriggers.h
+++ b/src/modules/Bots/playerbot/strategy/triggers/GenericTriggers.h
@@ -563,6 +563,15 @@ namespace ai
         virtual bool IsActive();
     };
 
+    class NoTanksTargetActiveTrigger : public Trigger
+    {
+    public:
+        NoTanksTargetActiveTrigger(PlayerbotAI* ai) : Trigger(ai, "no tanks target active") {}
+
+    public:
+        virtual bool IsActive();
+    };
+
     class EnemyPlayerIsAttacking : public Trigger
     {
     public:
@@ -625,3 +634,4 @@ namespace ai
 #include "RangeTriggers.h"
 #include "HealthTriggers.h"
 #include "CureTriggers.h"
+

--- a/src/modules/Bots/playerbot/strategy/triggers/TriggerContext.h
+++ b/src/modules/Bots/playerbot/strategy/triggers/TriggerContext.h
@@ -49,6 +49,7 @@ namespace ai
             creators["no target"] = &TriggerContext::NoTarget;
             creators["target in sight"] = &TriggerContext::TargetInSight;
             creators["not least hp target active"] = &TriggerContext::not_least_hp_target_active;
+            creators["no tanks target active"] = &TriggerContext::no_tanks_target_active;
             creators["has nearest adds"] = &TriggerContext::has_nearest_adds;
             creators["enemy player is attacking"] = &TriggerContext::enemy_player_is_attacking;
 
@@ -142,6 +143,7 @@ namespace ai
         static Trigger* NoTarget(PlayerbotAI* ai) { return new NoTargetTrigger(ai); }
         static Trigger* TargetInSight(PlayerbotAI* ai) { return new TargetInSightTrigger(ai); }
         static Trigger* not_least_hp_target_active(PlayerbotAI* ai) { return new NotLeastHpTargetActiveTrigger(ai); }
+        static Trigger* no_tanks_target_active(PlayerbotAI* ai) { return new NoTanksTargetActiveTrigger(ai); }
         static Trigger* has_nearest_adds(PlayerbotAI* ai) { return new HasNearestAddsTrigger(ai); }
         static Trigger* enemy_player_is_attacking(PlayerbotAI* ai) { return new EnemyPlayerIsAttacking(ai); }
         static Trigger* Random(PlayerbotAI* ai) { return new RandomTrigger(ai); }

--- a/src/modules/Bots/playerbot/strategy/values/DpsTanksTargetValue.h
+++ b/src/modules/Bots/playerbot/strategy/values/DpsTanksTargetValue.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "../Value.h"
+#include "TargetValue.h"
+
+namespace ai
+{
+    class DpsTanksTargetValue : public TargetValue
+    {
+    public:
+        DpsTanksTargetValue(PlayerbotAI* ai) : TargetValue(ai) {}
+
+    public:
+        Unit* Calculate() override
+        {
+            Player* tank = ai->GetGroupTank(bot);
+            if (!tank)
+                return NULL;
+            return tank->getVictim();
+        }
+    };
+}

--- a/src/modules/Bots/playerbot/strategy/values/DpsTargetValue.h
+++ b/src/modules/Bots/playerbot/strategy/values/DpsTargetValue.h
@@ -11,6 +11,6 @@ namespace ai
         DpsTargetValue(PlayerbotAI* ai) : TargetValue(ai) {}
 
     public:
-        Unit* Calculate();
+        Unit* Calculate() override;
     };
 }

--- a/src/modules/Bots/playerbot/strategy/values/ValueContext.h
+++ b/src/modules/Bots/playerbot/strategy/values/ValueContext.h
@@ -54,6 +54,7 @@
 #include "LfgValues.h"
 #include "EnemyHealerTargetValue.h"
 #include "ItemUsageValue.h"
+#include "DpsTanksTargetValue.h"
 
 namespace ai
 {
@@ -79,6 +80,7 @@ namespace ai
             creators["tank target"] = &ValueContext::tank_target;
             creators["dps target"] = &ValueContext::dps_target;
             creators["least hp target"] = &ValueContext::least_hp_target;
+            creators["dps tanks target"] = &ValueContext::dps_tanks_target;
             creators["enemy player target"] = &ValueContext::enemy_player_target;
             creators["cc target"] = &ValueContext::cc_target;
             creators["current cc target"] = &ValueContext::current_cc_target;
@@ -207,6 +209,7 @@ namespace ai
         static UntypedValue* tank_target(PlayerbotAI* ai) { return new TankTargetValue(ai); }
         static UntypedValue* dps_target(PlayerbotAI* ai) { return new DpsTargetValue(ai); }
         static UntypedValue* least_hp_target(PlayerbotAI* ai) { return new LeastHpTargetValue(ai); }
+        static UntypedValue* dps_tanks_target(PlayerbotAI* ai) { return new DpsTanksTargetValue(ai); }
         static UntypedValue* enemy_player_target(PlayerbotAI* ai) { return new EnemyPlayerValue(ai); }
         static UntypedValue* cc_target(PlayerbotAI* ai) { return new CcTargetValue(ai); }
         static UntypedValue* current_cc_target(PlayerbotAI* ai) { return new CurrentCcTargetValue(ai); }


### PR DESCRIPTION
Adds a new DPS strategy for groups: "dps tanks" will cause DPS to only target whatever their group tank is targeting.  While not the most subtle, it is very predictable and easy to manage when leading a bot group as the tank, and is quickly becoming my favorite.  This is one of a few ideas I have for expanding dps targeting options.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/326)
<!-- Reviewable:end -->
