### PR TITLE
Optimize bot process loop

### DIFF
--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
@@ -333,7 +333,7 @@ void RandomPlayerbotMgr::RandomTeleport(Player* bot, vector<WorldLocation> &locs
         {
             continue;
         }
-        
+
         sLog.outDetail("Random teleporting bot %s to %s %f,%f,%f", bot->GetName(), area->area_name[0], x, y, z);
         float height = map->GetTerrain()->GetHeightStatic(x, y, 0.5f + z, true, MAX_HEIGHT);
         if (height <= INVALID_HEIGHT)

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
@@ -330,8 +330,10 @@ void RandomPlayerbotMgr::RandomTeleport(Player* bot, vector<WorldLocation> &locs
         if (!terrain->IsOutdoors(x, y, z) ||
             +terrain->IsUnderWater(x, y, z) ||
             +terrain->IsInWater(x, y, z))
+        {
             continue;
-
+        }
+        
         sLog.outDetail("Random teleporting bot %s to %s %f,%f,%f", bot->GetName(), area->area_name[0], x, y, z);
         float height = map->GetTerrain()->GetHeightStatic(x, y, 0.5f + z, true, MAX_HEIGHT);
         if (height <= INVALID_HEIGHT)
@@ -421,7 +423,9 @@ void RandomPlayerbotMgr::IncreaseLevel(Player* bot)
     uint32 maxLevel = sWorld.getConfig(CONFIG_UINT32_MAX_PLAYER_LEVEL);
     uint32 botCap = sPlayerbotAIConfig.randomBotMaxLevel;
     if (botCap > maxLevel)
+    {
         botCap = maxLevel;
+    }
     if (bot->getLevel() >= botCap)
     {
         RandomizeFirst(bot);
@@ -605,8 +609,9 @@ bool RandomPlayerbotMgr::IsRandomBot(uint32 bot)
 {
     std::unordered_map<uint32, bool>::iterator it = m_randomBotCache.find(bot);
     if (it != m_randomBotCache.end())
+    {
         return it->second;
-
+    }
     bool value = (GetEventValue(bot, "add") != 0);
     m_randomBotCache[bot] = value;
     return value;

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
@@ -419,6 +419,15 @@ void RandomPlayerbotMgr::Randomize(Player* bot)
 void RandomPlayerbotMgr::IncreaseLevel(Player* bot)
 {
     uint32 maxLevel = sWorld.getConfig(CONFIG_UINT32_MAX_PLAYER_LEVEL);
+    uint32 botCap = sPlayerbotAIConfig.randomBotMaxLevel;
+    if (botCap > maxLevel)
+        botCap = maxLevel;
+    if (bot->getLevel() >= botCap)
+    {
+        RandomizeFirst(bot);
+        return;
+    }
+
     uint32 level = min((uint32)(bot->getLevel() + 1), maxLevel);
     PlayerbotFactory factory(bot, level);
     if (bot->GetGuildId())
@@ -450,8 +459,7 @@ void RandomPlayerbotMgr::RandomizeFirst(Player* bot)
         for (GameTeleMap::const_iterator itr = teleMap.begin(); itr != teleMap.end(); ++itr)
         {
             GameTele const* tele = &itr->second;
-            if (( tele->mapId == mapId) &&
-                (IsZoneSafeForBot(bot, tele->mapId, tele->position_x, tele->position_y, tele->position_z)))
+            if (tele->mapId == mapId)
             {
                 locs.push_back(tele);
             }
@@ -490,10 +498,23 @@ void RandomPlayerbotMgr::RandomizeFirst(Player* bot)
             continue;
         }
 
+        if (!IsZoneSafeForBot(bot, tele->mapId, tele->position_x, tele->position_y, tele->position_z, level))
+        {
+            continue;
+        }
+
         PlayerbotFactory factory(bot, level);
         factory.CleanRandomize();
         RandomTeleport(bot, tele->mapId, tele->position_x, tele->position_y, tele->position_z);
         break;
+    }
+
+    if (bot->getLevel() > maxLevel)
+    {
+        uint32 newLevel =  urand(sPlayerbotAIConfig.randomBotMinLevel, maxLevel);
+        PlayerbotFactory factory(bot, newLevel);
+        factory.CleanRandomize();
+        RandomTeleportForLevel(bot);
     }
 }
 
@@ -663,7 +684,7 @@ vector<uint32> RandomPlayerbotMgr::GetFreeBots(bool alliance)
     return guids;
 }
 
-bool RandomPlayerbotMgr::IsZoneSafeForBot(Player* bot, uint32 mapId, float x, float y, float z)
+bool RandomPlayerbotMgr::IsZoneSafeForBot(Player* bot, uint32 mapId, float x, float y, float z, uint32 useLevel)
 {
     Map* map = sMapMgr.FindMap(mapId);
     if (!map)
@@ -723,7 +744,7 @@ bool RandomPlayerbotMgr::IsZoneSafeForBot(Player* bot, uint32 mapId, float x, fl
     AreaCreatureStats const* stats = (statsItr != m_areaCreatureStatsMap.end()) ? &statsItr->second : nullptr;
     if (stats && stats->creatureCount > 0)
     {
-        uint8 botLevel = bot->getLevel();
+        uint8 botLevel = useLevel ? useLevel : bot->getLevel();
         uint8 tolerance = sPlayerbotAIConfig.randomBotTeleLevel;
         if (botLevel < stats->minLevel - tolerance || botLevel > stats->maxLevel + tolerance)
         {
@@ -808,6 +829,15 @@ void RandomPlayerbotMgr::EnsureGroupedBotsOnline()
 uint32 RandomPlayerbotMgr::GetEventValue(uint32 bot, string event)
 {
     uint32 value = 0;
+    auto key = std::make_pair(bot, event);
+    auto it = m_eventValueCache.find(key);
+    if (it != m_eventValueCache.end())
+    {
+        if ((time(0) - it->second.lastChangeTime) < it->second.validIn)
+        {
+            return it->second.value;
+        }
+    }
 
     // Query the database to get the event value for the specified bot
     QueryResult* results = CharacterDatabase.PQuery(
@@ -824,6 +854,7 @@ uint32 RandomPlayerbotMgr::GetEventValue(uint32 bot, string event)
         {
             value = 0;
         }
+        m_eventValueCache[key] = {value, lastChangeTime, validIn};
         delete results;
     }
 
@@ -846,6 +877,7 @@ uint32 RandomPlayerbotMgr::SetEventValue(uint32 bot, string event, uint32 value,
     if (event == "add")
         m_randomBotCache[bot] = (value != 0);
 
+    m_eventValueCache[std::make_pair(bot, event)] = {value, (uint32)time(0), validIn};
     return value;
 }
 

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.h
@@ -262,7 +262,7 @@ class RandomPlayerbotMgr : public PlayerbotHolder
          * @param teleZ The Z coordinate.
          * @return true if the zone is good for random teleport, false otherwise
          */
-        bool IsZoneSafeForBot(Player* bot, uint32 mapId, float x, float y, float z);
+        bool IsZoneSafeForBot(Player* bot, uint32 mapId, float x, float y, float z, uint32 useLevel = 0);
 
         /**
          * @brief Calculate creature stats for various areas, to be used for bot teleport.
@@ -277,6 +277,12 @@ class RandomPlayerbotMgr : public PlayerbotHolder
         std::map<std::pair<uint32, uint32>, uint32> m_cellToAreaCache;
         std::unordered_map<uint32, bool> m_randomBotCache;
         std::unordered_map<uint32, uint32> m_playerZoneCounts; ///< zone_id -> real player count, for O(1) bot tick gating.
+        struct EventValueEntry {
+            uint32 value;
+            uint32 lastChangeTime;
+            uint32 validIn;
+        };
+        std::map<std::pair<uint32, std::string>, EventValueEntry> m_eventValueCache;
 };
 
 #define sRandomPlayerbotMgr MaNGOS::Singleton<RandomPlayerbotMgr>::Instance()


### PR DESCRIPTION
The bot process loop (where bots are logged in, set up, and relocated) had a couple of hotspots:
1. Bug: Bots being endlessly re-initialized when max level is lowered  (fixed)

(The playerbot system acts very weird on re-config; it was really designed to be configured before the first run, and then never changed).

2. Bots hitting the DB with GetEventValue numerous times on every loop.  Cache added to fix this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/364)
<!-- Reviewable:end -->
