### PR TITLE
bots random movement configuration

### DIFF
--- a/src/modules/Bots/CMakeLists.txt
+++ b/src/modules/Bots/CMakeLists.txt
@@ -130,6 +130,8 @@ set(BOT_SRCS
     playerbot/strategy/actions/MovementActions.h
     playerbot/strategy/actions/NonCombatActions.cpp
     playerbot/strategy/actions/NonCombatActions.h
+    playerbot/strategy/actions/NearestPlayersValue.cpp
+    playerbot/strategy/actions/NearestPlayersValue.h
     playerbot/strategy/actions/PassLeadershipToMasterAction.h
     playerbot/strategy/actions/PositionAction.cpp
     playerbot/strategy/actions/PositionAction.h

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
@@ -202,6 +202,11 @@ bool PlayerbotAIConfig::Initialize()
 
     commandPrefix = config.GetStringDefault("AiPlayerbot.CommandPrefix", "");
 
+    {
+        std::string name = "RandomMovementTargets";
+        SetValue(name, config.GetStringDefault("AiPlayerbot.RandomMovementTargets", "anynpcs,anyitems,random"));
+    }
+
     commandServerPort = config.GetIntDefault("AiPlayerbot.CommandServerPort", 0);
 
     // Load class spec probabilities from the configuration file
@@ -309,6 +314,11 @@ string PlayerbotAIConfig::GetValue(string name) const
         out << iterationsPerTick;
     }
 
+    else if (name == "RandomMovementTargets")
+    {
+        out << randomMovementTargetsAsString;
+    }
+
     return out.str();
 }
 
@@ -379,6 +389,34 @@ void PlayerbotAIConfig::SetValue(string &name, string value)
     else if (name == "IterationsPerTick")
     {
         out >> iterationsPerTick;
+    }
+
+    else if (name == "RandomMovementTargets")
+    {
+        randomMovementTargetsAsString = value;
+        randomMovementTargets.clear();
+        std::vector<std::string> tokens = split(value, ',');
+        std::set<std::string> validTargets = {"usefulnpcs", "anynpcs", "players", "tradeskillitems", "interactableitems", "anyitems", "random"};
+        for (std::vector<std::string>::iterator i = tokens.begin(); i != tokens.end(); ++i)
+        {
+            std::string token = *i;
+            size_t start = token.find_first_not_of(" \t");
+            size_t end = token.find_last_not_of(" \t");
+            if (start == std::string::npos)
+            {
+                continue;
+            }
+            token = token.substr(start, end - start + 1);
+            std::string lowerToken = token;
+            for (size_t j = 0; j < lowerToken.size(); ++j)
+            {
+                lowerToken[j] = tolower(lowerToken[j]);
+            }
+            if (validTargets.find(lowerToken) != validTargets.end())
+            {
+                randomMovementTargets.push_back(lowerToken);
+            }
+        }
     }
 }
 

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.h
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.h
@@ -80,6 +80,9 @@ class PlayerbotAIConfig
         uint32 specProbability[MAX_CLASSES][3]; ///< Probability of class specs for random bots.
         std::string commandPrefix; ///< Prefix for bot commands.
 
+        std::string randomMovementTargetsAsString; ///< Comma-separated string of random movement targets.
+        std::vector<std::string> randomMovementTargets; ///< List of validated random movement targets.
+
         uint32 iterationsPerTick; ///< Number of iterations per tick.
 
         int commandServerPort; ///< Port for the command server.

--- a/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
+++ b/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
@@ -85,6 +85,19 @@ AiPlayerbot.CommandPrefix = ~
 #AiPlayerbot.WhisperToZoneOnly = false
 #AiPlayerbot.ContactDistance = 0.5
 
+# Random movement target priority (comma-separated, earlier = higher weight)
+# Valid types: usefulnpcs, anynpcs, players, tradeskillitems, interactableitems, anyitems, random
+#   usefulnpcs       = NPCs with service flags (bankers, vendors, quest givers, trainers, ...)
+#   anynpcs          = any friendly NPC including non-interactable critters
+#   players          = other player characters (including bots)
+#   tradeskillitems  = game objects matching bot's tradeskills (mining, herbalism, etc.)
+#   interactableitems= chests, quest items, usable objects (type-based filter)
+#   anyitems         = any game object including decorative
+#   random           = random position in the area
+# Omitting a type from the list excludes it as a possible target entirely
+# Example: AiPlayerbot.RandomMovementTargets = anynpcs,anyitems,random
+#AiPlayerbot.RandomMovementTargets = anynpcs,anyitems,random
+
 # Bot can flee for enemy
 #AiPlayerbot.FleeingEnabled = 1
 

--- a/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
+++ b/src/modules/Bots/playerbot/strategy/actions/MovementActions.cpp
@@ -560,6 +560,38 @@ bool RunAwayAction::Execute(Event event)
     return Flee(AI_VALUE(Unit*, "master target"));
 }
 
