### PR TITLE
Add observability logging for server hang diagnosis

### DIFF
--- a/src/game/Maps/MapUpdater.cpp
+++ b/src/game/Maps/MapUpdater.cpp
@@ -37,6 +37,7 @@
 #include "DelayExecutor.h"
 #include "Map.h"
 #include "DatabaseEnv.h"
+#include "Timer.h"
 
 #include <ace/Guard_T.h>
 #include <ace/Method_Request.h>
@@ -117,11 +118,18 @@ int MapUpdater::deactivate()
  */
 int MapUpdater::wait()
 {
-    ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, m_mutex, -1);
+    uint32 start = getMSTime();
+    {
+        ACE_GUARD_RETURN(ACE_Thread_Mutex, guard, m_mutex, -1);
 
-    while (pending_requests > 0)
-        m_condition.wait();
-
+        while (pending_requests > 0)
+            m_condition.wait();
+    }
+    uint32 waited = getMSTimeDiff(start, getMSTime());
+    if (waited > 1000)
+    {
+        sLog.outError("MapUpdater::wait() took %u ms", waited);
+    }
     return 0;
 }
 

--- a/src/mangosd/WorldThread.cpp
+++ b/src/mangosd/WorldThread.cpp
@@ -94,6 +94,12 @@ int WorldThread::svc()
 
         uint32 executionTimeDiff = getMSTimeDiff(realCurrTime, getMSTime());
 
+        if (executionTimeDiff > 1000)
+        {
+            sLog.outError("WorldThread::svc: sWorld.Update(diff=%u) took %u ms (loopCounter=%u, sessions=%u)",
+                          diff, executionTimeDiff, World::m_worldLoopCounter.value(), sWorld.GetActiveSessionCount());
+        }
+
         // we know exactly how long it took to update the world, if the update took less than WORLD_SLEEP_CONST, sleep for WORLD_SLEEP_CONST - world update time
         if (executionTimeDiff < WORLD_SLEEP_CONST)
         {

--- a/src/mangosd/mangosd.cpp
+++ b/src/mangosd/mangosd.cpp
@@ -561,7 +561,9 @@ int main(int argc, char** argv)
     //************************************************************************************************************************
     // 4. Start the freeze catcher thread
     //************************************************************************************************************************
-    AntiFreezeThread* freezeThread = new AntiFreezeThread(1000 * sConfig.GetIntDefault("MaxCoreStuckTime", 0));
+    uint32 stuckTime = sConfig.GetIntDefault("MaxCoreStuckTime", 0);
+    sLog.outString("AntiFreezeThread: MaxCoreStuckTime = %u, watchdog %s", stuckTime, stuckTime > 0 ? "ARMED" : "DISABLED");
+    AntiFreezeThread* freezeThread = new AntiFreezeThread(1000 * stuckTime);
     freezeThread->open(NULL);
 
     //************************************************************************************************************************

--- a/src/mangosd/mangosd.cpp
+++ b/src/mangosd/mangosd.cpp
@@ -554,7 +554,9 @@ int main(int argc, char** argv)
     //************************************************************************************************************************
     // 4. Start the freeze catcher thread
     //************************************************************************************************************************
-    AntiFreezeThread* freezeThread = new AntiFreezeThread(1000 * sConfig.GetIntDefault("MaxCoreStuckTime", 0));
+    uint32 stuckTime = sConfig.GetIntDefault("MaxCoreStuckTime", 0);
+    sLog.outString("AntiFreezeThread: MaxCoreStuckTime = %u, watchdog %s", stuckTime, stuckTime > 0 ? "ARMED" : "DISABLED");
+    AntiFreezeThread* freezeThread = new AntiFreezeThread(1000 * stuckTime);
     freezeThread->open(NULL);
 
     //************************************************************************************************************************

--- a/src/shared/Database/SqlDelayThread.cpp
+++ b/src/shared/Database/SqlDelayThread.cpp
@@ -35,6 +35,7 @@
 #include "Database/SqlDelayThread.h"
 #include "Database/SqlOperations.h"
 #include "DatabaseEnv.h"
+#include "Timer.h"
 
 /**
  * @brief Constructor for SqlDelayThread
@@ -96,7 +97,13 @@ void SqlDelayThread::run()
         // empty the queue before exiting
         ACE_Based::Thread::Sleep(loopSleepms);
 
+        uint32 start = getMSTime();
         ProcessRequests();
+        uint32 elapsed = getMSTimeDiff(start, getMSTime());
+        if (elapsed > 5000)
+        {
+            sLog.outError("SqlDelayThread: ProcessRequests took %u ms", elapsed);
+        }
 
         // Send periodic ping to keep connection alive
         if ((loopCounter++) >= pingEveryLoop)

--- a/src/shared/LockedQueue/LockedQueue.h
+++ b/src/shared/LockedQueue/LockedQueue.h
@@ -132,6 +132,17 @@ namespace ACE_Based
                 ACE_GUARD_RETURN (LockType, g, this->_lock, false);
                 return _queue.empty();
             }
+
+            /**
+             * @brief Returns the number of elements in the queue with locks held
+             *
+             * @return size_t
+             */
+            size_t size()
+            {
+                ACE_GUARD_RETURN (LockType, g, this->_lock, 0);
+                return _queue.size();
+            }
     };
 }
 #endif


