### PR TITLE
fix to intentional switch fall-through

### DIFF
--- a/src/game/Object/Object.cpp
+++ b/src/game/Object/Object.cpp
@@ -396,7 +396,8 @@ void Object::BuildMovementUpdate(ByteBuffer* data, uint8 updateFlags) const
             {
                 ((Unit*)this)->m_movementInfo.RemoveMovementFlag(MOVEFLAG_ONTRANSPORT);
             }
-            break;
+
+        // fall through to TYPEID_UNIT — unit must be set for UPDATEFLAG_LIVING
         case TYPEID_UNIT:
             unit = static_cast<Unit const*>(this);
             moveflags = unit->m_movementInfo.GetMovementFlags();


### PR DESCRIPTION
Fixes a crash where the unit reference and the moveflags weren't being set, causing the MAGOS_ASSERT to crash the server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/344)
<!-- Reviewable:end -->
