### PR TITLE
[LivingWorld]Add grid occupancy diagnostic commands

### DIFF
--- a/src/game/ChatCommands/GridCommands.cpp
+++ b/src/game/ChatCommands/GridCommands.cpp
@@ -93,13 +93,17 @@ namespace
 
                 CellObjectGuids const* guids = sObjectMgr.GetCellObjectGuidsReadOnly(mapId, cellId);
                 if (!guids)
+                {
                     continue;
+                }
 
                 uint32 nCreatures = uint32(guids->creatures.size());
                 uint32 nGameobjects = uint32(guids->gameobjects.size());
                 uint32 nCorpses = uint32(guids->corpses.size());
                 if (nCreatures + nGameobjects + nCorpses == 0)
+                {
                     continue;
+                }
 
                 CellOccupancy cell;
                 cell.cellX = cellX;
@@ -234,7 +238,9 @@ bool ChatHandler::HandleGridAnchorsCommand(char* args)
     {
         CreatureData const* data = sObjectMgr.GetCreatureData(itr->second);
         if (!data)
+        {
             continue;
+        }
 
         GridPair gp = MaNGOS::ComputeGridPair(data->posX, data->posY);
         std::pair<uint32, uint32> key(gp.x_coord, gp.y_coord);

--- a/src/game/ChatCommands/GridCommands.cpp
+++ b/src/game/ChatCommands/GridCommands.cpp
@@ -1,0 +1,280 @@
+/**
+ * MaNGOS is a full featured server for World of Warcraft, supporting
+ * the following clients: 1.12.x, 2.4.3, 3.3.5a, 4.3.4a and 5.4.8
+ *
+ * Copyright (C) 2005-2025 MaNGOS <https://www.getmangos.eu>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * World of Warcraft, and all World of Warcraft or Warcraft art, images,
+ * and lore are copyrighted by Blizzard Entertainment, Inc.
+ */
+
+/**
+ * @file GridCommands.cpp
+ * @brief Read-only LivingWorld grid/cell occupancy diagnostic commands.
+ *
+ * These GM-only, in-game-only commands report how many of a grid's 256 cells
+ * contain DB-backed spawns, to help quantify whether future cell-cluster object
+ * loading is worthwhile (LivingWorld Phase 1.5).
+ *
+ * IMPORTANT — all counts are STATIC DB spawn-definition counts (how many spawn
+ * GUIDs are registered in each cell's spawn store), NOT live in-memory object
+ * counts. The commands never load a grid, create a map, spawn anything, query
+ * the database, or mutate world state:
+ *  - occupancy is read from sObjectMgr's per-cell spawn store via the find-based,
+ *    non-inserting GetCellObjectGuidsReadOnly();
+ *  - load state is read via Map::IsGridLoaded() (never loads);
+ *  - the anchor set is read via the existing ObjectMgr active-creature accessor.
+ */
+
+#include "Chat.h"
+#include "Player.h"
+#include "Map.h"
+#include "ObjectMgr.h"
+#include "Creature.h"
+#include "GridDefines.h"
+
+#include <algorithm>
+#include <map>
+#include <utility>
+#include <vector>
+
+namespace
+{
+    uint32 const CELLS_PER_GRID = MAX_NUMBER_OF_CELLS * MAX_NUMBER_OF_CELLS; // 16 * 16 = 256
+
+    struct CellOccupancy
+    {
+        uint32 cellX;
+        uint32 cellY;
+        uint32 creatures;
+        uint32 gameobjects;
+        uint32 corpses;
+        uint32 Total() const { return creatures + gameobjects + corpses; }
+    };
+
+    struct GridOccupancy
+    {
+        uint32 occupiedCells;
+        uint32 creatures;
+        uint32 gameobjects;
+        uint32 corpses;
+        std::vector<CellOccupancy> occupied;
+
+        GridOccupancy() : occupiedCells(0), creatures(0), gameobjects(0), corpses(0) {}
+        uint32 TotalGuids() const { return creatures + gameobjects + corpses; }
+    };
+
+    // Static DB spawn-definition occupancy for one grid. Read-only: reads only the
+    // ObjectMgr per-cell spawn store. Never loads/creates grids, never spawns.
+    GridOccupancy ComputeGridOccupancy(uint16 mapId, uint32 gridX, uint32 gridY)
+    {
+        GridOccupancy occ;
+        for (uint32 cellX = 0; cellX < MAX_NUMBER_OF_CELLS; ++cellX)
+        {
+            for (uint32 cellY = 0; cellY < MAX_NUMBER_OF_CELLS; ++cellY)
+            {
+                uint32 globalX = (gridX * MAX_NUMBER_OF_CELLS) + cellX;
+                uint32 globalY = (gridY * MAX_NUMBER_OF_CELLS) + cellY;
+                uint32 cellId = (globalY * TOTAL_NUMBER_OF_CELLS_PER_MAP) + globalX;
+
+                CellObjectGuids const* guids = sObjectMgr.GetCellObjectGuidsReadOnly(mapId, cellId);
+                if (!guids)
+                    continue;
+
+                uint32 nCreatures = uint32(guids->creatures.size());
+                uint32 nGameobjects = uint32(guids->gameobjects.size());
+                uint32 nCorpses = uint32(guids->corpses.size());
+                if (nCreatures + nGameobjects + nCorpses == 0)
+                    continue;
+
+                CellOccupancy cell;
+                cell.cellX = cellX;
+                cell.cellY = cellY;
+                cell.creatures = nCreatures;
+                cell.gameobjects = nGameobjects;
+                cell.corpses = nCorpses;
+                occ.occupied.push_back(cell);
+
+                ++occ.occupiedCells;
+                occ.creatures += nCreatures;
+                occ.gameobjects += nGameobjects;
+                occ.corpses += nCorpses;
+            }
+        }
+        return occ;
+    }
+
+    bool CellOccupancyMore(CellOccupancy const& a, CellOccupancy const& b)
+    {
+        return a.Total() > b.Total();
+    }
+}
+
+/**
+ * @brief .grid info [gridX gridY]
+ *
+ * Reports static DB spawn-definition occupancy for one grid on the player's
+ * current map: occupied/empty cell counts, total spawn GUIDs by type, and the
+ * busiest cells. With no args, uses the player's current grid. Read-only.
+ */
+bool ChatHandler::HandleGridInfoCommand(char* args)
+{
+    Player* player = m_session ? m_session->GetPlayer() : NULL;
+    if (!player)
+    {
+        SendSysMessage("This command requires an in-game player.");
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    uint16 mapId = player->GetMapId();
+    uint32 gridX = 0;
+    uint32 gridY = 0;
+
+    if (ExtractUInt32(&args, gridX))
+    {
+        if (!ExtractUInt32(&args, gridY))
+        {
+            SendSysMessage("Usage: .grid info [gridX gridY]   (0..63 each; omit for current grid)");
+            SetSentErrorMessage(true);
+            return false;
+        }
+
+        if (gridX >= MAX_NUMBER_OF_GRIDS || gridY >= MAX_NUMBER_OF_GRIDS)
+        {
+            PSendSysMessage("Grid indices out of range (valid 0..%u).", uint32(MAX_NUMBER_OF_GRIDS - 1));
+            SetSentErrorMessage(true);
+            return false;
+        }
+    }
+    else
+    {
+        GridPair gp = MaNGOS::ComputeGridPair(player->GetPositionX(), player->GetPositionY());
+        gridX = gp.x_coord;
+        gridY = gp.y_coord;
+    }
+
+    bool gridLoaded = player->GetMap()->IsGridLoaded(gridX, gridY);
+    GridOccupancy occ = ComputeGridOccupancy(mapId, gridX, gridY);
+
+    PSendSysMessage("[LivingWorld] grid occupancy (static DB spawn-definition, not live objects): map=%u grid=(%u,%u) loaded=%s",
+                    uint32(mapId), gridX, gridY, gridLoaded ? "yes" : "no");
+    PSendSysMessage("  cells: occupied=%u/%u empty=%u",
+                    occ.occupiedCells, CELLS_PER_GRID, CELLS_PER_GRID - occ.occupiedCells);
+    PSendSysMessage("  db-guids: creatures=%u gameobjects=%u corpses=%u total=%u",
+                    occ.creatures, occ.gameobjects, occ.corpses, occ.TotalGuids());
+
+    if (occ.occupiedCells == 0)
+    {
+        SendSysMessage("  (no static DB spawns defined in this grid)");
+        return true;
+    }
+
+    std::stable_sort(occ.occupied.begin(), occ.occupied.end(), CellOccupancyMore);
+
+    uint32 const topN = 10;
+    uint32 shown = uint32(occ.occupied.size()) < topN ? uint32(occ.occupied.size()) : topN;
+    PSendSysMessage("  top cells (by total, showing %u of %u occupied):", shown, occ.occupiedCells);
+    for (uint32 i = 0; i < shown; ++i)
+    {
+        CellOccupancy const& c = occ.occupied[i];
+        PSendSysMessage("    cell=(%u,%u) creatures=%u gameobjects=%u corpses=%u total=%u",
+                        c.cellX, c.cellY, c.creatures, c.gameobjects, c.corpses, c.Total());
+    }
+
+    return true;
+}
+
+/**
+ * @brief .grid anchors
+ *
+ * Reports static DB spawn-definition occupancy for the ENABLED startup anchor
+ * grids on the player's current map (the CREATURE_FLAG_EXTRA_ACTIVE set plus any
+ * LivingWorld anchors enabled by the current AnchorPolicyMask) -- not every
+ * possible DB anchor. Used to measure how sparse anchor-held grids are. Read-only.
+ */
+bool ChatHandler::HandleGridAnchorsCommand(char* args)
+{
+    Player* player = m_session ? m_session->GetPlayer() : NULL;
+    if (!player)
+    {
+        SendSysMessage("This command requires an in-game player.");
+        SetSentErrorMessage(true);
+        return false;
+    }
+
+    uint16 mapId = player->GetMapId();
+
+    // Startup-active anchor set restricted to the player's current map. This is the
+    // *enabled* startup anchor set (extra-active + enabled LivingWorld anchors), not
+    // every possible DB anchor. Dedupe to unique anchor grids and tally anchors per grid.
+    ActiveCreatureGuidsOnMap const* activeGuids = sObjectMgr.GetActiveCreatureGuids();
+
+    std::map<std::pair<uint32, uint32>, uint32> anchorGridSpawnCount;
+    std::pair<ActiveCreatureGuidsOnMap::const_iterator, ActiveCreatureGuidsOnMap::const_iterator> range =
+        activeGuids->equal_range(mapId);
+    for (ActiveCreatureGuidsOnMap::const_iterator itr = range.first; itr != range.second; ++itr)
+    {
+        CreatureData const* data = sObjectMgr.GetCreatureData(itr->second);
+        if (!data)
+            continue;
+
+        GridPair gp = MaNGOS::ComputeGridPair(data->posX, data->posY);
+        std::pair<uint32, uint32> key(gp.x_coord, gp.y_coord);
+        ++anchorGridSpawnCount[key];
+    }
+
+    PSendSysMessage("[LivingWorld] anchor grid occupancy (static DB spawn-definition, not live objects): map=%u",
+                    uint32(mapId));
+    PSendSysMessage("  enabled startup anchor grids on this map (extra-active + enabled LivingWorld anchors): %u",
+                    uint32(anchorGridSpawnCount.size()));
+
+    if (anchorGridSpawnCount.empty())
+    {
+        SendSysMessage("  (no startup-active anchors on this map)");
+        return true;
+    }
+
+    std::vector<uint32> occupancies;
+    occupancies.reserve(anchorGridSpawnCount.size());
+
+    for (std::map<std::pair<uint32, uint32>, uint32>::const_iterator itr = anchorGridSpawnCount.begin();
+         itr != anchorGridSpawnCount.end(); ++itr)
+    {
+        uint32 gridX = itr->first.first;
+        uint32 gridY = itr->first.second;
+        uint32 anchorsHere = itr->second;
+
+        bool gridLoaded = player->GetMap()->IsGridLoaded(gridX, gridY);
+        GridOccupancy occ = ComputeGridOccupancy(mapId, gridX, gridY);
+        occupancies.push_back(occ.occupiedCells);
+
+        PSendSysMessage("  grid=(%u,%u) anchors=%u loaded=%s occupied=%u/%u creatures=%u gameobjects=%u corpses=%u",
+                        gridX, gridY, anchorsHere, gridLoaded ? "yes" : "no",
+                        occ.occupiedCells, CELLS_PER_GRID,
+                        occ.creatures, occ.gameobjects, occ.corpses);
+    }
+
+    std::sort(occupancies.begin(), occupancies.end());
+    uint32 minOccupied = occupancies.front();
+    uint32 maxOccupied = occupancies.back();
+    uint32 medianOccupied = occupancies[occupancies.size() / 2];
+    PSendSysMessage("  anchor-grid sparsity (occupied cells /%u): min=%u median=%u max=%u across %u grids",
+                    CELLS_PER_GRID, minOccupied, medianOccupied, maxOccupied, uint32(occupancies.size()));
+
+    return true;
+}

--- a/src/game/ChatCommands/GridCommands.cpp
+++ b/src/game/ChatCommands/GridCommands.cpp
@@ -149,14 +149,16 @@ bool ChatHandler::HandleGridInfoCommand(char* args)
     {
         if (!ExtractUInt32(&args, gridY))
         {
-            SendSysMessage("Usage: .grid info [gridX gridY]   (0..63 each; omit for current grid)");
+            SendSysMessage("Usage: .grid info [gridX gridY] "
+                           "(0..63 each; omit for current grid)");
             SetSentErrorMessage(true);
             return false;
         }
 
         if (gridX >= MAX_NUMBER_OF_GRIDS || gridY >= MAX_NUMBER_OF_GRIDS)
         {
-            PSendSysMessage("Grid indices out of range (valid 0..%u).", uint32(MAX_NUMBER_OF_GRIDS - 1));
+            PSendSysMessage("Grid indices out of range (valid 0..%u).",
+                            uint32(MAX_NUMBER_OF_GRIDS - 1));
             SetSentErrorMessage(true);
             return false;
         }
@@ -171,7 +173,8 @@ bool ChatHandler::HandleGridInfoCommand(char* args)
     bool gridLoaded = player->GetMap()->IsGridLoaded(gridX, gridY);
     GridOccupancy occ = ComputeGridOccupancy(mapId, gridX, gridY);
 
-    PSendSysMessage("[LivingWorld] grid occupancy (static DB spawn-definition, not live objects): map=%u grid=(%u,%u) loaded=%s",
+    PSendSysMessage("[LivingWorld] grid occupancy (static DB spawn-definition, "
+                       "not live objects): map=%u grid=(%u,%u) loaded=%s",
                     uint32(mapId), gridX, gridY, gridLoaded ? "yes" : "no");
     PSendSysMessage("  cells: occupied=%u/%u empty=%u",
                     occ.occupiedCells, CELLS_PER_GRID, CELLS_PER_GRID - occ.occupiedCells);
@@ -238,9 +241,11 @@ bool ChatHandler::HandleGridAnchorsCommand(char* args)
         ++anchorGridSpawnCount[key];
     }
 
-    PSendSysMessage("[LivingWorld] anchor grid occupancy (static DB spawn-definition, not live objects): map=%u",
+    PSendSysMessage("[LivingWorld] anchor grid occupancy (static DB "
+                       "spawn-definition, not live objects): map=%u",
                     uint32(mapId));
-    PSendSysMessage("  enabled startup anchor grids on this map (extra-active + enabled LivingWorld anchors): %u",
+    PSendSysMessage("  enabled startup anchor grids on this map "
+                       "(extra-active + enabled LivingWorld anchors): %u",
                     uint32(anchorGridSpawnCount.size()));
 
     if (anchorGridSpawnCount.empty())
@@ -263,7 +268,8 @@ bool ChatHandler::HandleGridAnchorsCommand(char* args)
         GridOccupancy occ = ComputeGridOccupancy(mapId, gridX, gridY);
         occupancies.push_back(occ.occupiedCells);
 
-        PSendSysMessage("  grid=(%u,%u) anchors=%u loaded=%s occupied=%u/%u creatures=%u gameobjects=%u corpses=%u",
+        PSendSysMessage("  grid=(%u,%u) anchors=%u loaded=%s occupied=%u/%u "
+                        "creatures=%u gameobjects=%u corpses=%u",
                         gridX, gridY, anchorsHere, gridLoaded ? "yes" : "no",
                         occ.occupiedCells, CELLS_PER_GRID,
                         occ.creatures, occ.gameobjects, occ.corpses);
@@ -273,8 +279,10 @@ bool ChatHandler::HandleGridAnchorsCommand(char* args)
     uint32 minOccupied = occupancies.front();
     uint32 maxOccupied = occupancies.back();
     uint32 medianOccupied = occupancies[occupancies.size() / 2];
-    PSendSysMessage("  anchor-grid sparsity (occupied cells /%u): min=%u median=%u max=%u across %u grids",
-                    CELLS_PER_GRID, minOccupied, medianOccupied, maxOccupied, uint32(occupancies.size()));
+    PSendSysMessage("  anchor-grid sparsity (occupied cells /%u): "
+                       "min=%u median=%u max=%u across %u grids",
+                    CELLS_PER_GRID, minOccupied, medianOccupied, maxOccupied,
+                    uint32(occupancies.size()));
 
     return true;
 }

--- a/src/game/ChatCommands/GridCommands.cpp
+++ b/src/game/ChatCommands/GridCommands.cpp
@@ -178,7 +178,7 @@ bool ChatHandler::HandleGridInfoCommand(char* args)
     GridOccupancy occ = ComputeGridOccupancy(mapId, gridX, gridY);
 
     PSendSysMessage("[LivingWorld] grid occupancy (static DB spawn-definition, "
-                       "not live objects): map=%u grid=(%u,%u) loaded=%s",
+                    "not live objects): map=%u grid=(%u,%u) loaded=%s",
                     uint32(mapId), gridX, gridY, gridLoaded ? "yes" : "no");
     PSendSysMessage("  cells: occupied=%u/%u empty=%u",
                     occ.occupiedCells, CELLS_PER_GRID, CELLS_PER_GRID - occ.occupiedCells);
@@ -248,10 +248,10 @@ bool ChatHandler::HandleGridAnchorsCommand(char* args)
     }
 
     PSendSysMessage("[LivingWorld] anchor grid occupancy (static DB "
-                       "spawn-definition, not live objects): map=%u",
+                    "spawn-definition, not live objects): map=%u",
                     uint32(mapId));
     PSendSysMessage("  enabled startup anchor grids on this map "
-                       "(extra-active + enabled LivingWorld anchors): %u",
+                    "(extra-active + enabled LivingWorld anchors): %u",
                     uint32(anchorGridSpawnCount.size()));
 
     if (anchorGridSpawnCount.empty())
@@ -286,7 +286,7 @@ bool ChatHandler::HandleGridAnchorsCommand(char* args)
     uint32 maxOccupied = occupancies.back();
     uint32 medianOccupied = occupancies[occupancies.size() / 2];
     PSendSysMessage("  anchor-grid sparsity (occupied cells /%u): "
-                       "min=%u median=%u max=%u across %u grids",
+                    "min=%u median=%u max=%u across %u grids",
                     CELLS_PER_GRID, minOccupied, medianOccupied, maxOccupied,
                     uint32(occupancies.size()));
 

--- a/src/game/Object/ObjectMgr.h
+++ b/src/game/Object/ObjectMgr.h
@@ -1099,10 +1099,11 @@ class ObjectMgr
             return mMapObjectGuids[mapid][cell_id];
         }
 
-        // Read-only per-cell spawn lookup for diagnostics. Unlike GetCellObjectGuids()
-        // this is find-based and const: it never inserts an empty entry on miss, so
-        // scanning many cells (e.g. a whole grid) does not mutate mMapObjectGuids.
-        // Returns NULL when the cell has no static DB spawn definitions.
+        // Read-only per-cell spawn lookup for diagnostics. Unlike
+        // GetCellObjectGuids() this is find-based and const: it never
+        // inserts an empty entry on miss, so scanning many cells (e.g. a
+        // whole grid) does not mutate mMapObjectGuids. Returns NULL when
+        // the cell has no static DB spawn definitions.
         CellObjectGuids const* GetCellObjectGuidsReadOnly(uint16 mapid, uint32 cell_id) const
         {
             MapObjectGuids::const_iterator mapItr = mMapObjectGuids.find(mapid);

--- a/src/game/Object/ObjectMgr.h
+++ b/src/game/Object/ObjectMgr.h
@@ -1099,10 +1099,10 @@ class ObjectMgr
             return mMapObjectGuids[mapid][cell_id];
         }
 
-        // Read-only per-cell spawn lookup for diagnostics. Unlike GetCellObjectGuids() this is
-        // find-based and const: it never inserts an empty entry on miss, so scanning many cells
-        // (e.g. a whole grid) does not mutate mMapObjectGuids. Returns NULL when the cell has no
-        // static DB spawn definitions.
+        // Read-only per-cell spawn lookup for diagnostics. Unlike GetCellObjectGuids()
+        // this is find-based and const: it never inserts an empty entry on miss, so
+        // scanning many cells (e.g. a whole grid) does not mutate mMapObjectGuids.
+        // Returns NULL when the cell has no static DB spawn definitions.
         CellObjectGuids const* GetCellObjectGuidsReadOnly(uint16 mapid, uint32 cell_id) const
         {
             MapObjectGuids::const_iterator mapItr = mMapObjectGuids.find(mapid);

--- a/src/game/Object/ObjectMgr.h
+++ b/src/game/Object/ObjectMgr.h
@@ -1107,10 +1107,14 @@ class ObjectMgr
         {
             MapObjectGuids::const_iterator mapItr = mMapObjectGuids.find(mapid);
             if (mapItr == mMapObjectGuids.end())
+            {
                 return NULL;
+            }
             CellObjectGuidsMap::const_iterator cellItr = mapItr->second.find(cell_id);
             if (cellItr == mapItr->second.end())
+            {
                 return NULL;
+            }
             return &cellItr->second;
         }
 

--- a/src/game/Object/ObjectMgr.h
+++ b/src/game/Object/ObjectMgr.h
@@ -1099,6 +1099,21 @@ class ObjectMgr
             return mMapObjectGuids[mapid][cell_id];
         }
 
+        // Read-only per-cell spawn lookup for diagnostics. Unlike GetCellObjectGuids() this is
+        // find-based and const: it never inserts an empty entry on miss, so scanning many cells
+        // (e.g. a whole grid) does not mutate mMapObjectGuids. Returns NULL when the cell has no
+        // static DB spawn definitions.
+        CellObjectGuids const* GetCellObjectGuidsReadOnly(uint16 mapid, uint32 cell_id) const
+        {
+            MapObjectGuids::const_iterator mapItr = mMapObjectGuids.find(mapid);
+            if (mapItr == mMapObjectGuids.end())
+                return NULL;
+            CellObjectGuidsMap::const_iterator cellItr = mapItr->second.find(cell_id);
+            if (cellItr == mapItr->second.end())
+                return NULL;
+            return &cellItr->second;
+        }
+
         // modifiers for global grid objects state (static DB spawns, global spawn mods from gameevent system)
         // Don't must be used for modify instance specific spawn state modifications
         void AddCreatureToGrid(uint32 guid, CreatureData const* data);

--- a/src/game/WorldHandlers/Chat.cpp
+++ b/src/game/WorldHandlers/Chat.cpp
@@ -314,6 +314,13 @@ ChatCommand* ChatHandler::getCommandTable()
         { NULL,             0,                  false, NULL,                                           "", NULL }
     };
 
+    static ChatCommand gridCommandTable[] =
+    {
+        { "info",           SEC_GAMEMASTER,     false, &ChatHandler::HandleGridInfoCommand,            "", NULL },
+        { "anchors",        SEC_GAMEMASTER,     false, &ChatHandler::HandleGridAnchorsCommand,         "", NULL },
+        { NULL,             0,                  false, NULL,                                           "", NULL }
+    };
+
     static ChatCommand guildCommandTable[] =
     {
         { "create",         SEC_GAMEMASTER,     true,  &ChatHandler::HandleGuildCreateCommand,         "", NULL },
@@ -757,6 +764,7 @@ ChatCommand* ChatHandler::getCommandTable()
         { "honor",          SEC_GAMEMASTER,     false, NULL,                                           "", honorCommandTable    },
         { "go",             SEC_MODERATOR,      false, NULL,                                           "", goCommandTable       },
         { "gobject",        SEC_GAMEMASTER,     false, NULL,                                           "", gobjectCommandTable  },
+        { "grid",           SEC_GAMEMASTER,     false, NULL,                                           "", gridCommandTable     },
         { "guild",          SEC_GAMEMASTER,     true,  NULL,                                           "", guildCommandTable    },
         { "instance",       SEC_ADMINISTRATOR,  true,  NULL,                                           "", instanceCommandTable },
         { "learn",          SEC_MODERATOR,      false, NULL,                                           "", learnCommandTable    },

--- a/src/game/WorldHandlers/Chat.h
+++ b/src/game/WorldHandlers/Chat.h
@@ -708,6 +708,10 @@ class ChatHandler
         bool HandleAhBotCommand(char* args);
 #endif
 
+        //! LivingWorld grid occupancy diagnostic (read-only, GM-only, in-game only)
+        bool HandleGridInfoCommand(char* args);
+        bool HandleGridAnchorsCommand(char* args);
+
         //! Development Commands
         bool HandleSaveAllCommand(char* args);
 

--- a/src/game/WorldHandlers/Map.h
+++ b/src/game/WorldHandlers/Map.h
@@ -197,6 +197,11 @@ class Map : public GridRefManager<NGridType>
             return loaded(p);
         }
 
+        // Read-only: true if the grid at the given grid indices is resident with its object data
+        // loaded. Index-based companion to IsLoaded(x,y); never loads or creates a grid. Caller
+        // must keep gridX/gridY within [0, MAX_NUMBER_OF_GRIDS).
+        bool IsGridLoaded(uint32 gridX, uint32 gridY) const { return loaded(GridPair(gridX, gridY)); }
+
         bool GetUnloadLock(const GridPair& p) const { return getNGrid(p.x_coord, p.y_coord)->getUnloadLock(); }
         void SetUnloadLock(const GridPair& p, bool on) { getNGrid(p.x_coord, p.y_coord)->setUnloadExplicitLock(on); }
         void ForceLoadGrid(float x, float y);

--- a/src/game/WorldHandlers/Map.h
+++ b/src/game/WorldHandlers/Map.h
@@ -197,9 +197,10 @@ class Map : public GridRefManager<NGridType>
             return loaded(p);
         }
 
-        // Read-only: true if the grid at the given grid indices is resident with its
-        // object data loaded. Index-based companion to IsLoaded(x,y); never loads or
-        // creates a grid. Caller must keep gridX/gridY within [0, MAX_NUMBER_OF_GRIDS).
+        // Read-only: true if the grid at the given grid indices is resident
+        // with its object data loaded. Index-based companion to IsLoaded(x,y);
+        // never loads or creates a grid. Caller must keep gridX/gridY within
+        // [0, MAX_NUMBER_OF_GRIDS).
         bool IsGridLoaded(uint32 gridX, uint32 gridY) const { return loaded(GridPair(gridX, gridY)); }
 
         bool GetUnloadLock(const GridPair& p) const { return getNGrid(p.x_coord, p.y_coord)->getUnloadLock(); }

--- a/src/game/WorldHandlers/Map.h
+++ b/src/game/WorldHandlers/Map.h
@@ -197,9 +197,9 @@ class Map : public GridRefManager<NGridType>
             return loaded(p);
         }
 