### PR DESCRIPTION
## Summary

Adds low-risk observability logging to help diagnose MaNGOS Zero server hangs where `MaxCoreStuckTime` is armed but does not catch the bad state.

This is intentionally logging-only. It does not change world update behavior, map update behavior, DB behavior, shutdown behavior, or the existing AntiFreeze crash path.

## Changes

- Log `MaxCoreStuckTime` startup state clearly:
  - `watchdog ARMED` when `MaxCoreStuckTime > 0`
  - `watchdog DISABLED` when `MaxCoreStuckTime = 0`

- Log slow async DB delay-thread processing:
  - times `SqlDelayThread::ProcessRequests()`
  - logs if one processing cycle exceeds 5000 ms

- Add `LockedQueue::size()` using the existing lock/guard style
  - added for queue-depth diagnostics / follow-up instrumentation

- Log slow `MapUpdater::wait()` calls:
  - logs if wait exceeds 1000 ms
  - logging happens after the mutex guard is released

- Log slow world updates:
  - logs if `sWorld.Update(diff)` takes more than 1000 ms
  - includes `diff`, elapsed time, world loop counter, and active session count

## Non-goals

This PR does not:

- change watchdog crash behavior
- add a global heartbeat registry
- add network/reactor heartbeat logic
- add minidump / WER / crash-handler changes
- change shutdown behavior
- change gameplay behavior
- modify DB schema or submodules

## Why

The existing AntiFreeze watchdog only monitors `World::m_worldLoopCounter`. If the world loop continues ticking while another subsystem is unhealthy, or if the issue is outside the world thread, `MaxCoreStuckTime` may not fire.

These logs add signal around likely blind spots without changing behavior.

## Testing

- Built successfully on Windows:
  - `26 succeeded, 0 failed, 0 up-to-date, 0 skipped`

- Runtime smoke test:
  - confirmed startup log appears:
    - `AntiFreezeThread: MaxCoreStuckTime = 10, watchdog ARMED`
  - confirmed original AntiFreeze startup log still appears:
    - `AntiFreeze Thread started (10 seconds max stuck time)`
  - no false-positive `MapUpdater`, `WorldThread`, or `SqlDelayThread` slow logs observed during normal runtime smoke testing

## Notes

A permanently blocked DB call inside `ProcessRequests()` will not emit the slow-cycle log because the timing log only runs after `ProcessRequests()` returns. That case still requires an external dump/thread-stack capture or future heartbeat work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/331)
<!-- Reviewable:end -->
