### PR TITLE
Fix mmap path height selection over stacked terrain and WMO floors

### DIFF
--- a/src/game/WorldHandlers/GridMap.cpp
+++ b/src/game/WorldHandlers/GridMap.cpp
@@ -1147,27 +1147,24 @@ float TerrainInfo::GetHeightStatic(float x, float y, float z, bool useVmaps/*=tr
     // vmapheight set for any under Z value or <= INVALID_HEIGHT
     if (vmapHeight > INVALID_HEIGHT)
     {
-        if (mapHeight > INVALID_HEIGHT)
+        // vmap surface above the .map terrain always wins (platforms/bridges/upper floors); this also
+        // covers the case where only vmapHeight is valid (mapHeight <= INVALID_HEIGHT).
+        if (vmapHeight > mapHeight)
         {
-            // we have mapheight and vmapheight and must select more appropriate
-
-            // we are already under the surface or vmap height above map heigt
-            if (z < mapHeight || vmapHeight > mapHeight)
-            {
-                return vmapHeight;
-            }
-            else
-            {
-                return mapHeight;                            // better use .map surface height
-            }
+            return vmapHeight;
         }
-        else
+
+        // vmap floor is below the terrain: only consider dropping to it when the query Z is genuinely
+        // below the terrain, and even then return whichever surface is nearer to Z. This prevents a
+        // navmesh vertex that sits a fraction below the heightmap from being snapped down onto a lower
+        // WMO/building floor. (vmapHeight <= mapHeight here, so the midpoint test == nearest-surface.)
+        if (z < mapHeight)
         {
-            return vmapHeight;                               // we have only vmapHeight (if have)
+            return (z < (vmapHeight + mapHeight) * 0.5f) ? vmapHeight : mapHeight;
         }
     }
 
-    return mapHeight;
+    return mapHeight;                                        // better use .map surface height
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes an mmap movement/pathing issue where valid Detour path points could be snapped down to a lower WMO/building floor when terrain and vmap surfaces were stacked at the same XY.

This was exposed after mmap tile loading was restored. Detour was returning a correct path point on the visible hillside, but `NormalizePath -> UpdateAllowedPositionZ -> Map::GetHeight -> TerrainInfo::GetHeightStatic` could select the lower WMO floor because the path point was fractionally below the terrain heightmap.

## Root cause

At the Thelsamar hill test case, the raw Detour point was correct and on the hill:

- RAW Detour Z: approximately `340.32`
- Terrain height: approximately `340.32`
- Lower WMO/building floor: approximately `327.67`

However, after path normalization, the path point became:

- Normalized Z: approximately `327.67`

The decisive diagnostic line was:

`i=3 xy(-5311.53,-2982.02) zBefore=340.32 zAfter=327.67 terrain=340.32 staticSel=327.67 combined=327.67 vmapWon=1 z<terrain=1`

This proved that:

- Detour/mmaps were returning the correct hill position.
- Terrain height was valid.
- The lower WMO floor existed and remained detectable.
- The bad Z was introduced after Detour, during height correction.
- The zero-tolerance `z < mapHeight` branch treated a path point that was only fractionally below terrain as if it were genuinely under the terrain, then selected the lower WMO floor.

A simplified navmesh point can legitimately sit slightly below the exact terrain heightmap due to mesh simplification/precision. That should not be interpreted as “the unit is below terrain and should snap to a WMO floor 12 yards lower.”

## Fix

Adjusts the height-selection logic so stacked terrain/WMO surfaces are selected relative to the caller’s reference Z instead of blindly preferring a lower vmap floor when the point is only fractionally below terrain.

This preserves stacked-surface support while preventing valid mmap path points on outdoor terrain from being snapped to unrelated WMO floors below.

The fix does not:

- Change mmap tile loading.
- Change Detour/Recast.
- Change mmap generation.
- Regenerate mmap data.
- Clamp all path Z values to terrain.

## Validation

Tested in-game at Thelsamar, Loch Modan.

Before this fix:

- Mountaineer Gwarth climbed partway up the hill, then vanished/dropped into the building floor under the hill.
- `.mmap path` and `.mmap path straight` returned `PATHFIND_NORMAL`, so this was not fallback/no-mmap behavior.
- `.mmap path` reported an `actual end` 8-15 yards below the requested/Detour hill Z.
- Diagnostic logging showed raw Detour points were correct and the drop happened during normalization.

After this fix:

- Mountaineer Gwarth paths fully up and down the hill without vanishing.
- Valid Detour hill points remain on the hill surface after normalization.
- The lower WMO/building floor remains detectable, but is no longer incorrectly selected for path points that are effectively on the terrain.
- The original mmap tile coordinate-order fix remains valid and untouched.

## Scope note

This PR is intentionally limited to the height-selection bug.

A separate Thelsamar issue remains under investigation: some building-interior waypoints have vmap collision floors but no corresponding mmap navmesh polygons. That appears to be an mmap generation/Recast filtering issue involving small WMO interior regions, and is not addressed by this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/359)
<!-- Reviewable:end -->
