### PR TITLE
Fix for quest lootable items

### DIFF
--- a/src/game/Object/GameObject.cpp
+++ b/src/game/Object/GameObject.cpp
@@ -1264,8 +1264,8 @@ bool GameObject::ActivateToQuest(Player* pTarget) const
                             return false;
                         }
                     }
-                    return true;
                 }
+                return true;
             }
             break;
         }


### PR DESCRIPTION
This fixes a problem with all quest lootables that got introduced in the brace-refactor.  

I've been seeing the quest problems a-plenty, but when I discovered how quest-id requirements are saved in the DB, I just assumed it was a data problem.  Then it occurred to me to check out an older quest which I KNOW worked 3-4 months ago and IT was broken also, which led me to look deeper.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mangoszero/server/373)
<!-- Reviewable:end -->
