### PR TITLE
db crash fix on shutdown

### DIFF
--- a/src/shared/Database/Database.cpp
+++ b/src/shared/Database/Database.cpp
@@ -459,7 +459,7 @@ bool Database::DirectPExecute(const char* format, ...)
 
 bool Database::BeginTransaction()
 {
-    if (!m_pAsyncConn)
+    if (!m_pAsyncConn || !m_TransStorage)
     {
         return false;
     }


### PR DESCRIPTION
Ran into a shutdown crash / core dump, so added a guard on the offending pointer in BeginTransaction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/367)
<!-- Reviewable:end -->
