### PR TITLE
Add LivingWorld startup observability summary

### DIFF
--- a/src/game/WorldHandlers/MapManager.cpp
+++ b/src/game/WorldHandlers/MapManager.cpp
@@ -562,11 +562,19 @@ BattleGroundMap* MapManager::CreateBattleGroundMap(uint32 id, uint32 InstanceId,
     return map;
 }
 
+// Temporary startup accumulator for LivingWorld observability (written during LoadContinents only)
+static MapManager::LivingWorldStartupStats s_livingWorldStats;
+static bool s_livingWorldStartupPass = false;
+
 /**
  * @brief Ensures the main continent maps are loaded.
  */
-void MapManager::LoadContinents()
+MapManager::LivingWorldStartupStats MapManager::LoadContinents()
 {
+    // Reset startup accumulator before continent creation
+    s_livingWorldStats = MapManager::LivingWorldStartupStats();
+    s_livingWorldStartupPass = true;
+
     uint32 continents[] = {0, 1, 369};
     Map* _map = NULL;
 
@@ -585,7 +593,8 @@ void MapManager::LoadContinents()
         }
     }
 
-    return;
+    s_livingWorldStartupPass = false;
+    return s_livingWorldStats;
 }
 
 /**
@@ -595,17 +604,44 @@ void MapManager::LoadContinents()
  */
 void MapManager::LoadActiveEntities(Map* m)
 {
-
     // Create all local transporters for this map
     m->LoadLocalTransports();
 
+    uint32 localTransportCount = uint32(m->GetLocalTransports().size());
+
+    bool forceLoad = sWorld.isForceLoadMap(m->GetId());
+
+    uint32 forceLoadRequests = 0;
+    uint32 uniqueGridCount = 0;
+    uint32 newlyLoaded = 0;
+    uint32 alreadyLoaded = 0;
+
+    std::set<std::pair<uint32, uint32>> uniqueGrids;
+
+    // Count active-creature GUIDs present on this map (extra-active, NOT the load driver on force-load maps)
+    uint32 activeCreatureGuids = 0;
+    {
+        std::pair<ActiveCreatureGuidsOnMap::const_iterator, ActiveCreatureGuidsOnMap::const_iterator> activeBounds = sObjectMgr.GetActiveCreatureGuids()->equal_range(m->GetId());
+        for (ActiveCreatureGuidsOnMap::const_iterator itr = activeBounds.first; itr != activeBounds.second; ++itr)
+            ++activeCreatureGuids;
+    }
+
     // Load grids for all objects on this map, if configured so
-    if (sWorld.isForceLoadMap(m->GetId()))
+    if (forceLoad)
     {
         for (CreatureDataMap::const_iterator itr = sObjectMgr.GetCreatureDataMap()->begin(); itr != sObjectMgr.GetCreatureDataMap()->end(); ++itr)
         {
             if (itr->second.mapid == m->GetId())
             {
+                ++forceLoadRequests;
+                GridPair gridPair = MaNGOS::ComputeGridPair(itr->second.posX, itr->second.posY);
+                uniqueGrids.insert(std::make_pair(gridPair.x_coord, gridPair.y_coord));
+
+                if (m->IsLoaded(itr->second.posX, itr->second.posY))
+                    ++alreadyLoaded;
+                else
+                    ++newlyLoaded;
+
                 m->ForceLoadGrid(itr->second.posX, itr->second.posY);
             }
         }
@@ -616,7 +652,41 @@ void MapManager::LoadActiveEntities(Map* m)
         for (ActiveCreatureGuidsOnMap::const_iterator itr = bounds.first; itr != bounds.second; ++itr)
         {
             CreatureData const* data = sObjectMgr.GetCreatureData(itr->second);
+            ++forceLoadRequests;
+            GridPair gridPair = MaNGOS::ComputeGridPair(data->posX, data->posY);
+            uniqueGrids.insert(std::make_pair(gridPair.x_coord, gridPair.y_coord));
+
+            if (m->IsLoaded(data->posX, data->posY))
+                ++alreadyLoaded;
+            else
+                ++newlyLoaded;
+
             m->ForceLoadGrid(data->posX, data->posY);
+        }
+    }
+
+    uniqueGridCount = uint32(uniqueGrids.size());
+
+    // Only emit startup summary and accumulate totals during the LoadContinents startup pass
+    if (s_livingWorldStartupPass)
+    {
+        // Accumulate to startup totals
+        s_livingWorldStats.totalUniqueGrids += uniqueGridCount;
+        s_livingWorldStats.totalNewlyLoaded += newlyLoaded;
+        s_livingWorldStats.totalLocalTransports += localTransportCount;
+        if (forceLoad)
+            ++s_livingWorldStats.forcedMaps;
+
+        // Per-map summary (O(1) log volume)
+        if (forceLoad)
+        {
+            sLog.outString("[LivingWorld] map %u: force-load=ON, creature-rows=%u, ForceLoadGrid-requests=%u, unique-grids=%u, newly-loaded=%u (explicit-locks-set), already-loaded=%u, extra-active-creatures=%u, local-transports=%u",
+                           m->GetId(), forceLoadRequests, forceLoadRequests, uniqueGridCount, newlyLoaded, alreadyLoaded, activeCreatureGuids, localTransportCount);
+        }
+        else
+        {
+            sLog.outString("[LivingWorld] map %u: force-load=OFF, extra-active-creatures=%u, ForceLoadGrid-requests=%u, unique-grids=%u, newly-loaded=%u (explicit-locks-set), already-loaded=%u, local-transports=%u",
+                           m->GetId(), activeCreatureGuids, forceLoadRequests, uniqueGridCount, newlyLoaded, alreadyLoaded, localTransportCount);
         }
     }
 }

