### PR TITLE
Bot "pull" command

### DIFF
--- a/src/modules/Bots/CMakeLists.txt
+++ b/src/modules/Bots/CMakeLists.txt
@@ -133,6 +133,8 @@ set(BOT_SRCS
     playerbot/strategy/actions/PassLeadershipToMasterAction.h
     playerbot/strategy/actions/PositionAction.cpp
     playerbot/strategy/actions/PositionAction.h
+    playerbot/strategy/actions/PullActions.cpp
+    playerbot/strategy/actions/PullActions.h
     playerbot/strategy/actions/QueryItemUsageAction.cpp
     playerbot/strategy/actions/QueryItemUsageAction.h
     playerbot/strategy/actions/QueryQuestAction.cpp
@@ -140,6 +142,7 @@ set(BOT_SRCS
     playerbot/strategy/actions/QuestAction.cpp
     playerbot/strategy/actions/QuestAction.h
     playerbot/strategy/actions/ReachTargetActions.h
+    playerbot/strategy/actions/ReachTargetActions.cpp
     playerbot/strategy/actions/ReadyCheckAction.cpp
     playerbot/strategy/actions/ReadyCheckAction.h
     playerbot/strategy/actions/ReleaseSpiritAction.h
@@ -374,6 +377,8 @@ set(BOT_SRCS
     playerbot/strategy/paladin/PaladinTriggers.h
     playerbot/strategy/paladin/TankPaladinStrategy.cpp
     playerbot/strategy/paladin/TankPaladinStrategy.h
+    playerbot/strategy/StrategyMultiplier.cpp
+    playerbot/strategy/StrategyMultiplier.h
     playerbot/strategy/PassiveMultiplier.cpp
     playerbot/strategy/PassiveMultiplier.h
     playerbot/strategy/priest/GenericPriestStrategy.cpp
@@ -543,6 +548,8 @@ set(BOT_SRCS
     playerbot/strategy/values/SpellCastUsefulValue.h
     playerbot/strategy/values/SpellIdValue.cpp
     playerbot/strategy/values/SpellIdValue.h
+    playerbot/strategy/values/SpellRangeValue.cpp
+    playerbot/strategy/values/SpellRangeValue.h
     playerbot/strategy/values/StatsValues.cpp
     playerbot/strategy/values/StatsValues.h
     playerbot/strategy/values/TankTargetValue.cpp

--- a/src/modules/Bots/playerbot/PlayerbotAI.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAI.cpp
@@ -541,14 +541,19 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
         {
             WorldPacket p(packet);
             p.rpos(0);
-            uint8 status, result;
-            p >> status >> result;
+            uint32 spellId;
+            p >> spellId;
+            uint8 result = SPELL_CAST_OK;
+            if (p.size() >= 6) // failure packet has status + result bytes
+            {
+                uint8 status;
+                p >> status >> result;
+            }
             if (result != SPELL_CAST_OK)
             {
-                LastSpellCast& lastSpell = aiObjectContext->GetValue<LastSpellCast&>("last spell cast")->Get();
-                SpellInterrupted(lastSpell.id);
-                botOutgoingPacketHandlers.AddPacket(packet);
+                SpellInterrupted(spellId);
             }
+            botOutgoingPacketHandlers.AddPacket(packet);
             return;
         }
         case SMSG_SPELL_FAILURE:
@@ -589,6 +594,7 @@ void PlayerbotAI::HandleBotOutgoingPacket(const WorldPacket& packet)
         }
         default:
             botOutgoingPacketHandlers.AddPacket(packet);
+            break;
     }
 }
 
@@ -1455,7 +1461,9 @@ bool PlayerbotAI::CastSpell(uint32 spellId, Unit* target)
     MotionMaster &mm = *bot->GetMotionMaster();
     if (bot->isMoving() && GetSpellCastTime(pSpellInfo, NULL))
     {
-        return false;
+        // bot wants to cast, but mm is still active; don't reject, just STOP!
+        bot->StopMoving(false);
+        mm.MoveIdle();
     }
 
     if (bot->IsTaxiFlying())

--- a/src/modules/Bots/playerbot/strategy/Action.h
+++ b/src/modules/Bots/playerbot/strategy/Action.h
@@ -102,9 +102,12 @@ namespace ai
             {
                 verbose = true;
             }
+            void SetPersistenceStartTime(uint32 time) { m_persistStart = time; }
+            uint32 GetPersistenceStartTime() { return m_persistStart; }
 
         protected:
             bool verbose;
+            uint32 m_persistStart = 0;
     };
 
     class ActionNode
@@ -131,7 +134,14 @@ namespace ai
                 return action;
             }
 
-            void setAction(Action* action) { this->action = action; }
+            void setAction(Action* action)
+            {
+                this->action = action;
+                if (action && isPersistent())
+                {
+                    action->SetPersistenceStartTime(0);
+                }
+            }
             string getName()
             {
                 return name;
@@ -153,12 +163,40 @@ namespace ai
                 return NextAction::merge(NextAction::clone(prerequisites), action ? action->getPrerequisites() : NULL);
             }
 
+    public:
+            ActionNode* persist(uint32 timeoutMs)
+            {
+                m_persistTimeout = timeoutMs;
+                if (action)
+                {
+                    action->SetPersistenceStartTime(0);
+                }
+                return this;
+            }
+            bool isPersistent() const
+            {
+                return m_persistTimeout > 0;
+            }
+            bool hasPersistTimedOut()
+            {
+                if (!isPersistent())
+                {
+                    return false;
+                }
+                if (action->GetPersistenceStartTime() == 0)
+                {
+                    action->SetPersistenceStartTime(getMSTime());
+                }
+                return getMSTimeDiff(action->GetPersistenceStartTime(), getMSTime()) >= m_persistTimeout;
+            }
+
         private:
             string name;
             Action* action;
             NextAction** continuers;
             NextAction** alternatives;
             NextAction** prerequisites;
+            uint32 m_persistTimeout = 0;
     };
 
     //---------------------------------------------------------------------------------------------------------------------

--- a/src/modules/Bots/playerbot/strategy/Engine.cpp
+++ b/src/modules/Bots/playerbot/strategy/Engine.cpp
@@ -209,8 +209,17 @@ bool Engine::DoNextAction(Unit* unit, int depth)
 
                     if (actionExecuted)
                     {
-                        LogAction("A:%s - OK", action->getName().c_str());
-                        MultiplyAndPush(actionNode->getContinuers(), 0, false, event);
+                        if (actionNode->isPersistent() && action->isUseful() &&
+                            !actionNode->hasPersistTimedOut())
+                        {
+                            LogAction("A:%s - OK - REPUSH", action->getName().c_str());
+                            PushAgain(actionNode, relevance, event);
+                        }
+                        else
+                        {
+                            LogAction("A:%s - OK", action->getName().c_str());
+                            MultiplyAndPush(actionNode->getContinuers(), 0, false, event);
+                        }
                         lastRelevance = relevance;
                         break;
                     }

