### PR TITLE
Add Windows console title & connection status

### DIFF
--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -109,6 +109,8 @@ struct ClientPktHeader
 #pragma pack(pop)
 #endif
 
+std::atomic<uint32> WorldSocket::s_openConnections{0};
+
 /**
  * @brief WorldSocket constructor
  *
@@ -133,6 +135,7 @@ WorldSocket::WorldSocket(void) :
     m_Seed(rand32())
 {
     reference_counting_policy().value(ACE_Event_Handler::Reference_Counting_Policy::ENABLED);
+    s_openConnections.fetch_add(1, std::memory_order_relaxed);
 }
 
 /**
@@ -158,6 +161,7 @@ WorldSocket::~WorldSocket(void)
     {
         delete pct;
     }
+    s_openConnections.fetch_sub(1, std::memory_order_relaxed);
 }
 
 /**

--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -109,7 +109,9 @@ struct ClientPktHeader
 #pragma pack(pop)
 #endif
 
+#ifdef _WIN32
 std::atomic<uint32> WorldSocket::s_openConnections{0};
+#endif
 
 /**
  * @brief WorldSocket constructor
@@ -135,7 +137,9 @@ WorldSocket::WorldSocket(void) :
     m_Seed(rand32())
 {
     reference_counting_policy().value(ACE_Event_Handler::Reference_Counting_Policy::ENABLED);
+#ifdef _WIN32
     s_openConnections.fetch_add(1, std::memory_order_relaxed);
+#endif
 }
 
 /**
@@ -161,7 +165,9 @@ WorldSocket::~WorldSocket(void)
     {
         delete pct;
     }
+#ifdef _WIN32
     s_openConnections.fetch_sub(1, std::memory_order_relaxed);
+#endif
 }
 
 /**

--- a/src/game/Server/WorldSocket.h
+++ b/src/game/Server/WorldSocket.h
@@ -48,6 +48,7 @@
 
 #include "Common.h"
 #include "Auth/AuthCrypt.h"
+#include <atomic>
 
 class ACE_Message_Block;
 class WorldPacket;
@@ -125,6 +126,9 @@ class WorldSocket : protected WorldHandler
 
         /// Remove reference to this object.
         long RemoveReference(void);
+
+        /// Number of currently open world TCP socket connections (observability).
+        static uint32 GetOpenConnectionCount() { return s_openConnections.load(std::memory_order_relaxed); }
 
     protected:
         /// things called by ACE framework.
@@ -214,6 +218,9 @@ class WorldSocket : protected WorldHandler
         PacketQueueT m_PacketQueue;
 
         const uint32 m_Seed;
+
+        /// Live count of constructed WorldSocket objects (open connections). Observability only.
+        static std::atomic<uint32> s_openConnections;
 };
 
 #endif  /* _WORLDSOCKET_H */

--- a/src/game/Server/WorldSocket.h
+++ b/src/game/Server/WorldSocket.h
@@ -48,7 +48,9 @@
 
 #include "Common.h"
 #include "Auth/AuthCrypt.h"
+#ifdef _WIN32
 #include <atomic>
+#endif
 
 class ACE_Message_Block;
 class WorldPacket;
@@ -127,8 +129,10 @@ class WorldSocket : protected WorldHandler
         /// Remove reference to this object.
         long RemoveReference(void);
 
+#ifdef _WIN32
         /// Number of currently open world TCP socket connections (observability).
         static uint32 GetOpenConnectionCount() { return s_openConnections.load(std::memory_order_relaxed); }
+#endif
 
     protected:
         /// things called by ACE framework.
@@ -219,8 +223,10 @@ class WorldSocket : protected WorldHandler
 
         const uint32 m_Seed;
 
+#ifdef _WIN32
         /// Live count of constructed WorldSocket objects (open connections). Observability only.
         static std::atomic<uint32> s_openConnections;
+#endif
 };
 
 #endif  /* _WORLDSOCKET_H */

--- a/src/mangosd/WorldThread.cpp
+++ b/src/mangosd/WorldThread.cpp
@@ -48,6 +48,23 @@
 #ifdef WIN32
 #include "ServiceWin32.h"
 extern int m_ServiceStatus;
+#include <windows.h>
+#endif
+
+#ifdef _WIN32
+/// Update the console title with current player/connection counts, only if changed.
+static void UpdateConsoleTitle(uint32 players, uint32 connections)
+{
+    static std::string s_lastTitle;
+    char title[128];
+    snprintf(title, sizeof(title), "MaNGOS Zero (%u Players - %u Connections)", players, connections);
+    std::string newTitle(title);
+    if (s_lastTitle != newTitle)
+    {
+        s_lastTitle = newTitle;
+        SetConsoleTitleA(title);
+    }
+}
 #endif
 
 /**
@@ -91,6 +108,15 @@ int WorldThread::svc()
 
         sWorld.Update(diff);
         realPrevTime = realCurrTime;
+
+#ifdef _WIN32
+        static uint32 titleUpdateCounter = 0;
+        if ((++titleUpdateCounter) >= 60) // ~3 seconds at WORLD_SLEEP_CONST=50ms
+        {
+            titleUpdateCounter = 0;
+            UpdateConsoleTitle(sWorld.GetActiveSessionCount(), WorldSocket::GetOpenConnectionCount());
+        }
+#endif
 
         uint32 executionTimeDiff = getMSTimeDiff(realCurrTime, getMSTime());
 

--- a/src/mangosd/WorldThread.cpp
+++ b/src/mangosd/WorldThread.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "Common.h"
+#include "SystemConfig.h"
 #include "WorldSocket.h"
 #include "WorldSocketMgr.h"
 #include "World.h"
@@ -57,7 +58,7 @@ static void UpdateConsoleTitle(uint32 players, uint32 connections)
 {
     static std::string s_lastTitle;
     char title[128];
-    snprintf(title, sizeof(title), "MaNGOS Zero (%u Players - %u Connections)", players, connections);
+    snprintf(title, sizeof(title), "%s (%u Players - %u Connections)", MANGOS_PACKAGENAME, players, connections);
     std::string newTitle(title);
     if (s_lastTitle != newTitle)
     {


### PR DESCRIPTION
## Summary

Adds Windows console title status for `mangosd` and updates the `realmd` submodule for matching console title support.

`mangosd` title format:

`MaNGOS Zero (<players> Players - <connections> Connections)`

`realmd` title format:

`MaNGOS Realm-Daemon (<authWaiting> Auth/Waiting - <connections> Connections)`

## Details

- Adds an atomic `WorldSocket` connection counter.
- Shows active world sessions via `sWorld.GetActiveSessionCount()`.
- Updates the Windows console title approximately every 3 seconds.
- Caches the last title and only calls `SetConsoleTitleA` when values change.
- Updates `src/realmd` to the matching console-title implementation.

## Testing

- `git diff --check`: PASS
- Windows build: PASS
- Smoke test: PASS
  - `realmd` showed `1 Auth/Waiting - 1 Connections` during login/realm list
  - `realmd` returned to `0 Auth/Waiting - 0 Connections` after world handoff
  - `mangosd` showed `1 Players - 1 Connections` in world
  - Ctrl+C/shutdown smoke test passed

## Notes

Windows-only UI/observability change. No gameplay, network, auth, DB, or logging behavior changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/337)
<!-- Reviewable:end -->