--- a/src/game/WorldHandlers/MapManager.cpp
+++ b/src/game/WorldHandlers/MapManager.cpp
@@ -623,7 +623,9 @@ void MapManager::LoadActiveEntities(Map* m)
     {
         std::pair<ActiveCreatureGuidsOnMap::const_iterator, ActiveCreatureGuidsOnMap::const_iterator> activeBounds = sObjectMgr.GetActiveCreatureGuids()->equal_range(m->GetId());
         for (ActiveCreatureGuidsOnMap::const_iterator itr = activeBounds.first; itr != activeBounds.second; ++itr)
+        {
             ++activeCreatureGuids;
+        }
     }
 
     // Load grids for all objects on this map, if configured so
@@ -638,9 +640,13 @@ void MapManager::LoadActiveEntities(Map* m)
                 uniqueGrids.insert(std::make_pair(gridPair.x_coord, gridPair.y_coord));
 
                 if (m->IsLoaded(itr->second.posX, itr->second.posY))
+                {
                     ++alreadyLoaded;
+                }
                 else
+                {
                     ++newlyLoaded;
+                }
 
                 m->ForceLoadGrid(itr->second.posX, itr->second.posY);
             }
@@ -657,9 +663,13 @@ void MapManager::LoadActiveEntities(Map* m)
             uniqueGrids.insert(std::make_pair(gridPair.x_coord, gridPair.y_coord));
 
             if (m->IsLoaded(data->posX, data->posY))
+            {
                 ++alreadyLoaded;
+            }
             else
+            {
                 ++newlyLoaded;
+            }
 
             m->ForceLoadGrid(data->posX, data->posY);
         }
@@ -675,7 +685,9 @@ void MapManager::LoadActiveEntities(Map* m)
         s_livingWorldStats.totalNewlyLoaded += newlyLoaded;
         s_livingWorldStats.totalLocalTransports += localTransportCount;
         if (forceLoad)
+        {
             ++s_livingWorldStats.forcedMaps;
+        }
 
         // Per-map summary (O(1) log volume)
         if (forceLoad)

--- a/src/game/WorldHandlers/MapManager.h
+++ b/src/game/WorldHandlers/MapManager.h
@@ -140,7 +140,15 @@ class MapManager : public MaNGOS::Singleton<MapManager, MaNGOS::ClassLevelLockab
 
         void RemoveAllObjectsInRemoveList();
 
-        void LoadContinents();
+        struct LivingWorldStartupStats
+        {
+            uint32 forcedMaps = 0;
+            uint32 totalUniqueGrids = 0;
+            uint32 totalNewlyLoaded = 0;
+            uint32 totalLocalTransports = 0;
+        };
+
+        LivingWorldStartupStats LoadContinents();
         void LoadTransports();
 
         typedef std::set<Transport*> TransportSet;

--- a/src/game/WorldHandlers/World.cpp
+++ b/src/game/WorldHandlers/World.cpp
@@ -1558,7 +1558,11 @@ void World::SetInitialWorldSettings()
     sLog.outString();
 
     sLog.outString("Loading grids for active creatures and local transports...");
-    sMapMgr.LoadContinents();
+    uint32 loadContinentsBegin = getMSTime();
+    MapManager::LivingWorldStartupStats lwStats = sMapMgr.LoadContinents();
+    uint32 loadContinentsMs = GetMSTimeDiffToNow(loadContinentsBegin);
+    sLog.outString("[LivingWorld] startup summary: maps-forced=%u, total-unique-grids=%u, total-newly-loaded=%u, total-local-transports=%u, LoadContinents=%u ms",
+                   lwStats.forcedMaps, lwStats.totalUniqueGrids, lwStats.totalNewlyLoaded, lwStats.totalLocalTransports, loadContinentsMs);
     sLog.outString();
 
     sLog.outString("Loading global transports...");


### PR DESCRIPTION
## Summary

Adds a bounded `[LivingWorld]` startup summary for the existing active-grid loading paths.

This helps show why grids are being loaded at startup, including configured force-loaded maps, extra-active creatures, unique grids, newly-loaded vs already-loaded grids, and local transports.

## Scope

Observability only.

No behavior changes, DB changes, config changes, GM commands, lease/activity-manager work, NPC classification changes, `ForceLoadGrid` signature changes, or `GridStates` logging.

## Verification

* `git diff --check`: clean
* Build: `game` PASS, `mangosd` PASS
* Smoke tested with `LoadAllGridsOnMaps = ""`

  * startup summary appears once
  * no per-grid/per-creature `[LivingWorld]` spam
  * runtime login/teleport/fresh map creation stays quiet
* Smoke tested with `LoadAllGridsOnMaps = "0"`

  * force-load summary appears
  * 24,034 map-0 `ForceLoadGrid` requests summarized without loop spam
  * counters are internally consistent
  * runtime paths stay quiet

Example output:

```text
[LivingWorld] map 0: force-load=ON, creature-rows=24034, ForceLoadGrid-requests=24034, unique-grids=322, newly-loaded=322 (explicit-locks-set), already-loaded=23712, extra-active-creatures=1, local-transports=14
[LivingWorld] startup summary: maps-forced=1, total-unique-grids=323, total-newly-loaded=323, total-local-transports=29, LoadContinents=4962 ms
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/339)
<!-- Reviewable:end -->