--- a/src/modules/Bots/playerbot/strategy/StrategyContext.h
+++ b/src/modules/Bots/playerbot/strategy/StrategyContext.h
@@ -38,6 +38,7 @@
 #include "generic/MoveRandomStrategy.h"
 #include "generic/CautiousStrategy.h"
 #include "generic/DpsTanksTargetStrategy.h"
+#include "generic/PullStrategy.h"
 
 namespace ai
 {
@@ -67,6 +68,7 @@ namespace ai
                 creators["pvp"] = &StrategyContext::pvp;
                 creators["move random"] = &StrategyContext::move_random;
                 creators["cautious"] = &StrategyContext::cautious;
+                creators["wait for pull"] = &StrategyContext::wait_for_pull;
             }
 
         private:
@@ -91,6 +93,7 @@ namespace ai
             static Strategy* pvp(PlayerbotAI* ai) { return new AttackEnemyPlayersStrategy(ai); }
             static Strategy* move_random(PlayerbotAI* ai) { return new MoveRandomStrategy(ai); }
             static Strategy* cautious(PlayerbotAI* ai) { return new CautiousStrategy(ai); }
+            static Strategy* wait_for_pull(PlayerbotAI* ai) { return new WaitForPullStrategy(ai); }
     };
 
     class MovementStrategyContext : public NamedObjectContext<Strategy>

--- a/src/modules/Bots/playerbot/strategy/StrategyMultiplier.cpp
+++ b/src/modules/Bots/playerbot/strategy/StrategyMultiplier.cpp
@@ -1,0 +1,50 @@
+#include "../../botpch.h"
+#include "../playerbot.h"
+#include "StrategyMultiplier.h"
+#include "Strategy.h"
+
+using namespace ai;
+
+StrategyMultiplier::StrategyMultiplier(PlayerbotAI* ai, Strategy* strategy) : Multiplier(ai, "strategy")
+{
+    if (!strategy)
+    {
+        return;
+    }
+
+    NextAction** defaultActions = strategy->getDefaultActions();
+    if (!defaultActions)
+    {
+        return;
+    }
+
+    for (int i = 0; defaultActions[i]; ++i)
+    {
+        allowedActions.push_back(defaultActions[i]->getName());
+    }
+    NextAction::destroy(defaultActions);
+
+    allowedActions.push_back("co");
+    allowedActions.push_back("nc");
+    allowedActions.push_back("reset ai");
+
+}
+
+float StrategyMultiplier::GetValue(Action* action)
+{
+    if (!action)
+    {
+        return 1.0f;
+    }
+
+    string name = action->getName();
+    for (list<string>::iterator i = allowedActions.begin(); i != allowedActions.end(); i++)
+    {
+        if (name == *i)
+        {
+            return 1.0f;
+        }
+    }
+    return 0;
+}
+

--- a/src/modules/Bots/playerbot/strategy/StrategyMultiplier.h
+++ b/src/modules/Bots/playerbot/strategy/StrategyMultiplier.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "Multiplier.h"
+#include "Action.h"
+
+namespace ai
+{
+    class Strategy;
+
+    class StrategyMultiplier : public Multiplier
+    {
+        public:
+            StrategyMultiplier(PlayerbotAI* ai, Strategy* strategy);
+            void AddAction(string name)
+            {
+                allowedActions.push_back(name);
+            }
+            virtual float GetValue(Action* action);
+        protected:
+            list<string> allowedActions;
+    };
+}

--- a/src/modules/Bots/playerbot/strategy/actions/ActionContext.h
+++ b/src/modules/Bots/playerbot/strategy/actions/ActionContext.h
@@ -13,6 +13,7 @@
 #include "SuggestWhatToDoAction.h"
 #include "PositionAction.h"
 #include "AttackAction.h"
+#include "PullActions.h"
 
 namespace ai
 {
@@ -25,12 +26,14 @@ namespace ai
                 creators["melee"] = &ActionContext::melee;
                 creators["reach spell"] = &ActionContext::ReachSpell;
                 creators["reach melee"] = &ActionContext::ReachMelee;
+                creators["ranged pull"] = &ActionContext::ranged_pull;
                 creators["flee"] = &ActionContext::flee;
                 creators["gift of the naaru"] = &ActionContext::gift_of_the_naaru;
                 creators["shoot"] = &ActionContext::shoot;
                 creators["lifeblood"] = &ActionContext::lifeblood;
                 creators["arcane torrent"] = &ActionContext::arcane_torrent;
                 creators["end pull"] = &ActionContext::end_pull;
+                creators["end wait for pull"] = &ActionContext::end_wait_for_pull;
                 creators["healthstone"] = &ActionContext::healthstone;
                 creators["healing potion"] = &ActionContext::healing_potion;
                 creators["bandage"] = &ActionContext::bandage;
@@ -44,10 +47,14 @@ namespace ai
                 creators["add loot"] = &ActionContext::add_loot;
                 creators["add gathering loot"] = &ActionContext::add_gathering_loot;
                 creators["add all loot"] = &ActionContext::add_all_loot;
-                creators["shoot"] = &ActionContext::shoot;
+                creators["shoot bow"] = &ActionContext::shoot_bow;
+                creators["shoot gun"] = &ActionContext::shoot_gun;
+                creators["shoot crossbow"] = &ActionContext::shoot_crossbow;
+                creators["throw"] = &ActionContext::throw_action;
                 creators["follow line"] = &ActionContext::follow_line;
                 creators["follow"] = &ActionContext::follow_master;
                 creators["follow master"] = &ActionContext::follow_master;
+                creators["reach master"] = &ActionContext::reach_master;
                 creators["be near"] = &ActionContext::follow_master_random;
                 creators["runaway"] = &ActionContext::runaway;
                 creators["stay"] = &ActionContext::stay;
@@ -70,6 +77,10 @@ namespace ai
                 creators["drop target"] = &ActionContext::drop_target;
                 creators["jump"] = &ActionContext::jump;
                 creators["back off"] = &ActionContext::back_off;
+                creators["watch target approach"] = &ActionContext::watch_target_approach;
+                creators["start pull"] = &ActionContext::start_pull;
+                creators["watch group pull"] = &ActionContext::watch_group_pull;
+                creators["reach shoot range"] = &ActionContext::reach_shoot_range;
             }
 
         private:
@@ -79,7 +90,12 @@ namespace ai
             static Action* open_loot(PlayerbotAI* ai) { return new OpenLootAction(ai); }
             static Action* move_to_loot(PlayerbotAI* ai) { return new MoveToLootAction(ai); }
             static Action* move_random(PlayerbotAI* ai) { return new MoveRandomAction(ai); }
-            static Action* shoot(PlayerbotAI* ai) { return new CastShootAction(ai); }
+            static Action* shoot(PlayerbotAI* ai) { return new CastSpellAction(ai, "shoot"); }
+            static Action* ranged_pull(PlayerbotAI* ai) { return new RangedPullAction(ai); }
+            static Action* shoot_bow(PlayerbotAI* ai) { return new CastSpellAction(ai, "shoot bow"); }
+            static Action* shoot_gun(PlayerbotAI* ai) { return new CastSpellAction(ai, "shoot gun"); }
+            static Action* shoot_crossbow(PlayerbotAI* ai) { return new CastSpellAction(ai, "shoot crossbow"); }
+            static Action* throw_action(PlayerbotAI* ai) { return new CastSpellAction(ai, "throw"); }
             static Action* melee(PlayerbotAI* ai) { return new MeleeAction(ai); }
             static Action* ReachSpell(PlayerbotAI* ai) { return new ReachSpellAction(ai); }
             static Action* ReachMelee(PlayerbotAI* ai) { return new ReachMeleeAction(ai); }
