### PR TITLE
Harden mangosd auth logging around verifier data

### DIFF
--- a/src/game/Server/WorldSocket.cpp
+++ b/src/game/Server/WorldSocket.cpp
@@ -821,9 +821,9 @@ int WorldSocket::HandleAuthSession(WorldPacket& recvPacket)
     const char* sStr = s.AsHexStr();                        // Must be freed by OPENSSL_free()
     const char* vStr = v.AsHexStr();                        // Must be freed by OPENSSL_free()
 
-    DEBUG_LOG("WorldSocket::HandleAuthSession: (s,v) check s: %s v: %s",
-              sStr,
-              vStr);
+    DEBUG_LOG("WorldSocket::HandleAuthSession: (s,v) present: s=%s v=%s",
+              sStr && *sStr ? "yes" : "no",
+              vStr && *vStr ? "yes" : "no");
 
     OPENSSL_free((void*) sStr);
     OPENSSL_free((void*) vStr);


### PR DESCRIPTION
## Summary

Removes raw SRP6 verifier/salt material from `mangosd` debug auth logging.

## Changes

- Replaces the debug log that printed raw `s` and `v` hex strings with presence-only logging.
- Keeps diagnostic value (`s=yes/no`, `v=yes/no`) without writing credential-equivalent verifier material to disk.

## Why

The SRP6 verifier is credential-equivalent material for offline password guessing if logs are exposed. The matching `realmd` auth log was already hardened; this applies the same pattern to the `mangosd` world-auth path.

## Testing

- `git diff --check`: PASS
- Build: not run / or fill in your build result
- No auth logic, control flow, protocol behavior, or OpenSSL cleanup changed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/338)
<!-- Reviewable:end -->
