### PR TITLE
Fix creature corpse teleport during removal

### DIFF
--- a/src/game/Object/Creature.cpp
+++ b/src/game/Object/Creature.cpp
@@ -376,7 +376,6 @@ void Creature::RemoveCorpse(bool inPlace)
     SetVisibility(VISIBILITY_REMOVE_CORPSE);
     UpdateObjectVisibility();
     SetVisibility(currentVis);                              // restore visibility state
-    UpdateObjectVisibility();
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes a creature corpse visibility issue where corpses could appear to snap or reappear at their respawn point during corpse cleanup.

`Creature::RemoveCorpse()` relocates the creature to its respawn coordinates before forcing corpse-removal visibility. The follow-up `UpdateObjectVisibility()` after restoring visibility could recreate the still-dead object for clients at the respawn position.

This removes that second visibility update while keeping the internal relocation required for respawn/grid state.

**This also mitigates the known creature level-up visual/sound artifact for normal players during respawn, because the corpse/object is no longer recreated through the extra visibility update before the live respawn.**

## Behavior

Before:
- Creature dies away from spawn.
- Corpse remains at death location.
- On corpse cleanup, corpse can visibly appear/snap to the spawn point.
- Creature later respawns alive at spawn.

After:
- Creature dies away from spawn.
- Corpse despawns for normal players without visible teleport.
- Creature still respawns alive at the correct spawn point.

## Testing

Verified locally:
- World creature corpse decay.
- Manual `.die` + `.respawn`.
- Automatic respawn at the expected spawn point.
- Normal-player visibility with GM mode off.
- Stockades instance trash respawn.
- Level-ranged respawn changed level without visible level-up effect for a normal player view.

## Notes

- GMs with `.gm on` may still observe the hidden corpse/object state at the respawn point. Normal players do not see the corpse teleport/reappear.
- This also mitigates the known client-side creature level-up visual/sound artifact during normal respawn. In testing, a level-ranged creature changed level on respawn without playing the player-style level-up effect. The root cause remains a client-side deferred-destroy/reuse-by-GUID behavior, so this PR describes it as a mitigation rather than a global client fix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/356)
<!-- Reviewable:end -->