@@ -89,6 +105,7 @@ namespace ai
             static Action* lifeblood(PlayerbotAI* ai) { return new CastLifeBloodAction(ai); }
             static Action* arcane_torrent(PlayerbotAI* ai) { return new CastArcaneTorrentAction(ai); }
             static Action* end_pull(PlayerbotAI* ai) { return new ChangeCombatStrategyAction(ai, "-pull"); }
+            static Action* end_wait_for_pull(PlayerbotAI* ai) { return new ChangeCombatStrategyAction(ai, "-wait for pull"); }
 
             static Action* emote(PlayerbotAI* ai) { return new EmoteAction(ai); }
             static Action* suggest_what_to_do(PlayerbotAI* ai) { return new SuggestWhatToDoAction(ai); }
@@ -103,6 +120,7 @@ namespace ai
             static Action* runaway(PlayerbotAI* ai) { return new RunAwayAction(ai); }
             static Action* follow_master_random(PlayerbotAI* ai) { return new FollowMasterRandomAction(ai); }
             static Action* follow_master(PlayerbotAI* ai) { return new FollowMasterAction(ai); }
+            static Action* reach_master(PlayerbotAI* ai) { return new ReachMasterAction(ai); }
             static Action* follow_line(PlayerbotAI* ai) { return new FollowLineAction(ai); }
             static Action* add_gathering_loot(PlayerbotAI* ai) { return new AddGatheringLootAction(ai); }
             static Action* add_loot(PlayerbotAI* ai) { return new AddLootAction(ai); }
@@ -120,6 +138,10 @@ namespace ai
             static Action* move_out_of_enemy_contact(PlayerbotAI* ai) { return new MoveOutOfEnemyContactAction(ai); }
             static Action* set_facing(PlayerbotAI* ai) { return new SetFacingTargetAction(ai); }
             static Action* jump(PlayerbotAI* ai) { return new JumpAction(ai); }
+            static Action* watch_target_approach(PlayerbotAI* ai) { return new WatchTargetApproachAction(ai); }
+            static Action* watch_group_pull(PlayerbotAI* ai) { return new WatchGroupPullAction(ai); }
+            static Action* start_pull(PlayerbotAI* ai) { return new StartPullAction(ai); }
+            static Action* reach_shoot_range(PlayerbotAI* ai) { return new ReachShootRangeAction(ai); }
 
     };
 };

--- a/src/modules/Bots/playerbot/strategy/actions/AttackAction.h
+++ b/src/modules/Bots/playerbot/strategy/actions/AttackAction.h
@@ -26,6 +26,25 @@ namespace ai
             virtual bool Execute(Event event);
     };
 
+    class PullMyTargetAction : public AttackMyTargetAction
+    {
+        public:
+            PullMyTargetAction(PlayerbotAI* ai, string name = "pull my target") : AttackMyTargetAction(ai, name) {}
+
+        public:
+            virtual bool Execute(Event event)
+            {
+                MakeVerbose();
+                ai->ChangeStrategy("+pull", BOT_STATE_COMBAT);
+                if (!AttackMyTargetAction::Execute(event))
+                {
+                    ai->ChangeStrategy("-pull", BOT_STATE_COMBAT);
+                    return false;
+                }
+                return true;
+            }
+    };
+
     class AttackDuelOpponentAction : public AttackAction
     {
         public:

--- a/src/modules/Bots/playerbot/strategy/actions/ChatActionContext.h
+++ b/src/modules/Bots/playerbot/strategy/actions/ChatActionContext.h
@@ -86,6 +86,7 @@ namespace ai
                 creators["dead"] = &ChatActionContext::dead;
                 creators["trainer"] = &ChatActionContext::trainer;
                 creators["attack my target"] = &ChatActionContext::attack_my_target;
+                creators["pull my target"] = &ChatActionContext::pull_my_target;
                 creators["chat"] = &ChatActionContext::chat;
                 creators["home"] = &ChatActionContext::home;
                 creators["destroy"] = &ChatActionContext::destroy;
@@ -140,6 +141,7 @@ namespace ai
             static Action* home(PlayerbotAI* ai) { return new SetHomeAction(ai); }
             static Action* chat(PlayerbotAI* ai) { return new ChangeChatAction(ai); }
             static Action* attack_my_target(PlayerbotAI* ai) { return new AttackMyTargetAction(ai); }
+            static Action* pull_my_target(PlayerbotAI* ai) { return new PullMyTargetAction(ai); }
             static Action* trainer(PlayerbotAI* ai) { return new TrainerAction(ai); }
             static Action* co(PlayerbotAI* ai) { return new ChangeCombatStrategyAction(ai); }
             static Action* nc(PlayerbotAI* ai) { return new ChangeNonCombatStrategyAction(ai); }

--- a/src/modules/Bots/playerbot/strategy/actions/FollowActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/FollowActions.cpp
@@ -15,6 +15,27 @@ bool FollowMasterAction::Execute(Event event)
     return Follow(AI_VALUE(Unit*, "master target"));
 }
 
