### PR TITLE
Fix to ah item selection

### DIFF
--- a/src/game/AuctionHouseBot/AuctionHouseBot.cpp
+++ b/src/game/AuctionHouseBot/AuctionHouseBot.cpp
@@ -1900,15 +1900,17 @@ bool AuctionBotSeller::Initialize()
                     {
                         continue;
                     }
-                    if (uint32 value = sAuctionBotConfig.getConfig(CONFIG_UINT32_AHBOT_CLASS_TRADEGOOD_MAX_ITEM_LEVEL))
+                }
+
+                if (uint32 value = sAuctionBotConfig.getConfig(CONFIG_UINT32_AHBOT_CLASS_TRADEGOOD_MAX_ITEM_LEVEL))
+                {
+                    if (prototype->ItemLevel > value)
                     {
-                        if (prototype->ItemLevel > value)
-                        {
-                            continue;
-                        }
-                        break;
+                        continue;
                     }
                 }
+
+                break;
             }
             case ITEM_CLASS_CONTAINER:
             case ITEM_CLASS_QUIVER:
@@ -1919,15 +1921,17 @@ bool AuctionBotSeller::Initialize()
                     {
                         continue;
                     }
-                    if (uint32 value = sAuctionBotConfig.getConfig(CONFIG_UINT32_AHBOT_CLASS_CONTAINER_MAX_ITEM_LEVEL))
+                }
+
+                if (uint32 value = sAuctionBotConfig.getConfig(CONFIG_UINT32_AHBOT_CLASS_CONTAINER_MAX_ITEM_LEVEL))
+                {
+                    if (prototype->ItemLevel > value)
                     {
-                        if (prototype->ItemLevel > value)
-                        {
-                            continue;
-                        }
-                        break;
+                        continue;
                     }
                 }
+
+                break;
             }
 
             default:


### PR DESCRIPTION
Fixes bug introduced by if condition re-scoping that prevented the level check, restoring the original logic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/349)
<!-- Reviewable:end -->