+template<typename F>
+static std::vector<WorldObject*> CollectValidUnits(PlayerbotAI* ai, const std::list<ObjectGuid>& guids, F filter)
+{
+    Player* bot = ai->GetBot();
+    std::vector<WorldObject*> results;
+    for (const auto& guid : guids)
+    {
+        Unit* unit = ai->GetUnit(guid);
+        if (unit && filter(unit) && bot->GetDistance(unit) > sPlayerbotAIConfig.tooCloseDistance)
+        {
+            results.push_back(unit);
+        }
+    }
+    return results;
+}
+
+template<typename F>
+static std::vector<WorldObject*> CollectValidGameObjects(PlayerbotAI* ai, const std::list<ObjectGuid>& guids, F filter)
+{
+    Player* bot = ai->GetBot();
+    std::vector<WorldObject*> results;
+    for (const auto& guid : guids)
+    {
+        GameObject* go = ai->GetGameObject(guid);
+        if (go && filter(go) && bot->GetDistance(go) > sPlayerbotAIConfig.tooCloseDistance)
+        {
+            results.push_back(go);
+        }
+    }
+    return results;
+}
+
 bool MoveRandomAction::Execute(Event event)
 {
     if (m_hasFaceTarget)
@@ -574,35 +606,102 @@ bool MoveRandomAction::Execute(Event event)
 
     WorldObject* target = NULL;
 
-    if (!(rand() % 3))
+    // If no configured targets, fall through to random-position fallback
+    if (!sPlayerbotAIConfig.randomMovementTargets.empty())
     {
-        list<ObjectGuid> npcs = AI_VALUE(list<ObjectGuid>, "nearest npcs");
-        for (list<ObjectGuid>::iterator i = npcs.begin(); i != npcs.end(); i++)
-        {
-            target = ai->GetUnit(*i);
+        // Cache all value queries ONCE per Execute()
+        std::list<ObjectGuid> npcs = AI_VALUE(std::list<ObjectGuid>, "nearest npcs");
+        std::list<ObjectGuid> players = AI_VALUE(std::list<ObjectGuid>, "nearest players");
+        std::list<ObjectGuid> gos = AI_VALUE(std::list<ObjectGuid>, "nearest game objects");
 
-            if (target && bot->GetDistance(target) > sPlayerbotAIConfig.tooCloseDistance)
+        struct CategoryPick { WorldObject* target; int weight; };
+        std::vector<CategoryPick> picks;
+        size_t configSize = sPlayerbotAIConfig.randomMovementTargets.size();
+
+        for (size_t idx = 0; idx < configSize; ++idx)
+        {
+            const std::string& type = sPlayerbotAIConfig.randomMovementTargets[idx];
+            int weight = 1 << (configSize - 1 - idx);
+
+            if (type == "random")
             {
-                break;
+                picks.push_back({nullptr, weight});
+                continue;
+            }
+
+            std::vector<WorldObject*> matches;
+
+            if (type == "anynpcs")
+            {
+                matches = CollectValidUnits(ai, npcs, [](Unit*) { return true; });
+            }
+            else if (type == "usefulnpcs")
+            {
+                matches = CollectValidUnits(ai, npcs, [](Unit* u)
+                {
+                    Creature* c = dynamic_cast<Creature*>(u);
+                    return c && c->GetUInt32Value(UNIT_NPC_FLAGS) != UNIT_NPC_FLAG_NONE;
+                });
+            }
+            else if (type == "players")
+            {
+                matches = CollectValidUnits(ai, players, [](Unit*) { return true; });
+            }
+            else if (type == "tradeskillitems")
+            {
+                for (std::list<ObjectGuid>::const_iterator gi = gos.begin(); gi != gos.end(); ++gi)
+                {
+                    LootObject loot(bot, *gi);
+                    if (loot.skillId != SKILL_NONE && bot->HasSkill(loot.skillId))
+                    {
+                        GameObject* go = ai->GetGameObject(*gi);
+                        if (go && bot->GetDistance(go) > sPlayerbotAIConfig.tooCloseDistance)
+                        {
+                            matches.push_back(go);
+                        }
+                    }
+                }
+            }
+            else if (type == "interactableitems")
+            {
+                matches = CollectValidGameObjects(ai, gos, [](GameObject* go)
+                {
+                    uint32 t = go->GetGOInfo()->type;
+                    return t == GAMEOBJECT_TYPE_CHEST || t == GAMEOBJECT_TYPE_QUESTGIVER ||
+                           t == GAMEOBJECT_TYPE_SPELL_FOCUS || t == GAMEOBJECT_TYPE_GOOBER;
+                });
+            }
+            else if (type == "anyitems")
+            {
+                matches = CollectValidGameObjects(ai, gos, [](GameObject*) { return true; });
+            }
+
+            if (!matches.empty())
+            {
+                picks.push_back({matches[urand(0, matches.size() - 1)], weight});
+            }
+        }
+
+        if (!picks.empty())
+        {
+            int totalWeight = 0;
+            for (const auto& pick : picks)
+            {
+                totalWeight += pick.weight;
+            }
+
+            int roll = urand(0, totalWeight - 1);
+            for (const auto& pick : picks)
+            {
+                if (roll < pick.weight)
+                {
+                    target = pick.target;
+                    break;
+                }
+                roll -= pick.weight;
             }
         }
     }
-
-    if (!target || !(rand() % 3))
-    {
-        list<ObjectGuid> gos = AI_VALUE(list<ObjectGuid>, "nearest game objects");
-        for (list<ObjectGuid>::iterator i = gos.begin(); i != gos.end(); i++)
-        {
-            target = ai->GetGameObject(*i);
-
-            if (target && bot->GetDistance(target) > sPlayerbotAIConfig.tooCloseDistance)
-            {
-                break;
-            }
-        }
-    }
-
-    float distance = sPlayerbotAIConfig.tooCloseDistance + sPlayerbotAIConfig.grindDistance * urand(3, 10) / 10.0f;
 
     if (target)
     {
@@ -615,6 +714,8 @@ bool MoveRandomAction::Execute(Event event)
         }
         return moved;
     }
+
+    float distance = sPlayerbotAIConfig.tooCloseDistance + sPlayerbotAIConfig.grindDistance * urand(3, 10) / 10.0f;
 
     for (int i = 0; i < 10; ++i)
     {

--- a/src/modules/Bots/playerbot/strategy/values/NearestPlayersValue.cpp
+++ b/src/modules/Bots/playerbot/strategy/values/NearestPlayersValue.cpp
@@ -1,0 +1,24 @@
+#include "botpch.h"
+#include "../../playerbot.h"
+#include "NearestPlayersValue.h"
+
+#include "GridNotifiers.h"
+#include "GridNotifiersImpl.h"
+#include "CellImpl.h"
+
+using namespace ai;
+using namespace MaNGOS;
+
+void NearestPlayersValue::FindUnits(list<Unit*> &targets)
+{
+    AnyFriendlyUnitInObjectRangeCheck u_check(bot, range);
+    UnitListSearcher<AnyFriendlyUnitInObjectRangeCheck> searcher(targets, u_check);
+    Cell::VisitAllObjects(bot, searcher, range);
+}
+
+bool NearestPlayersValue::AcceptUnit(Unit* unit)
+{
+    return dynamic_cast<Player*>(unit) &&
+           unit->GetObjectGuid() != bot->GetObjectGuid() &&
+           unit->IsAlive();
+}

--- a/src/modules/Bots/playerbot/strategy/values/NearestPlayersValue.h
+++ b/src/modules/Bots/playerbot/strategy/values/NearestPlayersValue.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "../Value.h"
+#include "NearestUnitsValue.h"
+#include "../../PlayerbotAIConfig.h"
+
+namespace ai
+{
+    class NearestPlayersValue : public NearestUnitsValue
+    {
+        public:
+            NearestPlayersValue(PlayerbotAI* ai, float range = sPlayerbotAIConfig.sightDistance) :
+            NearestUnitsValue(ai) {}
+
+        protected:
+            void FindUnits(list<Unit*> &targets);
+            bool AcceptUnit(Unit* unit);
+    };
+}

--- a/src/modules/Bots/playerbot/strategy/values/ValueContext.h
+++ b/src/modules/Bots/playerbot/strategy/values/ValueContext.h
@@ -3,6 +3,7 @@
 #include "NearestGameObjects.h"
 #include "LogLevelValue.h"
 #include "NearestNpcsValue.h"
+#include "NearestPlayersValue.h"
 #include "PossibleTargetsValue.h"
 #include "NearestAdsValue.h"
 #include "NearestCorpsesValue.h"
@@ -68,6 +69,7 @@ namespace ai
             {
                 creators["nearest game objects"] = &ValueContext::nearest_game_objects;
                 creators["nearest npcs"] = &ValueContext::nearest_npcs;
+                creators["nearest players"] = &ValueContext::nearest_players;
                 creators["possible targets"] = &ValueContext::possible_targets;
                 creators["nearest adds"] = &ValueContext::nearest_adds;
                 creators["nearest corpses"] = &ValueContext::nearest_corpses;
@@ -199,6 +201,7 @@ namespace ai
             static UntypedValue* nearest_game_objects(PlayerbotAI* ai) { return new NearestGameObjects(ai); }
             static UntypedValue* log_level(PlayerbotAI* ai) { return new LogLevelValue(ai); }
             static UntypedValue* nearest_npcs(PlayerbotAI* ai) { return new NearestNpcsValue(ai); }
+            static UntypedValue* nearest_players(PlayerbotAI* ai) { return new NearestPlayersValue(ai); }
             static UntypedValue* nearest_corpses(PlayerbotAI* ai) { return new NearestCorpsesValue(ai); }
             static UntypedValue* possible_targets(PlayerbotAI* ai) { return new PossibleTargetsValue(ai); }
             static UntypedValue* nearest_adds(PlayerbotAI* ai) { return new NearestAdsValue(ai); }


### PR DESCRIPTION
Bit of a whimsical feature that allows you to configure how bots behave when they move randomly.  The default configuration leaves the old behavior of moving to random objects unchanged, but you can configure it to prefer movement towards more meaningful things also.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/370)
<!-- Reviewable:end -->