+bool FollowMasterAction::isUseful()
+{
+    return (AI_VALUE2(float, "distance", "master target") > sPlayerbotAIConfig.followDistance && !AI_VALUE(bool, "can loot")) ||
+        transportBoardingDelayTime > 0;
+}
+
+bool ReachMasterAction::Execute(Event event)
+{
+    if (!FollowMasterAction::Execute(event))
+    {
+        return false;
+    }
+    return isUseful();
+}
+bool ReachMasterAction::isUseful()
+{
+    return (AI_VALUE2(float, "distance", "master target") - 2.0 > sPlayerbotAIConfig.followDistance &&
+            AI_VALUE2(float, "distance", "master target") < sPlayerbotAIConfig.reactDistance) ||
+                transportBoardingDelayTime > 0;
+}
+
 bool FollowMasterRandomAction::Execute(Event event)
 {
     Player* master = GetMaster();

--- a/src/modules/Bots/playerbot/strategy/actions/FollowActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/FollowActions.h
@@ -18,15 +18,16 @@ namespace ai
 
     class FollowMasterAction : public MovementAction {
         public:
-            FollowMasterAction(PlayerbotAI* ai) : MovementAction(ai, "follow master") {}
+            FollowMasterAction(PlayerbotAI* ai, string name="follow master") : MovementAction(ai, name) {}
             virtual bool Execute(Event event);
+            virtual bool isUseful();
+    };
 
-            virtual bool isUseful()
-            {
-                return AI_VALUE2(float, "distance", "master target") > sPlayerbotAIConfig.followDistance &&
-                    !AI_VALUE(bool, "can loot") || transportBoardingDelayTime > 0;
-            }
-
+    class ReachMasterAction : public FollowMasterAction {
+        public:
+            ReachMasterAction(PlayerbotAI* ai) : FollowMasterAction(ai, "reach master") {}
+            virtual bool Execute(Event event);
+            virtual bool isUseful();
     };
 
     class FollowMasterRandomAction : public MovementAction {

--- a/src/modules/Bots/playerbot/strategy/actions/GenericSpellActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/GenericSpellActions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../Action.h"
+#include "../AiObjectContext.h"
 #include "../../PlayerbotAIConfig.h"
 
 #define BEGIN_SPELL_ACTION(clazz, name) \
@@ -49,23 +50,7 @@ namespace ai
             {
                 this->spell = spell;
                 // Clamp range to actual spell's min/max range from DBC
-                uint32 spellId = AI_VALUE2(uint32, "spell id", spell);
-                if (spellId)
-                {
-                    const SpellEntry* pSpellInfo = sSpellStore.LookupEntry(spellId);
-                    if (pSpellInfo)
-                    {
-                        SpellRangeEntry const* spellRange = sSpellRangeStore.LookupEntry(pSpellInfo->rangeIndex);
-                        if (spellRange)
-                        {
-                            float actualMaxRange = GetSpellMaxRange(spellRange);
-                            if (actualMaxRange > 0)  // Only clamp if spell has a defined range
-                            {
-                                range = actualMaxRange;
-                            }
-                        }
-                    }
-                }
+                range = AI_VALUE2(float, "spell range", spell);
             }
 
             virtual string GetTargetName()
@@ -314,15 +299,6 @@ namespace ai
 
     //---------------------------------------------------------------------------------------------------------------------
 
-    class CastShootAction : public CastSpellAction
-    {
-        public:
-            CastShootAction(PlayerbotAI* ai) : CastSpellAction(ai, "shoot") {}
-            virtual ActionThreatType getThreatType()
-            {
-                return ACTION_THREAT_NONE;
-            }
-    };
 
     class CastLifeBloodAction : public CastHealingSpellAction
     {

--- a/src/modules/Bots/playerbot/strategy/actions/PullActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/PullActions.cpp
@@ -1,0 +1,168 @@
+#include "botpch.h"
+#include "../../playerbot.h"
+#include "PullActions.h"
+#include "ReachTargetActions.h"
+
+using namespace ai;
+
+bool WatchTargetApproachAction::Execute(Event event)
+{
+    bot->StopMoving();
+    return isUseful();
+}
+
+void WatchTargetApproachAction::Reset()
+{
+    context->GetValue<float>("last target position")->Set(0);
+}
+
+bool WatchTargetApproachAction::isUseful()
+{
+    Unit* target = GetTarget();
+    if (target == bot)
+    {
+        target = context->GetValue<Unit*>("old target")->Get();
+        context->GetValue<Unit*>("current target")->Set(target);
+    }
+    if (!target || !target->IsAlive())
+    {
+        Reset();
+        return false;
+    }
+    float lastDistance = context->GetValue<float>("last target position")->Get();
+    if (lastDistance == 0)
+    {
+        lastDistance = sPlayerbotAIConfig.sightDistance + sPlayerbotAIConfig.meleeDistance;
+        context->GetValue<float>("last target position")->Set(lastDistance);
+    }
+
+    float currentDistance = bot->GetDistance(target);
+    if (currentDistance <= sPlayerbotAIConfig.meleeDistance ||
+      currentDistance > sPlayerbotAIConfig.sightDistance + sPlayerbotAIConfig.meleeDistance)
+    {
+        Reset();
+        return false;
+    }
+
+    if (currentDistance < lastDistance)
+    {
+        context->GetValue<float>("last target position")->Set(currentDistance);
+        SetPersistenceStartTime(getMSTime());
+    }
+    return true;
+}
+
+bool StartPullAction::Execute(Event event)
+{
+    Unit* target = GetTarget();
+    if (!target || !target->IsAlive() || !bot->GetGroup())
+    {
+        return false;
+    }
+    if (!ai->HasStrategy("pull", BOT_STATE_COMBAT))
+    {
+        ai->ChangeStrategy("+pull", BOT_STATE_COMBAT);
+    }
+    Group *group = bot->GetGroup();
+    if (group)
+    {
+        for (GroupReference *gref = group->GetFirstMember(); gref; gref = gref->next())
+        {
+            Player* member = gref->getSource();
+            if (!member)
+            {
+                continue;
+            }
+            float currentDistance = bot->GetDistance(member);
+            if (member != bot &&
+                 member->GetPlayerbotAI() &&
+                !member->GetPlayerbotAI()->HasStrategy("pull", BOT_STATE_COMBAT) &&
+                !member->GetPlayerbotAI()->HasStrategy("wait for pull", BOT_STATE_COMBAT) &&
+                currentDistance < sPlayerbotAIConfig.reactDistance)
+                member->GetPlayerbotAI()->ChangeStrategy("+wait for pull",BOT_STATE_COMBAT);
+        }
+    }
+    return true;
+}
+
+bool WatchGroupPullAction::Execute(Event event)
+{
+    Unit* target = GetTarget();
+    if (!target || !target->IsAlive())
+    {
+        return false;
+    }
+    Player *tank = target->ToPlayer();
+    if (!tank || !tank->GetPlayerbotAI())
+    {
+        return false;
+    }
+    bot->StopMoving();
+    SetPersistenceStartTime(getMSTime());
+    return isUseful();
+}
+
+bool WatchGroupPullAction::isUseful()
+{
+    Unit* target = GetTarget();
+    if (!target || !target->IsAlive())
+    {
+        return false;
+    }
+    Player *tank = target->ToPlayer();
+    if (!tank || !tank->GetPlayerbotAI())
+    {
+        return false;
+    }
+    float distance = bot->GetDistance(tank);
+    if (distance > sPlayerbotAIConfig.reactDistance)
+    {
+        return false;
+    }
+
+    if (!tank->GetPlayerbotAI()->HasStrategy("pull", BOT_STATE_COMBAT))
+    {
+        return false;
+    }
+    return true;
+}
+
+RangedPullAction::RangedPullAction(PlayerbotAI* ai) : CastSpellAction(ai, "ranged pull")
+{
+    string spell = ReachShootRangeAction::GetShootSpell(bot);
+    if (spell.length() > 0)
+    {
+        this->spell = spell;
+    }
+}
+
+bool RangedPullAction::isUseful()
+{
+    Unit* target = GetTarget();
+    if (!target || !target->IsAlive() || target->IsInCombat())
+    {
+        return false;
+    }
+    // does not really matter if castspellaction::isuseful, because the point is aggro.
+    // returning castspellaction::isuseful, will return false when spell is in progress,
+    //   causing subsequent actions to stomp on it.
+    return true;
+}
+
+bool RangedPullAction::Execute(Event event)
+{
+    Unit* target = GetTarget();
+    if (!target || !target->IsAlive() || target->IsInCombat())
+    {
+        return false;
+    }
+    if (CastSpellAction::isUseful())
+    {
+        CastSpellAction::Execute(event);
+    }
+    // The point with this action is to use a ranged pull to get aggro, and
+    // so this action must continue to return true from execute until aggro
+    // is achieved.  Otherwise, the pull spellcast itself gets stomped
+    // by some subsequent action before aggro is achieved.
+    return isUseful();
+}

--- a/src/modules/Bots/playerbot/strategy/actions/PullActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/PullActions.h
@@ -1,0 +1,88 @@
+
+#pragma once
+
+#include "../Action.h"
+#include "GenericSpellActions.h"
+
+namespace ai
+{
+    /**
+     * @brief Causes bot to wait for a target to reach melee, with timeout.
+     */
+    class WatchTargetApproachAction : public Action
+    {
+        public:
+            WatchTargetApproachAction(PlayerbotAI* ai) : Action(ai, "watch target approach") {}
+            virtual bool Execute(Event event);
+            virtual void Reset();
+            virtual bool isUseful();
+            virtual string GetTargetName()
+            {
+                return "current target";
+            }
+    };
+
+    /**
+     * @brief Causes bot's group to wait for pulling member to complete pull.
+     *
+     * Includes a 10 second timeout.
+     */
+    class WatchGroupPullAction : public Action
+    {
+        public:
+            WatchGroupPullAction(PlayerbotAI* ai) : Action(ai, "watch group pull") {}
+            virtual bool Execute(Event event);
+            virtual bool isUseful();
+            virtual string GetTargetName()
+            {
+                return "puller target";
+            }
+    };
+
+    /**
+     * @brief Causes a bot to begin the pull process.
+     *
+     * This action will add the pull strategy to the bot
+     * performing this action, and if they are in a group, it
+     * will add the wait for pull strategy to the group members.
+     */
+    class StartPullAction : public Action
+    {
+        public:
+            StartPullAction(PlayerbotAI* ai) : Action(ai, "start pull") {}
+            virtual bool Execute(Event event);
+            virtual string GetTargetName()
+            {
+                return "current target";
+            }
+    };
+
+    /**
+     * @brief Causes a bot to persistently attempt to pull
+     *
+     * This action will use the correct pull spell to attempt
+     * to aggro the target, and will remain passive or retry
+     * so long as the target is not aggroed yet.
+     */
+    class RangedPullAction : public CastSpellAction
+    {
+        public:
+            RangedPullAction(PlayerbotAI* ai);
+            virtual bool isUseful();
+            virtual bool isPossible() { return true; }
+            virtual NextAction** getAlternatives()
+            {
+                return NULL;
+            }
+            virtual NextAction** getPrerequisites()
+            {
+                return NULL;
+            }
+            virtual bool Execute(Event event);
+            virtual string GetTargetName()
+            {
+                return "current target";
+            }
+    };
+}
+

--- a/src/modules/Bots/playerbot/strategy/actions/ReachTargetActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/ReachTargetActions.cpp
@@ -1,0 +1,76 @@
+#include "botpch.h"
+#include "../../playerbot.h"
+#include "ReachTargetActions.h"
+
+using namespace ai;
+
+void ReachShootRangeAction::Reset()
+{
+    context->GetValue<float>("last target position")->Set(0);
+    ReachTargetAction::Reset();
+}
+
+string ReachShootRangeAction::GetShootSpell(Player *bot)
+{
+    Item* rangedItem = bot->GetItemByPos(INVENTORY_SLOT_BAG_0, EQUIPMENT_SLOT_RANGED);
+    if (!rangedItem)
+    {
+        return "";
+    }
+    uint32 weaponSubClass = rangedItem->GetProto()->SubClass;
+    switch (weaponSubClass)
+    {
+        case ITEM_SUBCLASS_WEAPON_BOW:
+            return "shoot bow";
+        case ITEM_SUBCLASS_WEAPON_GUN:
+            return "shoot gun";
+        case ITEM_SUBCLASS_WEAPON_CROSSBOW:
+            return "shoot crossbow";
+        case ITEM_SUBCLASS_WEAPON_THROWN:
+            return "throw";
+    }
+    return "shoot";
+}
+
+bool ReachShootRangeAction::isUseful()
+{
+    Unit* target = GetTarget();
+    if (target == bot)
+    {
+        target = context->GetValue<Unit*>("old target")->Get();
+        context->GetValue<Unit*>("current target")->Set(target);
+    }
+    if (!target || !target->IsAlive())
+    {
+        Reset();
+        return false;
+    }
+
+    if (!ReachTargetAction::isUseful())
+    {
+        Reset();
+        return false;
+    }
+    float lastDistance = context->GetValue<float>("last target position")->Get();
+    const float targetDistance = sPlayerbotAIConfig.sightDistance + sPlayerbotAIConfig.meleeDistance;
+
+    if (lastDistance == 0)
+    {
+        context->GetValue<float>("last target position")->Set(targetDistance);
+    }
+
+    float currentDistance = bot->GetDistance(target);
+    if ((currentDistance <= sPlayerbotAIConfig.meleeDistance)
+    || (currentDistance > targetDistance))
+    {
+        Reset();
+        return false;
+    }
+
+    if (currentDistance < lastDistance)
+    {
+        context->GetValue<float>("last target position")->Set(currentDistance);
+        SetPersistenceStartTime(getMSTime());
+    }
+    return true;
+}

--- a/src/modules/Bots/playerbot/strategy/actions/ReachTargetActions.h
+++ b/src/modules/Bots/playerbot/strategy/actions/ReachTargetActions.h
@@ -2,6 +2,7 @@
 
 #include "../Action.h"
 #include "MovementActions.h"
+#include "GenericSpellActions.h"
 #include "../../PlayerbotAIConfig.h"
 
 namespace ai
@@ -54,7 +55,8 @@ namespace ai
 
             virtual bool isUseful()
             {
-                return AI_VALUE2(float, "distance", "current target") > distance + sPlayerbotAIConfig.contactDistance + bot->GetObjectBoundingRadius();
+                return AI_VALUE2(float, "distance", "current target") >
+                    distance + sPlayerbotAIConfig.contactDistance + bot->GetObjectBoundingRadius();
             }
     };
 
@@ -65,7 +67,8 @@ namespace ai
 
             virtual bool isUseful()
             {
-                return AI_VALUE2(float, "distance", "current target") < distance + sPlayerbotAIConfig.contactDistance + bot->GetObjectBoundingRadius();
+                return AI_VALUE2(float, "distance", "current target") <
+                        distance + sPlayerbotAIConfig.contactDistance + bot->GetObjectBoundingRadius();
             }
     };
 
@@ -73,15 +76,21 @@ namespace ai
     {
         public:
             ReachSpellAction(PlayerbotAI* ai) : ReachTargetAction(ai, "reach spell", sPlayerbotAIConfig.spellDistance) {}
-            virtual bool Execute(Event event)
+    };
+
+    class ReachShootRangeAction : public ReachTargetAction
+    {
+        public:
+            ReachShootRangeAction(PlayerbotAI* ai) : ReachTargetAction(ai, "reach shoot range", sPlayerbotAIConfig.spellDistance)
             {
-                distance = AI_VALUE(float, "reach spell distance");
-                return ReachTargetAction::Execute(event);
+                string spell = GetShootSpell(bot);
+                if (spell.length() > 0)
+                {
+                    distance = AI_VALUE2(float, "spell range", spell);
+                }
             }
-            virtual bool isUseful()
-            {
-                distance = AI_VALUE(float, "reach spell distance");
-                return ReachTargetAction::isUseful();
-            }
+            virtual bool isUseful();
+            virtual void Reset();
+            static string GetShootSpell(Player *bot);
     };
 }

