### PR TITLE
[Playerbots] Pace random-bot processing against a per-tick time budget

### DIFF
--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.cpp
@@ -59,6 +59,8 @@ PlayerbotAIConfig::PlayerbotAIConfig()
     maxRandomBotPvpTime(0),
     minRandomBotsPerInterval(0),
     maxRandomBotsPerInterval(0),
+    randomBotProcessBudgetMs(0),
+    randomBotCatchupInterval(0),
     minRandomBotsPriceChangeInterval(0),
     maxRandomBotsPriceChangeInterval(0),
     randomBotJoinLfg(false),
@@ -178,6 +180,8 @@ bool PlayerbotAIConfig::Initialize()
     randomBotTeleportDistance = config.GetIntDefault("AiPlayerbot.RandomBotTeleportDistance", 1000);
     minRandomBotsPerInterval = config.GetIntDefault("AiPlayerbot.MinRandomBotsPerInterval", 50);
     maxRandomBotsPerInterval = config.GetIntDefault("AiPlayerbot.MaxRandomBotsPerInterval", 100);
+    randomBotProcessBudgetMs = config.GetIntDefault("AiPlayerbot.RandomBotProcessBudgetMs", 50);
+    randomBotCatchupInterval = config.GetIntDefault("AiPlayerbot.RandomBotCatchupInterval", 1);
     minRandomBotsPriceChangeInterval = config.GetIntDefault("AiPlayerbot.MinRandomBotsPriceChangeInterval", 2 * 3600);
     maxRandomBotsPriceChangeInterval = config.GetIntDefault("AiPlayerbot.MaxRandomBotsPriceChangeInterval", 48 * 3600);
     randomBotJoinLfg = config.GetBoolDefault("AiPlayerbot.RandomBotJoinLfg", true);

--- a/src/modules/Bots/playerbot/PlayerbotAIConfig.h
+++ b/src/modules/Bots/playerbot/PlayerbotAIConfig.h
@@ -65,6 +65,8 @@ class PlayerbotAIConfig
         uint32 minRandomBotReviveTime, maxRandomBotReviveTime;
         uint32 minRandomBotPvpTime, maxRandomBotPvpTime;
         uint32 minRandomBotsPerInterval, maxRandomBotsPerInterval;
+        uint32 randomBotProcessBudgetMs; ///< Wall-clock budget (ms) for one random-bot processing pass; 0 disables pacing.
+        uint32 randomBotCatchupInterval; ///< Seconds until the next pass when a pass stops on its time budget.
         uint32 minRandomBotsPriceChangeInterval, maxRandomBotsPriceChangeInterval;
         bool randomBotJoinLfg; ///< Indicates if random bots should join Looking For Group.
         bool randomBotLoginAtStartup; ///< Indicates if random bots should login at startup.

--- a/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
+++ b/src/modules/Bots/playerbot/RandomPlayerbotMgr.cpp
@@ -14,6 +14,7 @@
 #include "MapManager.h"
 #include "LFGMgr.h"
 #include "Group.h"
+#include "Timer.h"
 
 INSTANTIATE_SINGLETON_1(RandomPlayerbotMgr);
 
@@ -85,8 +86,21 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed)
         }
     }
 
+    // Pace the pass against a wall-clock budget so a single update tick can not be
+    // monopolised by a burst of bot adds/randomizes/saves. Work that does not fit in
+    // the budget is carried over to the next (soon-rescheduled) pass.
+    uint32 passStart = getMSTime();
+    uint32 budgetMs = sPlayerbotAIConfig.randomBotProcessBudgetMs;
+    bool overBudget = false;
+
     while (botCount++ < maxAllowedBotCount)
     {
+        if (budgetMs && getMSTimeDiff(passStart, getMSTime()) >= budgetMs)
+        {
+            overBudget = true;
+            break;
+        }
+
         bool alliance = botCount % 2;
         uint32 bot = AddRandomBot(alliance);
         if (bot)
@@ -111,6 +125,12 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed)
     int botProcessed = 0;
     for (list<uint32>::iterator i = bots.begin(); i != bots.end(); ++i)
     {
+        if (budgetMs && getMSTimeDiff(passStart, getMSTime()) >= budgetMs)
+        {
+            overBudget = true;
+            break;
+        }
+
         uint32 bot = *i;
         if (ProcessBot(bot))
         {
@@ -123,8 +143,15 @@ void RandomPlayerbotMgr::UpdateAIInternal(uint32 elapsed)
         }
     }
 
