### PR TITLE
Add NPC watch diagnostic command

### DIFF
--- a/src/game/ChatCommands/CreatureCommands.cpp
+++ b/src/game/ChatCommands/CreatureCommands.cpp
@@ -1219,8 +1219,8 @@ bool ChatHandler::HandleNpcWatchCommand(char* /*args*/)
     CellPair cellPair = MaNGOS::ComputeCellPair(x, y);
     bool gridLoaded = target->GetMap()->IsLoaded(x, y);     // read-only: does NOT load the grid
 
-    PSendSysMessage("[LivingWorld] watch %s (entry %u) \"%s\"",
-                    target->GetGuidStr().c_str(), target->GetEntry(), target->GetName());
+    PSendSysMessage("[LivingWorld] watch %s \"%s\"",
+                    target->GetGuidStr().c_str(), target->GetName());
     PSendSysMessage("  map=%u instance=%u", target->GetMapId(), target->GetInstanceId());
     PSendSysMessage("  pos x=%.3f y=%.3f z=%.3f o=%.3f", x, y, z, o);
     PSendSysMessage("  grid[%u,%u] cell[%u,%u] grid-loaded=%s",

--- a/src/game/ChatCommands/CreatureCommands.cpp
+++ b/src/game/ChatCommands/CreatureCommands.cpp
@@ -1191,6 +1191,72 @@ bool ChatHandler::HandleNpcChangeEntryCommand(char* args)
 }
 
 /**
+ * @brief Handler for the .npc watch command (LivingWorld diagnostic, Phase 1).
+ *
+ * Read-only, one-shot snapshot of the currently selected creature. Inspects already-loaded
+ * state only via in-memory getters; performs no grid load, no map creation, and no
+ * movement/combat/AI/grid-state mutation.
+ *
+ * @param args Unused.
+ * @returns True on success; false (with the select-creature error) when nothing is selected.
+ */
+bool ChatHandler::HandleNpcWatchCommand(char* /*args*/)
+{
+    Creature* target = getSelectedCreature();
+    if (!target)
+    {
+        SendSysMessage(LANG_SELECT_CREATURE);
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    float x = target->GetPositionX();
+    float y = target->GetPositionY();
+    float z = target->GetPositionZ();
+    float o = target->GetOrientation();
+
+    GridPair gridPair = MaNGOS::ComputeGridPair(x, y);
+    CellPair cellPair = MaNGOS::ComputeCellPair(x, y);
+    bool gridLoaded = target->GetMap()->IsLoaded(x, y);     // read-only: does NOT load the grid
+
+    PSendSysMessage("[LivingWorld] watch %s (entry %u) \"%s\"",
+                    target->GetGuidStr().c_str(), target->GetEntry(), target->GetName());
+    PSendSysMessage("  map=%u instance=%u", target->GetMapId(), target->GetInstanceId());
+    PSendSysMessage("  pos x=%.3f y=%.3f z=%.3f o=%.3f", x, y, z, o);
+    PSendSysMessage("  grid[%u,%u] cell[%u,%u] grid-loaded=%s",
+                    gridPair.x_coord, gridPair.y_coord, cellPair.x_coord, cellPair.y_coord,
+                    gridLoaded ? "yes" : "no");
+    PSendSysMessage("  in-world=%s active-object=%s",
+                    target->IsInWorld() ? "yes" : "no",
+                    target->IsActiveObject() ? "yes" : "no");
+    PSendSysMessage("  movement-generator-type=%u in-combat=%s combat-timer=%u",
+                    uint32(target->GetMotionMaster()->GetCurrentMovementGeneratorType()),
+                    target->IsInCombat() ? "yes" : "no",
+                    target->GetCombatTimer());
+
+    if (Unit* victim = target->getVictim())
+    {
+        PSendSysMessage("  victim=%s", victim->GetGuidStr().c_str());
+    }
+    else
+    {
+        SendSysMessage("  victim=none");
+    }
+
+    ObjectGuid const& watchTargetGuid = target->GetTargetGuid();
+    if (!watchTargetGuid.IsEmpty())
+    {
+        PSendSysMessage("  target=%s", watchTargetGuid.GetString().c_str());
+    }
+    else
+    {
+        SendSysMessage("  target=none");
+    }
+
+    return true;
+}
+
+/**
  * @brief Handler for HandleNpcInfoCommand command.
  *
  * @param args Command arguments.

--- a/src/game/WorldHandlers/Chat.cpp
+++ b/src/game/WorldHandlers/Chat.cpp
@@ -463,6 +463,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "say",            SEC_MODERATOR,      false, &ChatHandler::HandleNpcSayCommand,              "", NULL },
         { "textemote",      SEC_MODERATOR,      false, &ChatHandler::HandleNpcTextEmoteCommand,        "", NULL },
         { "unfollow",       SEC_GAMEMASTER,     false, &ChatHandler::HandleNpcUnFollowCommand,         "", NULL },
+        { "watch",          SEC_GAMEMASTER,     false, &ChatHandler::HandleNpcWatchCommand,            "", NULL },
         { "whisper",        SEC_MODERATOR,      false, &ChatHandler::HandleNpcWhisperCommand,          "", NULL },
         { "yell",           SEC_MODERATOR,      false, &ChatHandler::HandleNpcYellCommand,             "", NULL },
         { "tame",           SEC_GAMEMASTER,     false, &ChatHandler::HandleNpcTameCommand,             "", NULL },

--- a/src/game/WorldHandlers/Chat.h
+++ b/src/game/WorldHandlers/Chat.h
@@ -434,6 +434,7 @@ class ChatHandler
         bool HandleNpcFlagCommand(char* args);
         bool HandleNpcFollowCommand(char* args);
         bool HandleNpcInfoCommand(char* args);
+        bool HandleNpcWatchCommand(char* args);
         bool HandleNpcMoveCommand(char* args);
         bool HandleNpcPlayEmoteCommand(char* args);
         bool HandleNpcSayCommand(char* args);


### PR DESCRIPTION
## Summary

Adds `.npc watch`, a read-only in-game GM diagnostic command for inspecting the currently selected creature.

The command reports a one-shot snapshot of the selected creature’s map, position, grid/cell, loaded/active state, movement generator, combat state, victim, and target.

## Scope

Diagnostic only.

Phase 1 is intentionally selected-creature only:

- no explicit GUID lookup
- no nearby/grid traversal
- no timers
- no DB/config changes
- no leases or activity manager
- no grid loading
- no movement/combat/AI mutation

The command is in-game only and is not available from console/RA.

## Verification

- `git diff --check`: clean
- Build: `game` PASS, `mangosd` PASS
- Branch contains only one commit on top of `master`:
  - `91ca5b85 Add NPC watch diagnostic command`
- Changed files only:
  - `src/game/ChatCommands/CreatureCommands.cpp`
  - `src/game/WorldHandlers/Chat.cpp`
  - `src/game/WorldHandlers/Chat.h`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/340)
<!-- Reviewable:end -->