--- a/src/modules/Bots/playerbot/strategy/generic/ChatCommandHandlerStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/generic/ChatCommandHandlerStrategy.cpp
@@ -85,6 +85,10 @@ void ChatCommandHandlerStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
         NextAction::array(0, new NextAction("attack my target", relevance), NULL)));
 
     triggers.push_back(new TriggerNode(
+            "pull",
+        NextAction::array(0, new NextAction("pull my target", relevance), NULL)));
+
+    triggers.push_back(new TriggerNode(
             "accept",
         NextAction::array(0, new NextAction("accept quest", relevance), NULL)));
 

--- a/src/modules/Bots/playerbot/strategy/generic/PullStrategy.cpp
+++ b/src/modules/Bots/playerbot/strategy/generic/PullStrategy.cpp
@@ -1,44 +1,82 @@
 #include "botpch.h"
 #include "../../playerbot.h"
-#include "../PassiveMultiplier.h"
 #include "PullStrategy.h"
+#include "../StrategyMultiplier.h"
 
 using namespace ai;
 
-class MagePullMultiplier : public PassiveMultiplier
+class PullStrategyActionNodeFactory : public NamedObjectFactory<ActionNode>
 {
     public:
-        MagePullMultiplier(PlayerbotAI* ai, string action) : PassiveMultiplier(ai)
+        PullStrategyActionNodeFactory()
         {
-            this->action = action;
+            creators["watch target approach"] = &watch_target_approach;
+            creators["start pull"] = &start_pull;
+            creators["ranged pull"] = &ranged_pull;
+            creators["reach shoot range"] = &reach_shoot_range;
+            creators["reach master"] = &reach_master;
         }
 
-    public:
-        virtual float GetValue(Action* action);
-
     private:
-        string action;
+        static ActionNode* watch_target_approach(PlayerbotAI* ai)
+        {
+            ActionNode* node = new ActionNode ("watch target approach",
+                /*P*/ NULL,
+                /*A*/ NULL,
+                /*C*/ NULL);
+            return node->persist(2000);
+        }
+        static ActionNode* start_pull(PlayerbotAI* ai)
+        {
+            ActionNode* node = new ActionNode ("start pull",
+                /*P*/ NULL,
+                /*A*/ NULL,
+                /*C*/ NULL);
+            return node;
+        }
+        static ActionNode* ranged_pull(PlayerbotAI* ai)
+        {
+            ActionNode* node = new ActionNode ("ranged pull",
+                /*P*/ NULL,
+                /*A*/ NULL,
+                /*C*/ NULL);
+            return node->persist(6000);
+        }
+        static ActionNode* reach_shoot_range(PlayerbotAI* ai)
+        {
+            ActionNode* node = new ActionNode ("reach shoot range",
+                /*P*/ NULL,
+                /*A*/ NULL,
+                /*C*/ NULL);
+            return node->persist(3000);
+        }
+        static ActionNode* reach_master(PlayerbotAI* ai)
+        {
+            ActionNode* node = new ActionNode ("reach master",
+                /*P*/ NULL,
+                /*A*/ NULL,
+                /*C*/ NULL);
+            return node->persist(3000);
+        }
 };
 