-    sLog.outString("%d bots processed. %d alliance and %d horde bots added. %d bots online. Next check in %d seconds",
-        botProcessed, allianceNewBots, hordeNewBots, playerBots.size(), sPlayerbotAIConfig.randomBotUpdateInterval);
+    // Still work left this pass - come back quickly instead of waiting a full interval.
+    if (overBudget && sPlayerbotAIConfig.randomBotCatchupInterval < sPlayerbotAIConfig.randomBotUpdateInterval)
+    {
+        SetNextCheckDelay(sPlayerbotAIConfig.randomBotCatchupInterval * 1000);
+    }
+
+    sLog.outString("%d bots processed%s. %d alliance and %d horde bots added. %d bots online. Next check in %d seconds",
+        botProcessed, overBudget ? " (budget reached, more pending)" : "", allianceNewBots, hordeNewBots, playerBots.size(),
+        overBudget ? sPlayerbotAIConfig.randomBotCatchupInterval : sPlayerbotAIConfig.randomBotUpdateInterval);
 
     if (processTicks++ == 1)
     {

--- a/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
+++ b/src/modules/Bots/playerbot/aiplayerbot.conf.dist.in
@@ -171,6 +171,16 @@ AiPlayerbot.RandomBotTeleLevel = 3
 #AiPlayerbot.MaxRandomRandomizeTime = 1209600
 #AiPlayerbot.MinRandomBotsPerInterval = 50
 #AiPlayerbot.MaxRandomBotsPerInterval = 100
+
+# Wall-clock budget (milliseconds) for a single random-bot processing pass. When a
+# pass exceeds this, it stops and resumes on the next (catch-up) pass instead of
+# blocking the world tick. Set to 0 to disable pacing (legacy burst behaviour).
+#AiPlayerbot.RandomBotProcessBudgetMs = 50
+
+# Seconds until the next pass when a pass stopped early on its time budget. Only used
+# while there is pending work; ignored once a pass finishes within budget.
+#AiPlayerbot.RandomBotCatchupInterval = 1
+
 #AiPlayerbot.MinRandomBotsPriceChangeInterval = 7200
 #AiPlayerbot.MaxRandomBotsPriceChangeInterval = 172800
 


### PR DESCRIPTION
Bot processing runs inline on the world thread (`World::Update` -> `RandomPlayerbotMgr::UpdateAIInternal`) with **no time budget**: at startup it processes the entire bot list in one tick, and the add-loop is unbounded. The result is multi-second world-tick stalls reported in Discord (`sWorld.Update took 17882 ms`) that #364's per-bot caching did not address, because the problem is burst geometry, not per-bot cost.

This paces the pass against a wall-clock budget. When a pass exceeds the budget it stops and resumes on the next pass (rescheduled in `RandomBotCatchupInterval` seconds instead of a full `RandomBotUpdateInterval`), so a single 17 s spike becomes a series of short blips. Bot population still ramps to target, just over a few extra passes.

**Changes**
- `RandomPlayerbotMgr::UpdateAIInternal`: time-budget guard on the add-loop and process-loop; short catch-up reschedule when work remains.
- New tunables (sane defaults, no config change required):
  - `AiPlayerbot.RandomBotProcessBudgetMs = 50` (`0` = legacy burst behaviour)
  - `AiPlayerbot.RandomBotCatchupInterval = 1`

The `ProcessRequests took` / `sWorld.Update took` instrumentation from #331 is the before/after meter.

Not addressed here (separate PRs): the 4x `SaveToDB` write burst in `PlayerbotFactory::Randomize`, and the single-FIFO async DB drain that serialises logins behind writes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/372)
<!-- Reviewable:end -->
