### PR TITLE
Cache random bot status

### DIFF
--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
@@ -576,12 +576,19 @@ void RandomPlayerbotMgr::Refresh(Player* bot)
 
 bool RandomPlayerbotMgr::IsRandomBot(Player* bot)
 {
-    return IsRandomBot(bot->GetObjectGuid());
+    if (!bot) return false;
+    return IsRandomBot(bot->GetGUIDLow());
 }
 
 bool RandomPlayerbotMgr::IsRandomBot(uint32 bot)
 {
-    return GetEventValue(bot, "add");
+    std::unordered_map<uint32, bool>::iterator it = m_randomBotCache.find(bot);
+    if (it != m_randomBotCache.end())
+        return it->second;
+
+    bool value = (GetEventValue(bot, "add") != 0);
+    m_randomBotCache[bot] = value;
+    return value;
 }
 
 list<uint32> RandomPlayerbotMgr::GetBots()
@@ -835,6 +842,9 @@ uint32 RandomPlayerbotMgr::SetEventValue(uint32 bot, string event, uint32 value,
                 "INSERT INTO `ai_playerbot_random_bots` (`owner`, `bot`, `time`, `validIn`, `event`, `value`) VALUES ('%u', '%u', '%u', '%u', '%s', '%u')",
             0, bot, (uint32)time(0), validIn, event.c_str(), value);
     }
+
+    if (event == "add")
+        m_randomBotCache[bot] = (value != 0);
 
     return value;
 }

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
@@ -275,6 +275,7 @@ class RandomPlayerbotMgr : public PlayerbotHolder
         set<uint32> m_groupedBots; ///< Cached set of bot GUIDs currently in a group, refreshed each update cycle.
         std::map<uint32, AreaCreatureStats> m_areaCreatureStatsMap;
         std::map<std::pair<uint32, uint32>, uint32> m_cellToAreaCache;
+        std::unordered_map<uint32, bool> m_randomBotCache;
         std::unordered_map<uint32, uint32> m_playerZoneCounts; ///< zone_id -> real player count, for O(1) bot tick gating.
 };
 


### PR DESCRIPTION
Looking up the 'random bot' status was a bit of a hot-spot that really pounded on the DB.  This adds a cache to fix this, and dropped my mangosd cpu usage with bots considerably.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/346)
<!-- Reviewable:end -->