-float MagePullMultiplier::GetValue(Action* action)
+PullStrategy::PullStrategy(PlayerbotAI* ai, string action) : RangedCombatStrategy(ai)
 {
-    if (!action)
-    {
-        return 1.0f;
-    }
-
-    string name = action->getName();
-    if (this->action == name ||
-        name == "reach spell" ||
-        name == "change strategy")
-        return 1.0f;
-
-    return PassiveMultiplier::GetValue(action);
+    this->action = action;
+    ai->GetAiObjectContext()->GetValue<float>("last target position")->Set(0);
+    actionNodeFactories.Add(new PullStrategyActionNodeFactory());
 }
 
 NextAction** PullStrategy::getDefaultActions()
 {
-    return NextAction::array(0, new NextAction(action, 105.0f), new NextAction("follow master", 104.0f), new NextAction("end pull", 103.0f), NULL);
+    return NextAction::array(0,
+            new NextAction("start pull", 160.0f),
+            new NextAction("reach shoot range", 150.0f),
+            new NextAction(action, 140.0f),
+            new NextAction("reach master", 130.0f),
+            new NextAction("set facing", 120.0f),
+            new NextAction("watch target approach", 110.0f),
+            new NextAction("end pull", 100.0f), NULL);
 }
 
 void PullStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
@@ -48,7 +86,63 @@ void PullStrategy::InitTriggers(std::list<TriggerNode*> &triggers)
 
 void PullStrategy::InitMultipliers(std::list<Multiplier*> &multipliers)
 {
-    multipliers.push_back(new MagePullMultiplier(ai, action));
+    StrategyMultiplier *multiplier = new StrategyMultiplier(ai, this);
+    multiplier->AddAction("shoot bow");
+    multiplier->AddAction("shoot crossbow");
+    multiplier->AddAction("shoot gun");
+    multiplier->AddAction("throw");
+    multiplier->AddAction("shoot");
+    multiplier->AddAction("auto shot");
+    multiplier->AddAction("-pull");
+    multiplier->AddAction("-wait for pull");
+    multipliers.push_back(multiplier);
     RangedCombatStrategy::InitMultipliers(multipliers);
 }
 
+class WaitForPullStrategyActionNodeFactory : public NamedObjectFactory<ActionNode>
+{
+    public:
+        WaitForPullStrategyActionNodeFactory()
+        {
+            creators["watch group pull"] = &watch_group_pull;
+            creators["end wait for pull"] = &end_wait_for_pull;
+        }
+
+    private:
+        static ActionNode* watch_group_pull(PlayerbotAI* ai)
+        {
+            ActionNode* node = new ActionNode ("watch group pull",
+                /*P*/ NULL,
+                /*A*/ NULL,
+                /*C*/ NULL);
+            return node->persist(2000);
+        }
+        static ActionNode* end_wait_for_pull(PlayerbotAI* ai)
+        {
+            ActionNode* node = new ActionNode ("end wait for pull",
+                /*P*/ NULL,
+                /*A*/ NULL,
+                /*C*/ NULL);
+            return node;
+        }
+};
+
+WaitForPullStrategy::WaitForPullStrategy(PlayerbotAI* ai) : CombatStrategy(ai)
+{
+    actionNodeFactories.Add(new WaitForPullStrategyActionNodeFactory());
+}
+
+NextAction** WaitForPullStrategy::getDefaultActions()
+{
+    return NextAction::array(0,
+            new NextAction("watch group pull", 160.0f),
+            new NextAction("end wait for pull", 150.0f), NULL);
+}
+
+void WaitForPullStrategy::InitMultipliers(std::list<Multiplier*> &multipliers)
+{
+    StrategyMultiplier *multiplier = new StrategyMultiplier(ai, this);
+    multiplier->AddAction("-wait for pull");
+    multipliers.push_back(multiplier);
+    CombatStrategy::InitMultipliers(multipliers);
+}

