### PR TITLE
Fix to seal of righteousness (and others?)

### DIFF
--- a/src/game/Object/SpellMgr.h
+++ b/src/game/Object/SpellMgr.h
@@ -241,7 +241,7 @@ bool IsNoStackAuraDueToAura(uint32 spellId_1, uint32 spellId_2);
 inline bool IsSealSpell(SpellEntry const* spellInfo)
 {
     // Collection of all the seal family flags. No other paladin spell has any of those.
-    return spellInfo->IsFitToFamily(SPELLFAMILY_PALADIN, UI64LIT(0x000000000A000200));
+    return spellInfo->IsFitToFamily(SPELLFAMILY_PALADIN, UI64LIT(0x0000000008000200));
 }
 
 inline bool IsElementalShield(SpellEntry const* spellInfo)

--- a/src/game/WorldHandlers/SpellAuras.cpp
+++ b/src/game/WorldHandlers/SpellAuras.cpp
@@ -6458,6 +6458,10 @@ void Aura::HandlePreventFleeing(bool apply, bool Real)
             GetTarget()->SetFeared(true, first->GetCasterGuid(), first->GetId());
         }
     }
+    else if (apply && GetTarget()->HasFlag(UNIT_FIELD_FLAGS, UNIT_FLAG_FLEEING))
+    {
+        GetTarget()->SetFeared(false, GetCasterGuid());
+    }
 }
 
 /**

--- a/src/game/WorldHandlers/SpellEffects.cpp
+++ b/src/game/WorldHandlers/SpellEffects.cpp
@@ -4822,7 +4822,7 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
                 int32 spellid = m_spellInfo->Id;            // send main spell id as basepoints for not used effect
                 m_caster->CastCustomSpell(unitTarget, 19993, &heal, &spellid, NULL, true);
             }
-            else if (m_spellInfo->SpellFamilyFlags & UI64LIT(0x0000000000800000))
+            else if (m_spellInfo->SpellIconID == 205)
             {
                 if (!unitTarget || !unitTarget->IsAlive())
                 {
@@ -4843,8 +4843,16 @@ void Spell::EffectScriptEffect(SpellEffectIndex eff_idx)
                         continue;
                     }
 
-                    // must be calculated base at raw base points in spell proto, GetModifier()->m_value for S.Righteousness modified by SPELLMOD_DAMAGE
-                    spellId2 = (*itr)->GetSpellProto()->CalculateSimpleValue((SpellEffectIndex)(*itr)->GetEffIndex());
+                    SpellEntry const* sealInfo = (*itr)->GetSpellProto();
+                    for (int32 eff = EFFECT_INDEX_0; eff < MAX_EFFECT_INDEX; ++eff)
+                    {
+                        uint32 val = sealInfo->CalculateSimpleValue(SpellEffectIndex(eff));
+                        if (val > 10000)
+                        {
+                            spellId2 = val;
+                            break;
+                        }
+                    }
 
                     if (spellId2 <= 1)
                     {


### PR DESCRIPTION
This fixes Seal of Righteousness judgements not applying any instant damage.  I also confirmed Seal of Crusader still works fine.  This change probably also fixes other seals I never saw problems with because I never used them.  So, after making this change, I confirmed that Seals of Light and Wisdom also seem to work as advertised.  Seal of Justice also had a bug in the handling of the no-flee aura, so that fix is also included here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/345)
<!-- Reviewable:end -->
