### PR TITLE
Fix/realmd auth log hardening

### DIFF
--- a/src/shared/Win/WheatyExceptionReport.cpp
+++ b/src/shared/Win/WheatyExceptionReport.cpp
@@ -929,7 +929,7 @@ char* WheatyExceptionReport::FormatOutputValue(char* pszCurrBuffer,
             if (!IsBadStringPtr(*(PSTR*)pAddress, 32))
             {
                 pszCurrBuffer += sprintf(pszCurrBuffer, " = \"%.31s\"",
-                                         *(PDWORD)pAddress);
+                                         *(PSTR*)pAddress);
             }
             else
                 pszCurrBuffer += sprintf(pszCurrBuffer, " = %X",

--- a/src/shared/Win/WheatyExceptionReport.h
+++ b/src/shared/Win/WheatyExceptionReport.h
@@ -27,12 +27,14 @@
 
 #include <dbghelp.h>
 
+#ifndef countof
 #if _MSC_VER < 1400
 #   define countof(array)   (sizeof(array) / sizeof(array[0]))
 #else
 #   include <stdlib.h>
 #   define countof  _countof
 #endif                                                      // _MSC_VER < 1400
+#endif                                                      // countof
 
 enum BasicType                                              // Stolen from CVCONST.H in the DIA 2.0 SDK
 {


### PR DESCRIPTION
## Summary

Updates the `src/realmd` submodule pointer to include auth logging hardening.

The realmd change removes SRP6 verifier/salt values from debug logs and escapes the client-provided OS field before SQL use.

## Dependency order

Merge the `mangos/realmd` PR first, then this parent submodule pointer update.

## Testing

- Windows `RelWithDebInfo` `realmd` target build: PASS
- No new warnings

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/335)
<!-- Reviewable:end -->