--- a/src/modules/Bots/playerbot/strategy/generic/PullStrategy.h
+++ b/src/modules/Bots/playerbot/strategy/generic/PullStrategy.h
@@ -7,10 +7,7 @@ namespace ai
     class PullStrategy : public RangedCombatStrategy
     {
         public:
-            PullStrategy(PlayerbotAI* ai, string action) : RangedCombatStrategy(ai)
-            {
-                this->action = action;
-            }
+            PullStrategy(PlayerbotAI* ai, string action);
 
         public:
             virtual void InitTriggers(std::list<TriggerNode*> &triggers);
@@ -21,7 +18,19 @@ namespace ai
             }
             virtual NextAction** getDefaultActions();
 
-        private:
+        protected:
             string action;
+    };
+
+    class WaitForPullStrategy : public CombatStrategy
+    {
+        public:
+            WaitForPullStrategy(PlayerbotAI* ai);
+            virtual void InitMultipliers(std::list<Multiplier*> &multipliers);
+            virtual string getName()
+            {
+                return "wait for pull";
+            }
+            virtual NextAction** getDefaultActions();
     };
 }

--- a/src/modules/Bots/playerbot/strategy/hunter/HunterAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/hunter/HunterAiObjectContext.cpp
@@ -7,6 +7,7 @@
 #include "GenericHunterNonCombatStrategy.h"
 #include "HunterBuffStrategies.h"
 #include "../NamedObjectContext.h"
+#include "../generic/PullStrategy.h"
 
 using namespace ai;
 
@@ -29,6 +30,7 @@ namespace ai
 
             private:
                 static Strategy* aoe(PlayerbotAI* ai) { return new DpsAoeHunterStrategy(ai); }
+                static Strategy* pull(PlayerbotAI* ai) { return new PullStrategy(ai, "auto shot"); }
                 static Strategy* dps(PlayerbotAI* ai) { return new DpsHunterStrategy(ai); }
                 static Strategy* nc(PlayerbotAI* ai) { return new GenericHunterNonCombatStrategy(ai); }
                 static Strategy* dps_debuff(PlayerbotAI* ai) { return new DpsHunterDebuffStrategy(ai); }

--- a/src/modules/Bots/playerbot/strategy/mage/MageAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/mage/MageAiObjectContext.cpp
@@ -32,7 +32,7 @@ namespace ai
 
             private:
                 static Strategy* nc(PlayerbotAI* ai) { return new GenericMageNonCombatStrategy(ai); }
-                static Strategy* pull(PlayerbotAI* ai) { return new PullStrategy(ai, "shoot"); }
+                static Strategy* pull(PlayerbotAI* ai) { return new PullStrategy(ai, "ranged pull"); }
                 static Strategy* fire_aoe(PlayerbotAI* ai) { return new FireMageAoeStrategy(ai); }
                 static Strategy* frost_aoe(PlayerbotAI* ai) { return new FrostMageAoeStrategy(ai); }
         };

--- a/src/modules/Bots/playerbot/strategy/priest/PriestAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/priest/PriestAiObjectContext.cpp
@@ -33,7 +33,7 @@ namespace ai
             private:
                 static Strategy* nc(PlayerbotAI* ai) { return new PriestNonCombatStrategy(ai); }
                 static Strategy* shadow_aoe(PlayerbotAI* ai) { return new ShadowPriestAoeStrategy(ai); }
-                static Strategy* pull(PlayerbotAI* ai) { return new PullStrategy(ai, "shoot"); }
+                static Strategy* pull(PlayerbotAI* ai) { return new PullStrategy(ai, "ranged pull"); }
                 static Strategy* shadow_debuff(PlayerbotAI* ai) { return new ShadowPriestDebuffStrategy(ai); }
         };
 

--- a/src/modules/Bots/playerbot/strategy/rogue/RogueAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/rogue/RogueAiObjectContext.cpp
@@ -9,6 +9,7 @@
 #include "RogueAmbushStrategy.h"
 #include "RogueSapStrategy.h"
 #include "../NamedObjectContext.h"
+#include "../generic/PullStrategy.h"
 
 using namespace ai;
 
@@ -27,6 +28,7 @@ namespace ai
                     creators["nc"] = &rogue::StrategyFactoryInternal::nc;
                     creators["ambush"] = &rogue::StrategyFactoryInternal::ambush;
                     creators["sap"] = &rogue::StrategyFactoryInternal::sap_strategy;
+                    creators["pull"] = &rogue::StrategyFactoryInternal::pull;
                 }
 
             private:
@@ -34,6 +36,7 @@ namespace ai
                 static Strategy* nc(PlayerbotAI* ai) { return new GenericRogueNonCombatStrategy(ai); }
                 static Strategy* ambush(PlayerbotAI* ai) { return new RogueAmbushStrategy(ai); }
                 static Strategy* sap_strategy(PlayerbotAI* ai) { return new RogueSapStrategy(ai); }
+                static Strategy* pull(PlayerbotAI* ai) { return new PullStrategy(ai, "ranged pull"); }
         };
     };
 };

--- a/src/modules/Bots/playerbot/strategy/triggers/ChatTriggerContext.h
+++ b/src/modules/Bots/playerbot/strategy/triggers/ChatTriggerContext.h
@@ -42,6 +42,7 @@ namespace ai
                 creators["dead"] = &ChatTriggerContext::dead;
                 creators["trainer"] = &ChatTriggerContext::trainer;
                 creators["attack"] = &ChatTriggerContext::attack;
+                creators["pull"] = &ChatTriggerContext::pull;
                 creators["chat"] = &ChatTriggerContext::chat;
                 creators["accept"] = &ChatTriggerContext::accept;
                 creators["home"] = &ChatTriggerContext::home;
@@ -104,6 +105,7 @@ namespace ai
             static Trigger* accept(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "accept"); }
             static Trigger* chat(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "chat"); }
             static Trigger* attack(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "attack"); }
+            static Trigger* pull(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "pull"); }
             static Trigger* trainer(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "trainer"); }
             static Trigger* co(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "co"); }
             static Trigger* nc(PlayerbotAI* ai) { return new ChatCommandTrigger(ai, "nc"); }

--- a/src/modules/Bots/playerbot/strategy/values/LastTargetPositionValue.h
+++ b/src/modules/Bots/playerbot/strategy/values/LastTargetPositionValue.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "../Value.h"
+
+namespace ai
+{
+    class LastTargetPositionValue : public ManualSetValue<float>
+    {
+        public:
+            LastTargetPositionValue(PlayerbotAI* ai) : ManualSetValue<float>(ai, 0.0f, "last target position") {}
+    };
+}

