### PR TITLE
fix: subdivide BuildShortcut path with terrain height snapping to prevent bunny-hop on missing navmesh tiles

### DIFF
--- a/src/game/MotionGenerators/PathFinder.cpp
+++ b/src/game/MotionGenerators/PathFinder.cpp
@@ -578,13 +578,28 @@ void PathFinder::BuildShortcut()
 
     clear();
 
-    // make two point path, our curr pos is the start, and dest is the end
-    uint32 size = 2;
-    m_pathPoints.resize(size);
+    Vector3 start = getStartPosition();
+    Vector3 end = getActualEndPosition();
 
-    // set start and a default next position
-    m_pathPoints[0] = getStartPosition();
-    m_pathPoints[1] = getActualEndPosition();
+    // Subdivide the shortcut into segments so that each point can be snapped
+    // to terrain height. This prevents the "bunny hop" effect on steep
+    // slopes when no navmesh is available.
+    const float segmentLength = 5.0f;
+    float dist = sqrt(dist3DSqr(start, end));
+    uint32 segments = std::max(1u, uint32(dist / segmentLength));
+    uint32 size = segments + 1;
+
+    m_pathPoints.resize(size);
+    m_pathPoints[0] = start;
+    m_pathPoints[size - 1] = end;
+
+    for (uint32 i = 1; i < size - 1; ++i)
+    {
+        float t = float(i) / float(segments);
+        Vector3 point = start + (end - start) * t;
+        m_sourceUnit->UpdateAllowedPositionZ(point.x, point.y, point.z);
+        m_pathPoints[i] = point;
+    }
 
     m_type = PATHFIND_SHORTCUT;
 }


### PR DESCRIPTION
## Summary

Fixes shortcut fallback movement over sloped terrain.

`BuildShortcut()` previously created a simple two-point path between the start and end positions. On hillsides, both endpoints could be on valid ground, but the straight 3D segment between them could cut through the air above the terrain. This made creatures appear to bunny-hop, arc, or snap while returning home or following a target.

This changes shortcut fallback paths to add terrain-snapped intermediate points. The result is a fallback path that follows the terrain contour more naturally while leaving normal navmesh paths unchanged.

## Details

This only affects `PATHFIND_SHORTCUT` fallback paths.

Normal mmap/navmesh paths are not changed.

The shortcut is subdivided at a fixed distance and each intermediate point is snapped to terrain height. This avoids the previous two-point aerial spline without reintroducing the old unbounded midpoint loop risk.

## Verification

Tested in Thelsamar / Loch Modan on steep hillside terrain after regenerated mmap data was installed.

Observed results:

- Spider evade-home movement on the hillside no longer bunny-hops up the slope.
- `.npc follow` from roughly 70 yards worked smoothly across raised path, dip, hillside, and the flight-master area.
- Creature repathed dynamically while following the player.
- Creature handled boxes/crates in the flight-master area by stepping/walking over them and resuming normal movement.
- Guard follow toward an awkward roof/steep-terrain position behaved acceptably: the guard pathed as close as possible and then resolved near the player, rather than stalling, repeatedly bunny-hopping, or falling through terrain.

This is primarily a correctness fix for shortcut fallback movement, but it also improves retail-like creature movement in hilly outdoor areas.

## Notes

No mmap re-extraction is required for this shortcut fallback change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/355)
<!-- Reviewable:end -->
