### PR TITLE
Fix MSVC warnings in WheatyException

### DIFF
--- a/src/shared/Win/WheatyExceptionReport.cpp
+++ b/src/shared/Win/WheatyExceptionReport.cpp
@@ -929,7 +929,7 @@ char* WheatyExceptionReport::FormatOutputValue(char* pszCurrBuffer,
             if (!IsBadStringPtr(*(PSTR*)pAddress, 32))
             {
                 pszCurrBuffer += sprintf(pszCurrBuffer, " = \"%.31s\"",
-                                         *(PDWORD)pAddress);
+                                         *(PSTR*)pAddress);
             }
             else
                 pszCurrBuffer += sprintf(pszCurrBuffer, " = %X",

--- a/src/shared/Win/WheatyExceptionReport.h
+++ b/src/shared/Win/WheatyExceptionReport.h
@@ -27,12 +27,14 @@
 
 #include <dbghelp.h>
 
+#ifndef countof
 #if _MSC_VER < 1400
 #   define countof(array)   (sizeof(array) / sizeof(array[0]))
 #else
 #   include <stdlib.h>
 #   define countof  _countof
 #endif                                                      // _MSC_VER < 1400
+#endif                                                      // countof
 
 enum BasicType                                              // Stolen from CVCONST.H in the DIA 2.0 SDK
 {


### PR DESCRIPTION
## Summary

Fixes MSVC warnings exposed by re-enabling `WheatyExceptionReport`.

This is a narrow warning-cleanup PR. It does not change shutdown logging, crash-handler wiring, WER behavior, or unrelated code.

## Changes

- Fixes a `sprintf("%.31s", ...)` argument mismatch in `WheatyExceptionReport.cpp`
  - The code first validates the value using `IsBadStringPtr(*(PSTR*)pAddress, 32)`
  - The `sprintf` call now passes the same `char*` interpretation: `*(PSTR*)pAddress`

- Guards the local `countof` macro definition in `WheatyExceptionReport.h`
  - avoids redefining `countof` when it has already been provided by `Common.h`

## Testing

- `git diff --check`: PASS
- Windows `RelWithDebInfo` build: PASS
- Confirmed removed warnings:
  - `C4477` at `WheatyExceptionReport.cpp`
  - `C4313` at `WheatyExceptionReport.cpp`
  - `C4005` at `WheatyExceptionReport.h`

## Notes

No broad `sprintf` / `sprintf_s` refactor was done. This PR only fixes the warnings directly produced by the recently re-enabled WER crash-handler code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/334)
<!-- Reviewable:end -->
