### PR TITLE
Define source file line-ending attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,88 @@
-# Lineendings
-*.sln        eol=crlf
-*.vcproj     eol=crlf
-*.vcxproj*   eol=crlf
+# ============================================================================
+# Line-ending and whitespace attributes
+#
+# Goal: keep source/text files normalized so that replacing a file with a
+# copy that only differs in CRLF/LF does NOT show up as a whole-file diff.
+# This defines behaviour going forward only; no mass renormalization is done.
+# ============================================================================
 
-src/shared/revision_nr.h eol=lf
-src/shared/revision_sql.h eol=lf
+# Let Git handle text detection and normalize text to LF in the repository.
+* text=auto
 
-# Whitespace rules
+# ----------------------------------------------------------------------------
+# C/C++ source -> stored and checked out as LF
+# ----------------------------------------------------------------------------
+*.c          text eol=lf
+*.cc         text eol=lf
+*.cpp        text eol=lf
+*.cxx        text eol=lf
+*.h          text eol=lf
+*.hpp        text eol=lf
+*.hxx        text eol=lf
+*.inl        text eol=lf
+
+# Generated revision headers must stay LF
+src/shared/revision_nr.h  text eol=lf
+src/shared/revision_sql.h text eol=lf
+
+# ----------------------------------------------------------------------------
+# CMake, config and other text files -> LF
+# ----------------------------------------------------------------------------
+CMakeLists.txt text eol=lf
+*.cmake      text eol=lf
+*.sql        text eol=lf
+*.txt        text eol=lf
+*.md         text eol=lf
+*.xml        text eol=lf
+*.conf       text eol=lf
+*.dist       text eol=lf
+*.json       text eol=lf
+*.yml        text eol=lf
+*.yaml       text eol=lf
+
+# ----------------------------------------------------------------------------
+# Unix shell scripts -> LF
+# ----------------------------------------------------------------------------
+*.sh         text eol=lf
+
+# ----------------------------------------------------------------------------
+# Windows scripts and Visual Studio project files -> CRLF
+# ----------------------------------------------------------------------------
+*.sln        text eol=crlf
+*.vcproj     text eol=crlf
+*.vcxproj*   text eol=crlf
+*.bat        text eol=crlf
+*.cmd        text eol=crlf
+*.ps1        text eol=crlf
+
+# ----------------------------------------------------------------------------
+# Binary / runtime artifacts -> never normalize
+# ----------------------------------------------------------------------------
+*.png        binary
+*.jpg        binary
+*.jpeg       binary
+*.gif        binary
+*.ico        binary
+*.bmp        binary
+*.mpq        binary
+*.dbc        binary
+*.db2        binary
+*.map        binary
+*.vmap       binary
+*.mmap       binary
+*.lib        binary
+*.dll        binary
+*.exe        binary
+*.pdb        binary
+*.zip        binary
+*.7z         binary
+*.gz         binary
+*.tar        binary
+
+# ============================================================================
+# Whitespace rules (preserved from the original .gitattributes)
+# ============================================================================
+
 # strict (no trailing, no tabs)
 *.cpp        whitespace=trailing-space,space-before-tab,tab-in-indent,cr-at-eol
 *.h          whitespace=trailing-space,space-before-tab,tab-in-indent,cr-at-eol


### PR DESCRIPTION
This adds repository-level `.gitattributes` rules for line-ending normalization.

The main goal is to prevent source-file replacements from appearing as whole-file changes when the only difference is CRLF/LF line endings.

Summary:
- Adds `* text=auto`
- Forces C/C++ source and common text/config files to LF
- Keeps Visual Studio project files and Windows scripts as CRLF
- Keeps shell scripts as LF
- Preserves existing generated revision-header LF rules
- Preserves existing whitespace rules
- Marks common binary/runtime artifacts as binary

Validation:
- Only `.gitattributes` was changed
- No `git add --renormalize .` was performed
- No mass source-file normalization was included
- No submodules or generated files were changed

This is intentionally a policy-only hygiene change. Any future repository-wide normalization pass, if wanted, should be handled separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/357)
<!-- Reviewable:end -->
