### PR TITLE
Creature backstab fix

### DIFF
--- a/src/game/Object/CreatureAI.cpp
+++ b/src/game/Object/CreatureAI.cpp
@@ -160,7 +160,7 @@ CanCastResult CreatureAI::DoCastSpellIfCan(Unit* pTarget, uint32 uiSpell, uint32
         pCaster = pTarget;
     }
 
-    if (uiSpell == 53 || uiSpell == 2589 || uiSpell == 7159) // All Backstab variants
+    if (uiSpell == 53 || uiSpell == 2589 || uiSpell == 7159 || uiSpell == 15657) // All Backstab variants
     {
         if (pTarget && pTarget->HasInArc(M_PI_F, pCaster))
         {


### PR DESCRIPTION
Fixes issue with npcs backstabbing players in the face while visible.  SpellID issue.
The constant backstabbing from the front seemed very wrong and made those npcs incredibly over-powered.
I'll leave it to you as to whether I'm correct in this.

REPRO: in the nw section of Arathi is a farmstead with stealthed rogue npcs.  Get one to attack you, then switch to the combat log to see the backstabs.
AFTER this fix, you'll find they only backstab you if you turn your back to them (or they manage to stealth in behind you).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/327)
<!-- Reviewable:end -->