-        // Read-only: true if the grid at the given grid indices is resident with its object data
-        // loaded. Index-based companion to IsLoaded(x,y); never loads or creates a grid. Caller
-        // must keep gridX/gridY within [0, MAX_NUMBER_OF_GRIDS).
+        // Read-only: true if the grid at the given grid indices is resident with its
+        // object data loaded. Index-based companion to IsLoaded(x,y); never loads or
+        // creates a grid. Caller must keep gridX/gridY within [0, MAX_NUMBER_OF_GRIDS).
         bool IsGridLoaded(uint32 gridX, uint32 gridY) const { return loaded(GridPair(gridX, gridY)); }
 
         bool GetUnloadLock(const GridPair& p) const { return getNGrid(p.x_coord, p.y_coord)->getUnloadLock(); }


### PR DESCRIPTION
## Summary

This is work for the upcoming living world work that is being performed, we are releasing commands ahead of the actual world changes, so people can get familiar with the commands. These are diagnostic commands to check grids/cells within an active server.

Adds GM-only grid occupancy diagnostics:

- `.grid info [gridX gridY]`
- `.grid anchors`

These commands report static DB spawn-definition occupancy by grid/cell without loading grids or changing world state.

## Details

- Adds a read-only grid occupancy command implementation.
- Adds a const/find-based ObjectMgr cell GUID accessor.
- Adds a read-only Map grid-loaded helper.
- Registers the new `.grid` command group.
- Reports whether the target grid is currently loaded.
- Reports occupied cells out of 256 and top occupied cells.
- Reports enabled startup anchor grid occupancy for the current map.

## Safety

- GM-only.
- Read-only.
- No DB writes.
- No grid loading.
- No spawning.
- No live object iteration.
- No gameplay behavior changes.

## Testing

Verified in-game:

- `.grid info`
- `.grid info 22 26`
- `.grid info` on unloaded/far grid reports `loaded=no` without loading it.
- `.grid anchors`
- Thelsamar grid diagnostic checks pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/362)
<!-- Reviewable:end -->
