### PR TITLE
Grouped bots dont help patrollers

### DIFF
--- a/src/modules/Bots/playerbot/strategy/values/AttackersValue.cpp
+++ b/src/modules/Bots/playerbot/strategy/values/AttackersValue.cpp
@@ -89,11 +89,38 @@ void AttackersValue::RemoveNonThreating(set<Unit*>& targets)
 
 bool AttackersValue::hasRealThreat(Unit *attacker)
 {
-    return attacker &&
-        attacker->IsInWorld() &&
-        attacker->IsAlive() &&
-        !attacker->IsPolymorphed() &&
-        !attacker->IsInRoots() &&
-        !attacker->IsFriendlyTo(bot) &&
-        (attacker->GetThreatManager().getCurrentVictim() || attacker->GetObjectGuid().IsPlayer());
+    if (!attacker ||
+        !attacker->IsInWorld() ||
+        !attacker->IsAlive() ||
+        attacker->IsPolymorphed() ||
+        attacker->IsInRoots() ||
+        attacker->IsFriendlyTo(bot))
+        return false;
+
+    if (attacker->GetObjectGuid().IsPlayer())
+        return true;
+
+    Group* group = bot->GetGroup();
+    if (!group)
+        return attacker->GetThreatManager().getCurrentVictim() != nullptr;
+
+    Unit* victim = attacker->getVictim();
+    if (!victim)
+        return false;
+
+    if (victim == bot)
+        return true;
+
+    Player* master = GetMaster();
+    if (master && victim == master)
+        return true;
+
+    if (victim->GetObjectGuid().IsPlayer())
+    {
+        Player* victimPlayer = sObjectMgr.GetPlayer(victim->GetObjectGuid());
+        if (victimPlayer && victimPlayer->GetGroup() == group)
+            return true;
+    }
+
+    return false;
 }


### PR DESCRIPTION
When a bot is grouped, it should limit its willingness to assist to its fellow group members, and not to whatever random fight is going on around it.  This keeps grouped bots from jumping into any random fight happening nearby, while allowing ungrouped bots to continue doing so, or assist with escort quests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/328)
<!-- Reviewable:end -->