--- a/src/modules/Bots/playerbot/strategy/values/PullerTargetValue.h
+++ b/src/modules/Bots/playerbot/strategy/values/PullerTargetValue.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "../Value.h"
+
+namespace ai
+{
+    class PullerTargetValue : public UnitCalculatedValue
+    {
+        public:
+            PullerTargetValue(PlayerbotAI* ai) : UnitCalculatedValue(ai) {}
+
+            virtual Unit* Calculate()
+            {
+                Player *bot = ai->GetBot();
+                if (!bot)
+                {
+                    return NULL;
+                }
+                if (ai->HasStrategy("pull", BOT_STATE_COMBAT))
+                {
+                    return bot;
+                }
+                Group *group = bot->GetGroup();
+                if (group)
+                {
+                    for (GroupReference *gref = group->GetFirstMember(); gref; gref = gref->next())
+                    {
+                        Player* member = gref->getSource();
+                        if (member &&
+                            member->GetPlayerbotAI() &&
+                            member->GetPlayerbotAI()->HasStrategy("pull", BOT_STATE_COMBAT))
+                        {
+                            return member;
+                        }
+                    }
+                }
+                return NULL;
+            }
+    };
+}

--- a/src/modules/Bots/playerbot/strategy/values/SpellRangeValue.cpp
+++ b/src/modules/Bots/playerbot/strategy/values/SpellRangeValue.cpp
@@ -1,0 +1,34 @@
+#include "botpch.h"
+#include "../../playerbot.h"
+#include "SpellRangeValue.h"
+#include "../../PlayerbotAIConfig.h"
+
+using namespace ai;
+
+SpellRangeValue::SpellRangeValue(PlayerbotAI* ai) :
+        CalculatedValue<float>(ai, "spell range", sPlayerbotAIConfig.spellDistance)
+{
+}
+
+float SpellRangeValue::Calculate()
+{
+    uint32 spellId = AI_VALUE2(uint32, "spell id", qualifier);
+    if (spellId)
+    {
+        const SpellEntry* pSpellInfo = sSpellStore.LookupEntry(spellId);
+        if (pSpellInfo)
+        {
+            SpellRangeEntry const* spellRange = sSpellRangeStore.LookupEntry(pSpellInfo->rangeIndex);
+            if (spellRange)
+            {
+                float actualMaxRange = GetSpellMaxRange(spellRange);
+                // Only clamp if spell has a defined range
+                if (actualMaxRange > 1 && actualMaxRange < sPlayerbotAIConfig.spellDistance)
+                {
+                    return actualMaxRange - 1;
+                }
+            }
+        }
+    }
+    return sPlayerbotAIConfig.spellDistance;
+}

--- a/src/modules/Bots/playerbot/strategy/values/SpellRangeValue.h
+++ b/src/modules/Bots/playerbot/strategy/values/SpellRangeValue.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "../Value.h"
+#include "TargetValue.h"
+
+namespace ai
+{
+
+    class SpellRangeValue : public CalculatedValue<float>, public Qualified
+    {
+        public:
+            SpellRangeValue(PlayerbotAI* ai);
+
+        public:
+            virtual float Calculate();
+    };
+}

--- a/src/modules/Bots/playerbot/strategy/values/ValueContext.h
+++ b/src/modules/Bots/playerbot/strategy/values/ValueContext.h
@@ -55,6 +55,9 @@
 #include "EnemyHealerTargetValue.h"
 #include "ItemUsageValue.h"
 #include "DpsTanksTargetValue.h"
+#include "PullerTargetValue.h"
+#include "SpellRangeValue.h"
+#include "LastTargetPositionValue.h"
 
 namespace ai
 {
@@ -142,6 +145,9 @@ namespace ai
                 creators["enemy healer target"] = &ValueContext::enemy_healer_target;
                 creators["item usage"] = &ValueContext::item_usage;
                 creators["reach spell distance"] = &ValueContext::reach_spell_distance;
+                creators["puller target"] = &ValueContext::puller_target;
+                creators["spell range"] = &ValueContext::spell_range;
+                creators["last target position"] = &ValueContext::last_target_position;
             }
 
         private:
@@ -223,5 +229,8 @@ namespace ai
             static UntypedValue* lfg_proposal(PlayerbotAI* ai) { return new LfgProposalValue(ai); }
             static UntypedValue* bag_space(PlayerbotAI* ai) { return new BagSpaceValue(ai); }
             static UntypedValue* enemy_healer_target(PlayerbotAI* ai) { return new EnemyHealerTargetValue(ai); }
+            static UntypedValue* puller_target(PlayerbotAI* ai) { return new PullerTargetValue(ai); }
+            static UntypedValue* spell_range(PlayerbotAI* ai) { return new SpellRangeValue(ai); }
+            static UntypedValue* last_target_position(PlayerbotAI* ai) { return new LastTargetPositionValue(ai); }
     };
 };

--- a/src/modules/Bots/playerbot/strategy/warlock/WarlockAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/warlock/WarlockAiObjectContext.cpp
@@ -33,7 +33,7 @@ namespace ai
                 static Strategy* nc(PlayerbotAI* ai) { return new GenericWarlockNonCombatStrategy(ai); }
                 static Strategy* aoe(PlayerbotAI* ai) { return new DpsAoeWarlockStrategy(ai); }
                 static Strategy* dps_debuff(PlayerbotAI* ai) { return new DpsWarlockDebuffStrategy(ai); }
-                static Strategy* pull(PlayerbotAI* ai) { return new PullStrategy(ai, "shoot"); }
+                static Strategy* pull(PlayerbotAI* ai) { return new PullStrategy(ai, "ranged pull"); }
         };
 
         class CombatStrategyFactoryInternal : public NamedObjectContext<Strategy>

--- a/src/modules/Bots/playerbot/strategy/warrior/WarriorAiObjectContext.cpp
+++ b/src/modules/Bots/playerbot/strategy/warrior/WarriorAiObjectContext.cpp
@@ -30,7 +30,7 @@ namespace ai
             private:
                 static Strategy* nc(PlayerbotAI* ai) { return new GenericWarriorNonCombatStrategy(ai); }
                 static Strategy* aoe(PlayerbotAI* ai) { return new DpsWarrirorAoeStrategy(ai); }
-                static Strategy* pull(PlayerbotAI* ai) { return new PullStrategy(ai, "shoot"); }
+                static Strategy* pull(PlayerbotAI* ai) { return new PullStrategy(ai, "ranged pull"); }
         };
 
         class CombatStrategyFactoryInternal : public NamedObjectContext<Strategy>


### PR DESCRIPTION
Gives players the ability to command a playerbot to 'pull' their current target, causing them to use an appropriate skill at range on the target, run back to the master, and wait for the target to approach.  If the target doesn't approach, the process is cancelled.  If the bot has other group members, they will also wait for the target and not mess up the pull.   All classes that have ranged attacks can be ordered to "pull" successfully.

This required one architectural addition to the action system, namely the ability to force an action to persist (be repeated) for a period of time before any other action is taken.  This allows the above iterative process to be possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/350)
<!-- Reviewable:end -->
