### PR TITLE
Bots Arrive for Meeting Stone Clicks

### DIFF
--- a/src/game/WorldHandlers/LFGHandler.cpp
+++ b/src/game/WorldHandlers/LFGHandler.cpp
@@ -55,6 +55,11 @@
 #include "LFGHandler.h"
 #include "LFGMgr.h"
 
+#ifdef ENABLE_PLAYERBOTS
+#include "PlayerbotMgr.h"
+#include "RandomPlayerbotMgr.h"
+#endif
+
 /**
  * @brief Handle meeting stone join request (CMSG_MEETINGSTONE_JOIN)
  * @param recv_data World packet containing meeting stone GameObject GUID
@@ -120,6 +125,10 @@ void WorldSession::HandleMeetingStoneJoinOpcode(WorldPacket& recv_data)
     }
 
     GameObjectInfo const* gInfo = ObjectMgr::GetGameObjectInfo(obj->GetEntry());
+
+#ifdef ENABLE_PLAYERBOTS
+    sRandomPlayerbotMgr.HandleMeetingStoneClick(_player, obj);
+#endif
 
     sLFGMgr.AddToQueue(_player, gInfo->meetingstone.areaID);
 }

--- a/src/game/WorldHandlers/LFGMgr.h
+++ b/src/game/WorldHandlers/LFGMgr.h
@@ -108,7 +108,6 @@ class LFGQueue
 
             return playerRole;
         }
-
         RolesPriority getPriority(Classes playerClass, ClassRoles playerRoles);
 
     private:

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
@@ -12,6 +12,8 @@
 #include "GridDefines.h"
 #include "Map.h"
 #include "MapManager.h"
+#include "LFGMgr.h"
+#include "Group.h"
 
 INSTANTIATE_SINGLETON_1(RandomPlayerbotMgr);
 
@@ -1097,6 +1099,58 @@ Player* RandomPlayerbotMgr::GetRandomPlayer()
     return players[index];
 }
 
+ClassRoles RandomPlayerbotMgr::FillRoleMap(Player *bot, int &heal, int &dps, int &tank)
+{
+    int spec = AiFactory::GetPlayerSpecTab(bot);
+    switch (bot->getClass())
+    {
+    case CLASS_DRUID:
+        if (spec == 2)
+        {
+            heal++;
+            return LFG_ROLE_HEALER;
+        }
+        break;
+    case CLASS_PALADIN:
+        if (spec == 1)
+        {
+            tank++;
+            return LFG_ROLE_TANK;
+        }
+        else if (spec == 0)
+        {
+            heal++;
+            return LFG_ROLE_HEALER;
+        }
+        break;
+    case CLASS_PRIEST:
+        if (spec != 2)
+        {
+            heal++;
+            return LFG_ROLE_HEALER;
+        }
+        break;
+    case CLASS_SHAMAN:
+        if (spec == 2)
+        {
+            heal++;
+            return LFG_ROLE_HEALER;
+        }
+        break;
+    case CLASS_WARRIOR:
+        if (spec == 2)
+        {
+            tank++;
+            return LFG_ROLE_TANK;
+        }
+        break;
+    default:
+        break;
+    }
+    dps++;
+    return LFG_ROLE_DPS;
+}
+
 void RandomPlayerbotMgr::PrintStats()
 {
     sLog.outString("%d Random Bots online", playerBots.size());
@@ -1139,67 +1193,7 @@ void RandomPlayerbotMgr::PrintStats()
             active++;
         }
 
-        int spec = AiFactory::GetPlayerSpecTab(bot);
-        switch (bot->getClass())
-        {
-        case CLASS_DRUID:
-            if (spec == 2)
-            {
-                heal++;
-            }
-            else
-            {
-                dps++;
-            }
-            break;
-        case CLASS_PALADIN:
-            if (spec == 1)
-            {
-                tank++;
-            }
-            else if (spec == 0)
-            {
-                heal++;
-            }
-            else
-            {
-                dps++;
-            }
-            break;
-        case CLASS_PRIEST:
-            if (spec != 2)
-            {
-                heal++;
-            }
-            else
-            {
-                dps++;
-            }
-            break;
-        case CLASS_SHAMAN:
-            if (spec == 2)
-            {
-                heal++;
-            }
-            else
-            {
-                dps++;
-            }
-            break;
-        case CLASS_WARRIOR:
-            if (spec == 2)
-            {
-                tank++;
-            }
-            else
-            {
-                dps++;
-            }
-            break;
-        default:
-            dps++;
-            break;
-        }
+        FillRoleMap(bot, heal, dps, tank);
     }
 
     sLog.outString("Per level:");
@@ -1287,4 +1281,104 @@ uint32 RandomPlayerbotMgr::GetTradeDiscount(Player* bot)
 {
     Group* group = bot->GetGroup();
     return GetLootAmount(bot) / (group ? group->GetMembersCount() : 10);
+}
+
+void RandomPlayerbotMgr::HandleMeetingStoneClick(Player* player, GameObject* obj)
+{
+    if (!player || !obj)
+        return;
+
+    if (!sPlayerbotAIConfig.randomBotJoinLfg)
+        return;
+
+    Group* grp = player->GetGroup();
+    if (!grp || !grp->IsLeader(player->GetObjectGuid()))
+    {
+        return;
+    }
+
+    float stoneX, stoneY, stoneZ;
+    obj->GetPosition(stoneX, stoneY, stoneZ);
+    GameObjectInfo const* gInfo = ObjectMgr::GetGameObjectInfo(obj->GetEntry());
+    uint32 minLevel = gInfo->meetingstone.minLevel;
+    uint32 maxLevel = gInfo->meetingstone.maxLevel;
+
+    uint32 mapId = obj->GetMapId();
+    int healers = 0, tanks = 0, dpses = 0;
+    vector<ClassRoles> missingRoles = {LFG_ROLE_TANK, LFG_ROLE_HEALER, LFG_ROLE_DPS, LFG_ROLE_DPS, LFG_ROLE_DPS};
+    for (Group::member_citerator citr = grp->GetMemberSlots().begin();
+         citr != grp->GetMemberSlots().end(); ++citr)
+    {
+        Player* member = sObjectMgr.GetPlayer(citr->guid);
+        if(member)
+        {
+            ClassRoles role = FillRoleMap(member, healers, dpses, tanks);
+            auto it = find(missingRoles.begin(), missingRoles.end(), role);
+            if (it != missingRoles.end())
+                missingRoles.erase(it);
+
+            if (!member->GetPlayerbotAI() || member == player)
+                continue;
+
+            if (!player->IsWithinDistInMap(member, sPlayerbotAIConfig.sightDistance))
+            {
+                member->GetMotionMaster()->Clear();
+                member->TeleportTo(mapId, stoneX, stoneY, stoneZ, 0);
+            }
+        }
+    }
+
+    if (grp->IsFull())
+    {
+        return;
+    }
+
+    if (missingRoles.size() == 0)
+        return;
+
+    uint32 team = player->GetTeam();
+    std::list<Player*> eligibleBots;
+    for(uint32_t zoneChk : {player->GetZoneId(), -1u})
+    {
+        if (missingRoles.size() == 0)
+            break;
+        for (auto botit = GetPlayerBotsBegin(); botit != GetPlayerBotsEnd(); ++botit)
+        {
+            Player* bot = botit->second;
+            if (!bot || !bot->IsInWorld())
+                continue;
+            if (bot->GetGroup())
+                continue;
+            if (zoneChk != (uint32_t)-1 && bot->GetZoneId() != zoneChk)
+                continue;
+            if (bot->GetTeam() != team)
+                continue;
+            if(bot->getLevel() < minLevel || bot->getLevel() > maxLevel)
+                continue;
+
+            ClassRoles role = FillRoleMap(bot, healers, dpses, tanks);
+            auto it = find(missingRoles.begin(), missingRoles.end(), role);
+            if (it != missingRoles.end())
+            {
+                missingRoles.erase(it);
+                eligibleBots.push_back(bot);
+                if (missingRoles.size() == 0)
+                    break;
+            }
+        }
+    }
+
+    for (Player* bot : eligibleBots)
+    {
+        if (grp->IsFull())
+            break;
+
+        grp->AddMember(bot->GetObjectGuid(), bot->GetName(), GROUP_LFG);
+
+        if (PlayerbotAI* ai = bot->GetPlayerbotAI())
+            ai->SetMaster(player);
+
+        bot->GetMotionMaster()->Clear();
+        bot->TeleportTo(mapId, stoneX, stoneY, stoneZ, 0);
+    }
 }

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
@@ -4,6 +4,7 @@
 #include "Common.h"
 #include "PlayerbotAIBase.h"
 #include "PlayerbotMgr.h"
+#include "LFGMgr.h"
 #include <set>
 #include <unordered_map>
 
@@ -116,6 +117,14 @@ class RandomPlayerbotMgr : public PlayerbotHolder
         void PrintStats();
 
         /**
+         * @brief Fill stats for role of the given bot.
+         * @param heal number of healers.
+         * @param dps number of dps.
+         * @param tank number of tanks.
+         */
+        ClassRoles FillRoleMap(Player *bot, int &heal, int &dps, int &tank);
+
+        /**
          * @brief Gets the buy multiplier for the given player bot.
          * @param bot Pointer to the player bot.
          * @return The buy multiplier.
@@ -151,10 +160,22 @@ class RandomPlayerbotMgr : public PlayerbotHolder
         uint32 GetTradeDiscount(Player* bot);
 
         /**
+         * @brief Handles meeting stone click by a real player.
+         * @param player the player who clicked.
+         * @param obj the meeting stone clicked.
+         */
+        void HandleMeetingStoneClick(Player* player, GameObject* obj);
+
+        /**
          * @brief Refreshes the given player bot.
          * @param bot Pointer to the player bot.
          */
         void Refresh(Player* bot);
