### PR TITLE
Add shutdown progress observability logging

### DIFF
--- a/src/game/Maps/MapUpdater.cpp
+++ b/src/game/Maps/MapUpdater.cpp
@@ -108,8 +108,12 @@ int MapUpdater::activate(size_t num_threads)
  */
 int MapUpdater::deactivate()
 {
+    sLog.outString("[shutdown] MapUpdater::deactivate: draining pending map updates (pending=%zu)", pending_requests);
     wait();
-    return m_executor.deactivate();
+    sLog.outString("[shutdown] MapUpdater::deactivate: pending drained; joining worker threads");
+    int r = m_executor.deactivate();
+    sLog.outString("[shutdown] MapUpdater::deactivate: worker threads joined");
+    return r;
 }
 
 /**

--- a/src/game/WorldHandlers/MapManager.cpp
+++ b/src/game/WorldHandlers/MapManager.cpp
@@ -390,7 +390,9 @@ void MapManager::UnloadAll()
 
     if (m_updater.activated())
     {
+        sLog.outString("[shutdown] MapManager::UnloadAll: deactivating MapUpdater...");
         m_updater.deactivate();
+        sLog.outString("[shutdown] MapManager::UnloadAll: MapUpdater deactivated");
     }
 }
 

--- a/src/mangosd/WorldThread.cpp
+++ b/src/mangosd/WorldThread.cpp
@@ -117,11 +117,19 @@ int WorldThread::svc()
         }
 #endif
     }
+    sLog.outString("[shutdown] world loop stopped; entering world-thread shutdown tail");
+    sLog.outString("[shutdown] KickAll: saving + kicking players...");
     sWorld.KickAll();                                       // save and kick all players
+    sLog.outString("[shutdown] KickAll done");
+    sLog.outString("[shutdown] final UpdateSessions...");
     sWorld.UpdateSessions(1);                               // real players unload required UpdateSessions call
+    sLog.outString("[shutdown] final UpdateSessions done");
+    sLog.outString("[shutdown] StopNetwork: ending reactor + joining network threads...");
     sWorldSocketMgr->StopNetwork();
-
+    sLog.outString("[shutdown] StopNetwork done");
+    sLog.outString("[shutdown] UnloadAll: unloading maps + MapUpdater teardown...");
     sMapMgr.UnloadAll();                                    // unload all grids (including locked in memory)
+    sLog.outString("[shutdown] UnloadAll returned; world thread exiting");
 
     sLog.outString("World Updater Thread stopped");
     return 0;

--- a/src/mangosd/mangosd.cpp
+++ b/src/mangosd/mangosd.cpp
@@ -582,6 +582,7 @@ int main(int argc, char** argv)
     }
 
     worldThread->wait();
+    sLog.outString("[shutdown] worldThread->wait() returned (world thread joined)");
 
     if (cliThread)
     {
@@ -589,7 +590,9 @@ int main(int argc, char** argv)
         delete cliThread;
     }
 
+    sLog.outString("[shutdown] joining all ACE task threads (ACE_Thread_Manager::wait)...");
     ACE_Thread_Manager::instance()->wait();
+    sLog.outString("[shutdown] all ACE task threads joined");
     sLog.outString("Halting process...");
 
     ///- Stop freeze protection before shutdown tasks
@@ -618,14 +621,18 @@ int main(int argc, char** argv)
     sMassMailMgr.Update(true);
 
     ///- Wait for DB delay threads to end
+    sLog.outString("[shutdown] halting DB delay threads (Character/World/Login)...");
     CharacterDatabase.HaltDelayThread();
     WorldDatabase.HaltDelayThread();
     LoginDatabase.HaltDelayThread();
+    sLog.outString("[shutdown] DB delay threads halted");
 
     // This is done to make sure that we cleanup our so file before it's
     // unloaded automatically, since the ~ScriptMgr() is called to late
     // as it's allocated with static storage.
+    sLog.outString("[shutdown] unloading script library...");
     sScriptMgr.UnloadScriptLibrary();
+    sLog.outString("[shutdown] script library unloaded");
 
     ///- Exit the process with specified return value
     int code = World::GetExitCode();

--- a/src/shared/Threading/DelayExecutor.cpp
+++ b/src/shared/Threading/DelayExecutor.cpp
@@ -50,6 +50,7 @@
 #include <ace/Log_Msg.h>
 
 #include "DelayExecutor.h"
+#include "Log.h"
 
 /**
  * @brief Get singleton instance
@@ -96,9 +97,10 @@ int DelayExecutor::deactivate()
     }
 
     activated(false);
+    sLog.outString("[shutdown] DelayExecutor::deactivate: deactivating activation queue + joining workers...");
     queue_.queue()->deactivate();
     wait();
-
+    sLog.outString("[shutdown] DelayExecutor::deactivate: workers joined");
     return 0;
 }
 


### PR DESCRIPTION
## Summary

Adds shutdown progress logging to help diagnose cases where the server receives a shutdown request but does not exit cleanly.

This is intentionally observability-only. It does not change shutdown order, timeout behavior, thread joins, forced-exit behavior, WER/minidump handling, or gameplay behavior.

## Changes

Adds `[shutdown]` milestone logs around:

- world-thread shutdown tail
- `KickAll`
- final `UpdateSessions`
- `StopNetwork`
- `sMapMgr.UnloadAll`
- `MapManager::UnloadAll`
- `MapUpdater::deactivate`
- `DelayExecutor::deactivate`
- `worldThread->wait`
- global `ACE_Thread_Manager::instance()->wait`
- DB delay-thread halt
- script library unload

## Why

A captured old/pre-PR1 dump showed a shutdown hang where the process had not crashed, but remained alive during shutdown. The world thread and network/reactor threads were already gone, while the main thread was blocked in the final ACE thread-manager join.

These logs make future shutdown hangs diagnosable from the console/log tail by showing the last completed shutdown milestone.

## Testing

- `git diff --check`: PASS
- Static review: APPROVE
- Windows `RelWithDebInfo` build: PASS
- Ctrl+C shutdown smoke test: PASS
  - server reached normal startup
  - Ctrl+C triggered ordered `[shutdown]` progress lines
  - process exited cleanly

## Notes

Remaining WER-related warnings are unrelated to this PR and should be handled separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/333)
<!-- Reviewable:end -->