+
+        /**
+         * @brief Internal bot update tick method, exposed for manual updating.
+         * @param elapsed
+         */
         virtual void UpdateAIInternal(uint32 elapsed);
 
     protected:
@@ -231,7 +252,21 @@ class RandomPlayerbotMgr : public PlayerbotHolder
          * @return The level of the zone.
          */
         uint32 GetZoneLevel(uint32 mapId, float teleX, float teleY, float teleZ);
+
+        /**
+         * @brief Returns whether a zone loc is a good random choice for a given bot.
+         * @param bot the bot to check for
+         * @param mapId The map ID.
+         * @param teleX The X coordinate.
+         * @param teleY The Y coordinate.
+         * @param teleZ The Z coordinate.
+         * @return true if the zone is good for random teleport, false otherwise
+         */
         bool IsZoneSafeForBot(Player* bot, uint32 mapId, float x, float y, float z);
+
+        /**
+         * @brief Calculate creature stats for various areas, to be used for bot teleport.
+         */
         void CalculateAreaCreatureStats();
 
     private:


### PR DESCRIPTION
This implements a feature that the aiplayerbot.conf file suggested should exist, but didn't:
When a player clicks on a dungeon meeting stone, the system will attempt to fill out a 5-man group from available playerbots of appropriate levels and missing roles.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/330)
<!-- Reviewable:end -->
